### PR TITLE
Auto detect latest Ookla quarter from current date

### DIFF
--- a/backend/data/scripts/ingest_ookla.py
+++ b/backend/data/scripts/ingest_ookla.py
@@ -376,7 +376,7 @@ def get_latest_available_quarter(today: Optional[datetime] = None) -> Tuple[int,
     To stay safe, we always return one full quarter behind the current date.
     Examples (today = Feb 2026  →  Q1 2026  →  returns 2025 Q4)
     """
-    now = datetime.now()
+    now = today or datetime.now()
     current_quarter = (now.month - 1) // 3 + 1
     year = now.year
 

--- a/backend/data/scripts/ingest_ookla.py
+++ b/backend/data/scripts/ingest_ookla.py
@@ -363,18 +363,54 @@ def save_to_database(df: pd.DataFrame, year: int, quarter: int):
 # MAIN
 # ============================================================================
 
+def get_latest_available_quarter() -> Tuple[int, int]:
+    """
+    Determine the latest Ookla quarter likely available on S3.
+
+    Ookla publishes data ~4-6 weeks after each quarter ends:
+        Q1 (Jan-Mar) → available ~May
+        Q2 (Apr-Jun) → available ~August
+        Q3 (Jul-Sep) → available ~November
+        Q4 (Oct-Dec) → available ~February
+
+    To stay safe, we always return one full quarter behind the current date.
+    Examples (today = Feb 2026  →  Q1 2026  →  returns 2025 Q4)
+    """
+    now = datetime.now()
+    current_quarter = (now.month - 1) // 3 + 1
+    year = now.year
+
+    quarter = current_quarter - 1
+    if quarter == 0:
+        quarter = 4
+        year -= 1
+
+    return year, quarter
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Ingest Ookla Open Data for Alaska (Optimized)')
-    parser.add_argument('--year', type=int, default=2024, help='Year of data (default: 2024)')
-    parser.add_argument('--quarter', type=int, default=4, choices=[1, 2, 3, 4], 
-                        help='Quarter (1-4, default: 4)')
-    parser.add_argument('--dry-run', action='store_true', 
+    auto_year, auto_quarter = get_latest_available_quarter()
+
+    parser = argparse.ArgumentParser(
+        description='Ingest Ookla Open Data for Alaska (Optimized)',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f'Latest auto-detected quarter: {auto_year} Q{auto_quarter}'
+    )
+    parser.add_argument('--year', type=int, default=auto_year,
+                        help=f'Year of data (default: auto-detected → {auto_year})')
+    parser.add_argument('--quarter', type=int, default=auto_quarter, choices=[1, 2, 3, 4],
+                        help=f'Quarter 1-4 (default: auto-detected → Q{auto_quarter})')
+    parser.add_argument('--dry-run', action='store_true',
                         help='Show what would be done without fetching data')
     parser.add_argument('--show-bounds', action='store_true',
                         help='Print Alaska tile bounds and exit')
-    
+
     args = parser.parse_args()
-    
+
+    print(f"[INFO] Target period: {args.year} Q{args.quarter}")
+    if args.year == auto_year and args.quarter == auto_quarter:
+        print(f"[INFO] (Auto-detected as latest available quarter based on today's date)")
+
     if args.show_bounds:
         bounds = get_alaska_tile_bounds(ZOOM_LEVEL)
         print(f"\nAlaska Tile Bounds at Zoom {ZOOM_LEVEL}:")

--- a/backend/data/scripts/ingest_ookla.py
+++ b/backend/data/scripts/ingest_ookla.py
@@ -363,7 +363,7 @@ def save_to_database(df: pd.DataFrame, year: int, quarter: int):
 # MAIN
 # ============================================================================
 
-def get_latest_available_quarter() -> Tuple[int, int]:
+def get_latest_available_quarter(today: Optional[datetime] = None) -> Tuple[int, int]:
     """
     Determine the latest Ookla quarter likely available on S3.
 


### PR DESCRIPTION

### What was the problem?

Every single time anyone wanted to refresh the Ookla speed test data, they had to *know* what year and quarter to type. The default was baked in as `--year 2024 --quarter 4`  hardcoded in the script. That means if you just ran:

```bash
python ingest_ookla.py
```

...you'd silently re-ingest 2024 Q4 data even though we're now well into 2026 and multiple newer quarters are sitting on Ookla's S3, waiting to be pulled. It was easy to forget to pass the flags, and nobody would notice until they looked at the DB and saw stale data.


### New script-

The script now figures out the right quarter **by itself**, based on today's date. It knows that Ookla typically publishes each quarter's data about 4–6 weeks after it ends, so it conservatively picks one full quarter behind the current date. Running it completely bare:

```bash
python ingest_ookla.py
```

Today (Feb 26, 2026) that automatically resolves to **2025 Q4** no flags, no mental math, no stale re-ingestion.

If you want a specific quarter, nothing changes  `--year` and `--quarter` still work exactly as before. The only difference is the default is no longer frozen in time.