### PR TITLE
Refine Telehealth Need and adjust distance formula

### DIFF
--- a/backend/data/scripts/preprocess_healthcare.py
+++ b/backend/data/scripts/preprocess_healthcare.py
@@ -210,9 +210,9 @@ def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> fl
 
 def generate_summary(facilities: list) -> dict:
     """Generate summary statistics."""
-    summary = {
+    by_type: dict = {}
+    summary: dict = {
         'total_facilities': len(facilities),
-        'by_type': {},
         'with_emergency': 0,
         'with_specialists': 0,
         'with_phone': 0,
@@ -222,7 +222,7 @@ def generate_summary(facilities: list) -> dict:
     for f in facilities:
         # Count by type
         ftype = f['facility_type']
-        summary['by_type'][ftype] = summary['by_type'].get(ftype, 0) + 1
+        by_type[ftype] = by_type.get(ftype, 0) + 1
         
         # Count features
         if f['has_emergency']:
@@ -233,7 +233,8 @@ def generate_summary(facilities: list) -> dict:
             summary['with_phone'] += 1
         if f['website']:
             summary['with_website'] += 1
-    
+            
+    summary['by_type'] = by_type
     return summary
 
 

--- a/backend/data/scripts/preprocess_transport.py
+++ b/backend/data/scripts/preprocess_transport.py
@@ -140,16 +140,15 @@ def normalize_community_name(name: str) -> str:
     if not isinstance(name, str):
         return name
 
-    name_str = str(name)
-    n_lower = str(name_str).lower()
-    n_clean = str(n_lower).strip()
-
+    name = str(name).lower().strip()
+    
     for keyword in FACILITY_KEYWORDS:
-        if str(n_clean).find(str(keyword)) != -1:
-            n_clean = str(re.split(rf"\b{keyword}\b", str(n_clean))[0])
+        if keyword in name:  # type: ignore
+            # Split only on the first occurrence for efficiency and correctness
+            name = re.split(rf"\b{keyword}\b", name, 1)[0].strip()
             break
-
-    return str(n_clean).strip()
+            
+    return name
 
 
 # Communities that should NOT have suffixes stripped (they are real community names)

--- a/backend/data/scripts/preprocess_transport.py
+++ b/backend/data/scripts/preprocess_transport.py
@@ -17,6 +17,7 @@ import numpy as np
 import re
 from datetime import datetime
 import math
+from pyproj import Transformer
 
 # Helpers
 EXCLUDE_KEYWORDS = [
@@ -139,14 +140,16 @@ def normalize_community_name(name: str) -> str:
     if not isinstance(name, str):
         return name
 
-    name = name.lower().strip()
+    name_str = str(name)
+    n_lower = str(name_str).lower()
+    n_clean = str(n_lower).strip()
 
     for keyword in FACILITY_KEYWORDS:
-        if keyword in name:
-            name = re.split(rf"\b{keyword}\b", name)[0]
+        if str(n_clean).find(str(keyword)) != -1:
+            n_clean = str(re.split(rf"\b{keyword}\b", str(n_clean))[0])
             break
 
-    return name.strip()
+    return str(n_clean).strip()
 
 
 # Communities that should NOT have suffixes stripped (they are real community names)
@@ -175,10 +178,11 @@ def infer_parent(community: str) -> str:
         return community
     
     # Try suffix stripping
-    original = community
+    original = str(community)
     for suffix in FACILITY_SUFFIXES:
-        if community.endswith(suffix):
-            community = community[:-len(suffix)].strip()
+        if str(community).endswith(str(suffix)):
+            idx = int(len(str(suffix)))
+            community = str(community)[:-idx].strip()  # type: ignore
             break
     
     # Check mapping again after suffix stripping
@@ -216,7 +220,7 @@ def alaska_albers_to_latlon(x, y):
     # Transform coordinates
     lon, lat = transformer.transform(x, y)
 
-    return round(lat, 6), round(lon, 6)
+    return float(f"{lat:.6f}"), float(f"{lon:.6f}")
 
 
 # -----------------------------

--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -68,6 +68,13 @@ def get_regions():
                 base_tier, base_score, region.properties, season
             )
             
+            # Calculate healthcare necessity score
+            from services.healthcare_desert_calculator import HealthcareDesertCalculator
+            necessity_data = HealthcareDesertCalculator.calculate_healthcare_necessity_score(
+                db, region.region_code, season
+            )
+            necessity_score = necessity_data['necessity_score'] if necessity_data else 0
+            
             result.append({
                 'id': region.id,
                 'region_name': region.region_name,
@@ -78,8 +85,9 @@ def get_regions():
                 'area_sqkm': region.area_sqkm,
                 'access_score': adjusted_score,  # Season-adjusted score
                 'base_access_score': base_score,
-                'centroid_lat': region.centroid_lat,
-                'centroid_lon': region.centroid_lon,
+                'necessity_score': necessity_score,
+                'centroid_lat': float(region.centroid_lat) if region.centroid_lat else None,
+                'centroid_lon': float(region.centroid_lon) if region.centroid_lon else None,
                 'description': explanation,  # Season-adjusted explanation
                 'season': season,
                 'created_at': region.created_at.isoformat() if region.created_at else None
@@ -151,15 +159,15 @@ def _calculate_seasonal_tier(base_tier: int, base_score: float, properties: dict
             tier_penalty += 1
             score_penalty += 20
         
-        adjusted_tier = min(4, base_tier + tier_penalty)
-        adjusted_score = max(0, base_score - score_penalty)
+        adjusted_tier = min(4, int(base_tier) + int(tier_penalty))
+        adjusted_score = max(0.0, float(base_score) - float(score_penalty))
         
         if tier_penalty > 0:
             explanation = f"Winter access: {', '.join(restricted_modes) if restricted_modes else 'Limited transport'}"
         else:
             explanation = f"Winter access: Air available; {base_explanation}"
         
-        return adjusted_tier, round(adjusted_score, 1), explanation
+        return adjusted_tier, float(f"{adjusted_score:.1f}"), explanation
     
     elif season == SEASON_SUMMER:
         # Summer can improve access slightly for communities with seasonal routes
@@ -177,8 +185,8 @@ def _calculate_seasonal_tier(base_tier: int, base_score: float, properties: dict
         if base_tier == 4 and (has_water or has_air):
             tier_bonus = -1
         
-        adjusted_tier = max(1, base_tier + tier_bonus)
-        adjusted_score = min(100, base_score + score_bonus)
+        adjusted_tier = max(1, int(base_tier) + int(tier_bonus))
+        adjusted_score = min(100.0, float(base_score) + float(score_bonus))
         
         if tier_bonus < 0:
             explanation = f"Summer access: Seasonal routes available; improved from Tier {base_tier}"
@@ -187,7 +195,7 @@ def _calculate_seasonal_tier(base_tier: int, base_score: float, properties: dict
         else:
             explanation = base_explanation
         
-        return adjusted_tier, round(adjusted_score, 1), explanation
+        return adjusted_tier, float(f"{adjusted_score:.1f}"), explanation
     
     return base_tier, base_score, base_explanation
 
@@ -572,9 +580,10 @@ def evaluate_feasibility(region_code):
             response['mode_results'] = result['mode_results']
             
             if not result['feasible'] and result['failure_reasons']:
-                response['explanation'] = result['failure_reasons'][0]
+                expl_str = str(result['failure_reasons'][0])
+                response['explanation'] = expl_str
                 # Determine failed gate from explanation
-                explanation = response['explanation'].lower()
+                explanation = expl_str.lower()
                 if 'bandwidth' in explanation:
                     response['failed_gate'] = 'BANDWIDTH'
                 elif 'latency' in explanation:
@@ -802,14 +811,17 @@ def get_telehealth_priority(region_code):
             BroadbandCoverage.region_code == region_code
         ).first()
 
-        if data_point and data_point.throughput_mbps is not None:
-            feasibility_result = CATDataHandler.check_cat4_telehealth_feasibility(
-                data_point, telehealth_mode='video'
-            )
-            connectivity_score = 100 if feasibility_result['feasible'] else 0
-        elif broadband and broadband.any_tech_25mbps_pct is not None:
-            # Use FCC 25 Mbps coverage percentage (stored as 0.0–1.0 decimal)
+        if broadband and broadband.wired_25mbps_pct is not None and broadband.wired_25mbps_pct >= 0:
+            # Prefer wired connectivity percentage to avoid 100% satellite false-positives in remote areas
+            connectivity_score = round(broadband.wired_25mbps_pct * 100)
+        elif broadband and broadband.any_tech_25mbps_pct is not None and broadband.primary_access != 'SATELLITE_DEPENDENT':
             connectivity_score = round(broadband.any_tech_25mbps_pct * 100)
+        elif data_point and data_point.throughput_mbps is not None:
+            # Scale throughput mbps to a score (0 to 100) assuming 100 Mbps is an ideal connection
+            connectivity_score = min(100, round((data_point.throughput_mbps / 100.0) * 100))
+        elif broadband and broadband.any_tech_25mbps_pct is not None:
+            # Fallback to any_tech but severely penalize if satellite dependent
+            connectivity_score = round((broadband.any_tech_25mbps_pct * 100) / 2)
         else:
             connectivity_score = 0
         
@@ -1066,8 +1078,9 @@ def get_data_gaps_summary():
                 gaps = r.data_gaps.split(';')
                 for gap in gaps:
                     gap = gap.strip()
-                    if gap in gap_stats:
-                        gap_stats[gap].append({
+                    lst = gap_stats.get(gap)
+                    if isinstance(lst, list):
+                        lst.append({
                             'place_id': r.place_id,
                             'place_name': r.place_name,
                             'confidence': r.confidence
@@ -1081,11 +1094,14 @@ def get_data_gaps_summary():
         }
         
         for gap_type, places in gap_stats.items():
-            summary['gap_breakdown'][gap_type] = {
-                'count': len(places),
-                'percentage': round(len(places) / len(all_records) * 100, 1) if all_records else 0,
-                'places': places[:10]  # Return first 10 for each gap type
-            }
+            pct = float(len(places)) / float(max(1, len(all_records))) * 100.0 if all_records else 0.0
+            bd = summary['gap_breakdown']
+            if isinstance(bd, dict):
+                bd[str(gap_type)] = {
+                    'count': len(places),
+                    'percentage': float(f"{pct:.1f}"),
+                    'places': [p for i, p in enumerate(places) if i < 10]
+                }
         
         # Confidence distribution
         summary['confidence_distribution'] = {
@@ -1139,19 +1155,34 @@ _ISP_CONFIG = _load_isp_config()
 
 def _get_regional_internet_cost(zcta: str) -> tuple:
     """Get internet cost for a ZCTA based on regional ISP availability."""
-    gci_urban = set(_ISP_CONFIG.get('zcta_mappings', {}).get('gci_urban', []))
-    extreme_rural = set(_ISP_CONFIG.get('zcta_mappings', {}).get('extreme_rural', []))
+    try:
+        gmap = _ISP_CONFIG.get('zcta_mappings', {})
+        if not isinstance(gmap, dict):
+            gmap = {}
+        gu_list = gmap.get('gci_urban', [])
+        er_list = gmap.get('extreme_rural', [])
+        gci_urban = set(gu_list if isinstance(gu_list, list) else [])
+        extreme_rural = set(er_list if isinstance(er_list, list) else [])
+    except Exception:
+        gci_urban = set()
+        extreme_rural = set()
+        
     pricing = _ISP_CONFIG.get('isp_pricing', {})
-    
+    if not isinstance(pricing, dict):
+        pricing = {}
+        
     if zcta in extreme_rural:
-        p = pricing.get('extreme_rural', {'cost': 450, 'name': 'Extreme Rural'})
-        return (p['cost'], p['name'])
+        p = pricing.get('extreme_rural', {'cost': 450.0, 'name': 'Extreme Rural'})
+        if not isinstance(p, dict): p = {'cost': 450.0, 'name': 'Extreme Rural'}
+        return (float(p.get('cost', 450.0)), str(p.get('name', 'Extreme Rural')))
     elif zcta in gci_urban:
-        p = pricing.get('gci', {'cost': 125, 'name': 'GCI'})
-        return (p['cost'], p['name'])
+        p = pricing.get('gci', {'cost': 125.0, 'name': 'GCI'})
+        if not isinstance(p, dict): p = {'cost': 125.0, 'name': 'GCI'}
+        return (float(p.get('cost', 125.0)), str(p.get('name', 'GCI')))
     else:
-        p = pricing.get('fastwyre', {'cost': 350, 'name': 'FastWyre'})
-        return (p['cost'], p['name'])
+        p = pricing.get('fastwyre', {'cost': 350.0, 'name': 'FastWyre'})
+        if not isinstance(p, dict): p = {'cost': 350.0, 'name': 'FastWyre'}
+        return (float(p.get('cost', 350.0)), str(p.get('name', 'FastWyre')))
 
 
 def _haversine_km(lat1, lon1, lat2, lon2):
@@ -1199,7 +1230,7 @@ def get_region_affordability(region_code):
                     min_dist = dist
                     best = c
         
-        if not best:
+        if best is None:
             # No income data found - return unavailable status
             return jsonify({
                 'has_income_data': False,
@@ -1210,22 +1241,29 @@ def get_region_affordability(region_code):
             }), 200
         
         # Calculate affordability
-        cost, isp_name = _get_regional_internet_cost(best.zcta)
-        monthly_income = best.median_income / 12
-        burden_pct = (cost / monthly_income) * 100 if monthly_income > 0 else 100
-        threshold = _ISP_CONFIG.get('thresholds', {}).get('affordability_burden_pct', 2.0)
-        is_affordable = burden_pct < threshold
+        assert best is not None
+        zcta_str = str(best.zcta) if hasattr(best, 'zcta') and best.zcta else ""
+        cost, isp_name = _get_regional_internet_cost(zcta_str)
+        med_inc = float(getattr(best, 'median_income', 0) or 0)
+        monthly_income = med_inc / 12.0
+        burden_pct = float((cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
+        
+        t_conf = _ISP_CONFIG.get('thresholds', {})
+        t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
+        threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
+        
+        is_affordable = bool(burden_pct < threshold)
         
         return jsonify({
             'has_income_data': True,
             'income_source': 'ZCTA',
-            'zcta': best.zcta,
-            'distance_km': round(min_dist, 1),
-            'median_income': best.median_income,
-            'monthly_income': round(monthly_income, 2),
-            'internet_cost': cost,
-            'isp': isp_name,
-            'burden_pct': round(burden_pct, 2),
+            'zcta': zcta_str,
+            'distance_km': float(f"{min_dist:.1f}"),
+            'median_income': med_inc,
+            'monthly_income': float(f"{monthly_income:.2f}"),
+            'internet_cost': float(cost),
+            'isp': str(isp_name),
+            'burden_pct': float(f"{burden_pct:.2f}"),
             'threshold_pct': threshold,
             'is_affordable': is_affordable,
             'status': 'AFFORDABLE' if is_affordable else 'UNAFFORDABLE',
@@ -1328,7 +1366,7 @@ def get_region_safety_net(region_code):
             'nearest_clinic': {
                 'name': nearest_clinic.name if nearest_clinic else None,
                 'type': nearest_clinic.site_type if nearest_clinic else None,
-                'distance_km': round(nearest_distance, 1) if nearest_clinic else None
+                'distance_km': float(f"{nearest_distance:.1f}") if nearest_clinic else None
             } if nearest_clinic else None,
             'classification': classification,
             'classification_color': color,
@@ -1381,15 +1419,21 @@ def get_region_telehealth_status(region_code):
         burden_pct = None
         internet_cost = None
         
-        if has_income_data:
-            internet_cost, isp_name = _get_regional_internet_cost(best_zcta.zcta)
-            monthly_income = best_zcta.median_income / 12
-            burden_pct = (internet_cost / monthly_income) * 100 if monthly_income > 0 else 100
-            threshold = _ISP_CONFIG.get('thresholds', {}).get('affordability_burden_pct', 2.0)
+        if has_income_data and best_zcta is not None:
+            assert best_zcta is not None
+            zcta_str = str(best_zcta.zcta) if hasattr(best_zcta, 'zcta') and best_zcta.zcta else ""
+            internet_cost, isp_name = _get_regional_internet_cost(zcta_str)
+            med_inc = float(getattr(best_zcta, 'median_income', 0) or 0)
+            monthly_income = med_inc / 12.0
+            burden_pct = float((internet_cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
+            
+            t_conf = _ISP_CONFIG.get('thresholds', {})
+            t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
+            threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
             
             # Absolute cost threshold: $400+/mo is inherently unaffordable regardless of income
-            absolute_cost_threshold = 400
-            is_affordable = burden_pct < threshold and internet_cost < absolute_cost_threshold
+            absolute_cost_threshold = 400.0
+            is_affordable = bool(burden_pct < threshold) and bool(internet_cost < absolute_cost_threshold)
         else:
             # No income data - check if cost is extreme rural ($450+)
             # Get cost based on region location
@@ -1476,13 +1520,13 @@ def get_region_telehealth_status(region_code):
             'affordability': {
                 'has_data': has_income_data,
                 'is_affordable': is_affordable,
-                'burden_pct': round(burden_pct, 2) if burden_pct else None,
+                'burden_pct': float(f"{burden_pct:.2f}") if burden_pct else None,
                 'internet_cost': internet_cost
             },
             'clinic_proximity': {
                 'has_nearby': has_nearby_clinic,
                 'nearest_name': nearest_clinic.name if nearest_clinic else None,
-                'nearest_distance_km': round(nearest_distance, 1) if nearest_clinic else None,
+                'nearest_distance_km': float(f"{nearest_distance:.1f}") if nearest_clinic else None,
                 'threshold_km': distance_threshold_km
             }
         }), 200
@@ -1541,13 +1585,18 @@ def get_all_telehealth_status():
             median_income = None
             isp_name = 'Unknown'
             
-            if has_income_data:
-                internet_cost, isp_name = _get_regional_internet_cost(best_zcta.zcta)
-                median_income = best_zcta.median_income
-                monthly_income = best_zcta.median_income / 12
-                burden_pct = (internet_cost / monthly_income) * 100 if monthly_income > 0 else 100
-                threshold = _ISP_CONFIG.get('thresholds', {}).get('affordability_burden_pct', 2.0)
-                is_affordable = burden_pct < threshold and internet_cost < 400
+            if has_income_data and best_zcta is not None:
+                assert best_zcta is not None
+                internet_cost, isp_name = _get_regional_internet_cost(str(getattr(best_zcta, 'zcta', '')))
+                median_income = float(getattr(best_zcta, 'median_income', 0) or 0)
+                monthly_income = median_income / 12.0
+                burden_pct = float((internet_cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
+                
+                t_conf = _ISP_CONFIG.get('thresholds', {})
+                t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
+                threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
+                
+                is_affordable = bool(burden_pct < threshold) and bool(internet_cost < 400.0)
             else:
                 internet_cost = 450  # Default fastwyre
                 isp_name = 'FastWyre (est.)'
@@ -1606,11 +1655,11 @@ def get_all_telehealth_status():
                 'color': color,
                 'internet_cost': internet_cost,
                 'isp_name': isp_name,
-                'burden_pct': round(burden_pct, 1) if burden_pct else None,
+                'burden_pct': float(f"{burden_pct:.1f}") if burden_pct else None,
                 'median_income': median_income,
                 'has_nearby_clinic': has_nearby_clinic,
                 'nearest_clinic_name': nearest_clinic_name,
-                'nearest_clinic_km': round(nearest_distance, 1) if nearest_distance != float('inf') else None,
+                'nearest_clinic_km': float(f"{nearest_distance:.1f}") if nearest_distance != float('inf') else None,
                 'access_mode': access_modes or 'unknown',
                 'recommendation': recommendation
             })
@@ -1777,14 +1826,16 @@ def get_healthcare_by_region(region_code):
         facilities_with_dist.sort(key=lambda x: x[1])
         
         # Return top 20 nearest
-        limit = request.args.get('limit', 20, type=int)
+        limit_val_str = request.args.get('limit', '20')
+        limit = int(limit_val_str) if str(limit_val_str).isdigit() else 20
+        
         result = []
-        for f, dist in facilities_with_dist[:limit]:
+        for f, dist in [x for i, x in enumerate(facilities_with_dist) if i < limit]:
             result.append({
                 'id': f.id,
                 'name': f.name,
                 'type': f.site_type,
-                'distance_km': round(dist, 1),
+                'distance_km': float(f"{dist:.1f}"),
                 'latitude': f.latitude,
                 'longitude': f.longitude,
                 'has_emergency': f.has_emergency,
@@ -1803,11 +1854,11 @@ def get_healthcare_by_region(region_code):
             'count': len(result),
             'nearest_hospital': {
                 'name': nearest_hospital_tuple[0].name,
-                'distance_km': round(nearest_hospital_tuple[1], 1)
+                'distance_km': float(f"{nearest_hospital_tuple[1]:.1f}")
             } if nearest_hospital_tuple else None,
             'nearest_clinic': {
                 'name': nearest_clinic_tuple[0].name,
-                'distance_km': round(nearest_clinic_tuple[1], 1)
+                'distance_km': float(f"{nearest_clinic_tuple[1]:.1f}")
             } if nearest_clinic_tuple else None
         }), 200
 

--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -69,7 +69,6 @@ def get_regions():
             )
             
             # Calculate healthcare necessity score
-            from services.healthcare_desert_calculator import HealthcareDesertCalculator
             necessity_data = HealthcareDesertCalculator.calculate_healthcare_necessity_score(
                 db, region.region_code, season
             )
@@ -1094,13 +1093,13 @@ def get_data_gaps_summary():
         }
         
         for gap_type, places in gap_stats.items():
-            pct = float(len(places)) / float(max(1, len(all_records))) * 100.0 if all_records else 0.0
+            pct = len(places) / max(1, len(all_records)) * 100.0 if all_records else 0.0
             bd = summary['gap_breakdown']
             if isinstance(bd, dict):
-                bd[str(gap_type)] = {
+                bd[gap_type] = {
                     'count': len(places),
-                    'percentage': float(f"{pct:.1f}"),
-                    'places': [p for i, p in enumerate(places) if i < 10]
+                    'percentage': round(float(pct), 1),  # type: ignore
+                    'places': list(places)[:10]  # type: ignore
                 }
         
         # Confidence distribution
@@ -1825,12 +1824,11 @@ def get_healthcare_by_region(region_code):
         # Sort by distance
         facilities_with_dist.sort(key=lambda x: x[1])
         
-        # Return top 20 nearest
-        limit_val_str = request.args.get('limit', '20')
-        limit = int(limit_val_str) if str(limit_val_str).isdigit() else 20
+        # Return top limit nearest
+        limit = request.args.get('limit', 20, type=int)
         
         result = []
-        for f, dist in [x for i, x in enumerate(facilities_with_dist) if i < limit]:
+        for f, dist in list(facilities_with_dist)[:limit]:  # type: ignore
             result.append({
                 'id': f.id,
                 'name': f.name,

--- a/backend/services/healthcare_desert_calculator.py
+++ b/backend/services/healthcare_desert_calculator.py
@@ -48,10 +48,10 @@ class HealthcareDesertCalculator:
         return R * c
     
     @staticmethod
-    def get_nearest_clinic_distance(db: Session, region_code: str) -> Optional[float]:
+    def get_nearest_facility_distances(db: Session, region_code: str) -> Optional[Dict[str, float]]:
         """
-        Calculate distance from region center to nearest healthcare site.
-        Returns distance in kilometers.
+        Calculate distance from region center to nearest clinic and nearest hospital.
+        Returns distances in kilometers.
         """
         region = db.query(CATRegion).filter(
             CATRegion.region_code == region_code
@@ -76,16 +76,24 @@ class HealthcareDesertCalculator:
         all_sites = db.query(HealthcareSite).all()
         
         if not all_sites:
-            return 999  # No healthcare sites in database
+            return {'clinic': 999.0, 'hospital': 999.0}  # No healthcare sites in database
         
-        min_distance = float('inf')
+        min_clinic = float('inf')
+        min_hospital = float('inf')
+        
         for site in all_sites:
             distance = HealthcareDesertCalculator.calculate_distance(
-                avg_lat, avg_lon, site.latitude, site.longitude
+                avg_lat, avg_lon, float(site.latitude), float(site.longitude)
             )
-            min_distance = min(min_distance, distance)
+            if site.site_type == 'hospital':
+                min_hospital = min(min_hospital, distance)
+            else:
+                min_clinic = min(min_clinic, distance)
         
-        return min_distance
+        return {
+            'clinic': min_clinic if min_clinic != float('inf') else 999.0,
+            'hospital': min_hospital if min_hospital != float('inf') else 999.0
+        }
     
     @staticmethod
     def calculate_healthcare_necessity_score(
@@ -111,13 +119,22 @@ class HealthcareDesertCalculator:
         4. Transportation difficulty - season-adjusted (20% weight)
         """
         
-        # 1. Distance factor (0-100)
-        distance = HealthcareDesertCalculator.get_nearest_clinic_distance(db, region_code)
-        if distance is None:
-            distance = 500  # Assume very remote
+        # 1. Distance factor (0-100) incorporates both clinic and hospital
+        distances = HealthcareDesertCalculator.get_nearest_facility_distances(db, region_code)
+        if distances is None:
+            clinic_dist = 500.0
+            hospital_dist = 500.0
+        else:
+            clinic_dist = distances['clinic']
+            hospital_dist = distances['hospital']
+            
+        # Normalize: 0km=0 points, 300+km=100 points for clinic
+        clinic_score = min(100.0, (clinic_dist / 300.0) * 100.0)
+        # Hospital distance is more vital, scales over 500km
+        hospital_score = min(100.0, (hospital_dist / 500.0) * 100.0)
         
-        # Normalize: 0km=0 points, 300+km=100 points
-        distance_score = min(100, (distance / 300) * 100)
+        # Strong penalty for lacking hospital access
+        distance_score = (0.6 * hospital_score) + (0.4 * clinic_score)
         
         # 2. Health site density (0-100)
         num_sites = db.query(HealthcareSite).filter(
@@ -170,30 +187,31 @@ class HealthcareDesertCalculator:
                 # Invert modifier: low availability = high difficulty
                 availability_penalty = (1.0 - road_modifier) * 30  # Up to 30 points
                 # Normalize: 0-60min=0, 240+min=100 (with adjustments)
-                base_transport_score = min(100, (adjusted_travel_time / 240) * 100)
-                transport_score = min(100, base_transport_score + availability_penalty)
+                base_transport_score = min(100.0, float(adjusted_travel_time / 240.0) * 100.0)
+                transport_score = min(100.0, float(base_transport_score + availability_penalty))
         else:
             # Unknown travel time - use seasonal default
             if season == SEASON_WINTER:
-                transport_score = 70  # Assume winter is harder
+                transport_score = 70.0  # Assume winter is harder
             elif season == SEASON_SUMMER:
-                transport_score = 40  # Assume summer is easier
+                transport_score = 40.0  # Assume summer is easier
             else:
-                transport_score = 50  # Year-round moderate
+                transport_score = 50.0  # Year-round moderate
         
         # Calculate weighted score
-        necessity_score = (
-            0.40 * distance_score +
-            0.20 * density_score +
-            0.20 * specialist_score +
+        necessity_score = float(
+            0.50 * distance_score +
+            0.15 * density_score +
+            0.15 * specialist_score +
             0.20 * transport_score
         )
         
         return {
-            'necessity_score': round(necessity_score, 2),
-            'distance_to_nearest_clinic_km': round(distance, 2),
-            'num_healthcare_sites': num_sites,
-            'has_specialist_access': has_specialists,
+            'necessity_score': round(float(necessity_score), 2),  # type: ignore
+            'distance_to_nearest_clinic_km': round(float(clinic_dist), 2),  # type: ignore
+            'distance_to_nearest_hospital_km': round(float(hospital_dist), 2),  # type: ignore
+            'num_healthcare_sites': int(num_sites),
+            'has_specialist_access': bool(has_specialists),
             'avg_travel_time_minutes': data_point.travel_time_minutes if data_point else None,
             'season_scenario': {
                 'active_season': season,
@@ -203,10 +221,10 @@ class HealthcareDesertCalculator:
                              'Actual conditions may vary.'
             },
             'breakdown': {
-                'distance_component': round(distance_score, 2),
-                'density_component': round(density_score, 2),
-                'specialist_component': round(specialist_score, 2),
-                'transport_component': round(transport_score, 2),
+                'distance_component': round(float(distance_score), 2),  # type: ignore
+                'density_component': round(float(density_score), 2),  # type: ignore
+                'specialist_component': round(float(specialist_score), 2),  # type: ignore
+                'transport_component': round(float(transport_score), 2),  # type: ignore
                 'transport_season_adjusted': True
             }
         }

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -20,6 +20,7 @@ export interface CATRegion {
     population: number | null;
     area_sqkm: number | null;
     access_score: number | null;
+    necessity_score: number;
 }
 
 export interface RegionsResponse {
@@ -135,6 +136,26 @@ export function getTierColor(tier: number): string {
         case 4: return '#ef4444'; // Red - Extreme
         default: return '#6b7280'; // Gray - Unknown
     }
+}
+
+/**
+ * Get map color based on Telehealth Necessity Score (0-100)
+ */
+export function getNeedColor(score: number): string {
+    if (score >= 75) return '#ef4444';      // Red - Critical Need
+    if (score >= 50) return '#f97316';      // Orange - High Need
+    if (score >= 25) return '#eab308';      // Yellow - Moderate Need
+    return '#22c55e';                       // Green - Low Need
+}
+
+/**
+ * Get label based on Telehealth Necessity Score (0-100)
+ */
+export function getNeedLabel(score: number): string {
+    if (score >= 75) return 'Critical Need';
+    if (score >= 50) return 'High Need';
+    if (score >= 25) return 'Moderate Need';
+    return 'Adequate Need';
 }
 
 /**

--- a/frontend/src/components/Legend.tsx
+++ b/frontend/src/components/Legend.tsx
@@ -1,26 +1,23 @@
 import React from 'react';
-import { getTierColor, getTierLabel } from '../api/catApi';
+import { getNeedColor, getNeedLabel } from '../api/catApi';
 
 interface LegendProps {
     totalRegions?: number;
 }
 
-// Helper for tier description
-const getTierCapability = (tier: number): string => {
-    switch (tier) {
-        case 1: return 'High-speed broadband, HD video telehealth supported';
-        case 2: return 'Adequate connectivity, standard video calls supported';
-        case 3: return 'Limited bandwidth, voice/audio consultations only';
-        case 4: return 'Minimal/no connectivity, text or async care only';
-        default: return '';
-    }
+// Helper for need description
+const getNeedCapability = (score: number): string => {
+    if (score >= 75) return 'Severe lack of nearby healthcare facilities';
+    if (score >= 50) return 'Limited access to clinics or hospitals';
+    if (score >= 25) return 'Adequate access with some travel distance';
+    return 'Good access to nearby healthcare facilities';
 };
 
 /**
  * Map legend showing CAT tier color coding
  */
 export default function Legend({ totalRegions }: LegendProps) {
-    const tiers = [1, 2, 3, 4];
+    const needLevels = [87, 62, 37, 12];
 
     return (
         <div style={{
@@ -54,14 +51,14 @@ export default function Legend({ totalRegions }: LegendProps) {
                     fontWeight: '700',
                     letterSpacing: '-0.02em'
                 }}>
-                    Community Access Tiers
+                    Telehealth Need
                 </h4>
-                <span style={{ fontSize: '10px', color: '#64748b', fontWeight: '500' }}>CAT-4</span>
+                <span style={{ fontSize: '10px', color: '#64748b', fontWeight: '500' }}>Score (0-100)</span>
             </div>
 
-            {tiers.map(tier => (
+            {needLevels.map(score => (
                 <div
-                    key={tier}
+                    key={score}
                     style={{
                         display: 'flex',
                         alignItems: 'flex-start',
@@ -73,17 +70,17 @@ export default function Legend({ totalRegions }: LegendProps) {
                         width: '12px',
                         height: '12px',
                         borderRadius: '50%',
-                        backgroundColor: getTierColor(tier),
+                        backgroundColor: getNeedColor(score),
                         flexShrink: 0,
                         marginTop: '3px',
                         boxShadow: '0 1px 2px rgba(0,0,0,0.15)'
                     }} />
                     <div>
                         <div style={{ color: '#1e293b', fontWeight: '500' }}>
-                            Tier {tier}: {getTierLabel(tier)}
+                            {getNeedLabel(score)}
                         </div>
                         <div style={{ color: '#64748b', fontSize: '10px' }}>
-                            {getTierCapability(tier)}
+                            {getNeedCapability(score)}
                         </div>
                     </div>
                 </div>
@@ -113,7 +110,7 @@ export default function Legend({ totalRegions }: LegendProps) {
                 <div style={{
                     height: '6px',
                     borderRadius: '3px',
-                    background: `linear-gradient(to right, ${getTierColor(1)}, ${getTierColor(2)}, ${getTierColor(3)}, ${getTierColor(4)})`,
+                    background: `linear-gradient(to right, ${getNeedColor(12)}, ${getNeedColor(37)}, ${getNeedColor(62)}, ${getNeedColor(87)})`,
                     marginBottom: '4px',
                 }} />
                 <div style={{
@@ -122,8 +119,8 @@ export default function Legend({ totalRegions }: LegendProps) {
                     fontSize: '9px',
                     color: '#94a3b8',
                 }}>
-                    <span>Full access</span>
-                    <span>No access</span>
+                    <span>Low Need</span>
+                    <span>High Need</span>
                 </div>
             </div>
         </div>

--- a/frontend/src/components/RegionMarker.tsx
+++ b/frontend/src/components/RegionMarker.tsx
@@ -5,6 +5,8 @@ import {
     CATRegion,
     getTierColor,
     getTierLabel,
+    getNeedColor,
+    getNeedLabel,
     Season,
     TelehealthPriorityResponse,
     fetchTelehealthPriority,
@@ -142,11 +144,11 @@ export default function RegionMarker({ region, season }: RegionMarkerProps) {
         return null;
     }
 
-    // Always use tier color so markers don't change color on click
-    const markerColor = getTierColor(region.tier_level);
+    // Use need score to color marker
+    const markerColor = getNeedColor(region.necessity_score);
     const icon = createMarkerIcon(markerColor);
-    const tierColor = getTierColor(region.tier_level);
-    const tierLabel = getTierLabel(region.tier_level);
+    const needColor = getNeedColor(region.necessity_score);
+    const needLabel = getNeedLabel(region.necessity_score);
 
     return (
         <Marker
@@ -171,17 +173,17 @@ export default function RegionMarker({ region, season }: RegionMarkerProps) {
                         display: 'inline-block',
                         padding: '2px 8px',
                         borderRadius: '12px',
-                        backgroundColor: tierColor,
+                        backgroundColor: needColor,
                         color: 'white',
                         fontSize: '12px',
                         fontWeight: '600',
                         marginBottom: '8px'
                     }}>
-                        Tier {region.tier_level}
+                        Telehealth Need Score: {region.necessity_score}
                     </div>
 
                     <div style={{ fontSize: '13px', color: '#374151' }}>
-                        <strong>Access Level:</strong> {tierLabel}
+                        <strong>Telehealth Priority:</strong> {needLabel}
                     </div>
 
                     {/* AFFORDABILITY & SAFETY NET BADGES */}
@@ -328,15 +330,12 @@ export default function RegionMarker({ region, season }: RegionMarkerProps) {
                                     fontSize: '12px',
                                     color: '#374151',
                                     display: 'grid',
-                                    gridTemplateColumns: '1fr 1fr',
-                                    gap: '4px 12px',
+                                    gridTemplateColumns: '1fr',
+                                    gap: '4px',
                                     marginBottom: '8px'
                                 }}>
                                     <div>
-                                        <strong>Need Score:</strong> {priority.necessity_score}
-                                    </div>
-                                    <div>
-                                        <strong>Connectivity:</strong> {priority.connectivity_score}%
+                                        <strong>Telehealth Need Score:</strong> {priority.necessity_score}
                                     </div>
                                 </div>
 


### PR DESCRIPTION
## Description
This pr focuses on fixing bugs in the CAT layer, improvises the formula used to calculate the telehealth_need_score. 
Now the CAT layer displays all the places according to their need for telehealth
<img width="1146" height="690" alt="image" src="https://github.com/user-attachments/assets/b5e9e71f-9afa-4468-a4a6-a75813bd16a6" />
Here we can see that places like Anchorage, Juneau where healthcare facilities are nearby (low telehealth need score) are considered under green markings, and other places with better conditions are placed in yellow markings, while highly remote places distant from hospitals/clinics are considered as red. 
this shows that the telehealth_need_score calculator formula is having much better accuracy now.