### PR TITLE
Region discovery api

### DIFF
--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -84,19 +84,30 @@ def _nearest_income_record(region, census_records):
     if region.centroid_lat is None or region.centroid_lon is None:
         return None
 
+    region_lat = float(region.centroid_lat)
+    region_lon = float(region.centroid_lon)
+    max_distance_km = 55
+    lat_window = max_distance_km / 111.0
+    lon_window = max_distance_km / (111.0 * max(math.cos(math.radians(region_lat)), 0.1))
+
     nearest = None
     min_dist = float('inf')
     for record in census_records:
         if record.centroid_lat is None or record.centroid_lon is None:
             continue
 
+        record_lat = float(record.centroid_lat)
+        record_lon = float(record.centroid_lon)
+        if abs(record_lat - region_lat) > lat_window or abs(record_lon - region_lon) > lon_window:
+            continue
+
         distance = _haversine_km(
-            region.centroid_lat,
-            region.centroid_lon,
-            record.centroid_lat,
-            record.centroid_lon,
+            region_lat,
+            region_lon,
+            record_lat,
+            record_lon,
         )
-        if distance < min_dist and distance < 55:
+        if distance < min_dist and distance < max_distance_km:
             min_dist = distance
             nearest = record
 

--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -1,7 +1,7 @@
 """
 API routes for Community Access Tier (CAT) data management
 """
-from database.models import CATRegion, HealthcareSite, CensusIncome, BroadbandCoverage
+from database.models import CATRegion, CATDataPoint, HealthcareSite, CensusIncome, BroadbandCoverage
 from flask import Blueprint, request, jsonify
 from werkzeug.utils import secure_filename
 import os
@@ -199,17 +199,92 @@ def _build_telehealth_context(db, regions):
     return context
 
 
-def _desert_score_for_region(db, region):
-    if region.centroid_lat is None or region.centroid_lon is None:
-        return None
+def _build_desert_score_lookup(db, regions):
+    region_codes = [region.region_code for region in regions if region.region_code]
+    if not region_codes:
+        return {}
 
-    try:
-        score_data = HealthcareDesertCalculator.calculate_healthcare_necessity_score(
-            db, region.region_code
+    data_points = db.query(CATDataPoint).filter(
+        CATDataPoint.region_code.in_(region_codes)
+    ).all()
+    points_by_region = {}
+    for point in data_points:
+        points_by_region.setdefault(point.region_code, []).append(point)
+
+    sites = db.query(HealthcareSite).all()
+    active_sites = [
+        site for site in sites
+        if site.is_active and site.latitude is not None and site.longitude is not None
+    ]
+
+    sites_by_region = {}
+    specialist_regions = set()
+    for site in sites:
+        if not site.region_code:
+            continue
+        sites_by_region[site.region_code] = sites_by_region.get(site.region_code, 0) + 1
+        if site.has_specialists:
+            specialist_regions.add(site.region_code)
+
+    score_lookup = {}
+    clinic_types = {'clinic', 'health_center', 'community_health_center'}
+
+    for region in regions:
+        if region.centroid_lat is None or region.centroid_lon is None:
+            score_lookup[region.region_code] = None
+            continue
+
+        region_points = points_by_region.get(region.region_code, [])
+        if region_points:
+            center_lat = sum(point.latitude for point in region_points) / len(region_points)
+            center_lon = sum(point.longitude for point in region_points) / len(region_points)
+            travel_time = region_points[0].travel_time_minutes
+        else:
+            center_lat = region.centroid_lat
+            center_lon = region.centroid_lon
+            travel_time = None
+
+        if active_sites:
+            clinic_dist = float('inf')
+            hospital_dist = float('inf')
+
+            for site in active_sites:
+                distance = _haversine_km(center_lat, center_lon, site.latitude, site.longitude)
+
+                site_type = (site.site_type or '').lower()
+                if site_type in clinic_types:
+                    clinic_dist = min(clinic_dist, distance)
+                if site_type == 'hospital':
+                    hospital_dist = min(hospital_dist, distance)
+
+            clinic_dist = 999 if clinic_dist == float('inf') else clinic_dist
+            hospital_dist = 999 if hospital_dist == float('inf') else hospital_dist
+        else:
+            clinic_dist = 999
+            hospital_dist = 999
+
+        clinic_score = HealthcareDesertCalculator.score_distance_component(clinic_dist)
+        hospital_score = min(100.0, (hospital_dist / 500.0) * 100.0)
+        distance_score = (0.6 * hospital_score) + (0.4 * clinic_score)
+        density_score = HealthcareDesertCalculator.score_density_component(
+            sites_by_region.get(region.region_code, 0)
         )
-        return score_data.get('necessity_score') if score_data else None
-    except Exception:
-        return None
+        specialist_score = HealthcareDesertCalculator.score_specialist_component(
+            region.region_code in specialist_regions
+        )
+        transport_score = HealthcareDesertCalculator.score_transport_component(
+            travel_time,
+            transport_mode='road',
+        )
+
+        score_lookup[region.region_code] = round(float(
+            0.50 * distance_score +
+            0.15 * density_score +
+            0.15 * specialist_score +
+            0.20 * transport_score
+        ), 2)
+
+    return score_lookup
 
 
 def _build_region_summary(db, regions):
@@ -218,6 +293,7 @@ def _build_region_summary(db, regions):
         [region.region_code for region in regions if region.region_code]
     )
     telehealth_lookup = _build_telehealth_context(db, regions)
+    desert_score_lookup = _build_desert_score_lookup(db, regions)
 
     summaries = []
     for region in regions:
@@ -231,7 +307,7 @@ def _build_region_summary(db, regions):
             'lon': _to_float_or_none(region.centroid_lon),
             'cat_tier': region.tier_level if region.tier_level is not None else None,
             'telehealth_status': telehealth.get('telehealth_status', 'DATA_UNAVAILABLE'),
-            'desert_score': _desert_score_for_region(db, region),
+            'desert_score': desert_score_lookup.get(region.region_code),
             'affordability_status': telehealth.get('affordability_status', 'unknown'),
             'data_confidence': _data_confidence(broadband),
             'has_data_gap': _has_broadband_data_gap(broadband),

--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -1,7 +1,7 @@
 """
 API routes for Community Access Tier (CAT) data management
 """
-from database.models import CATRegion, HealthcareSite, CensusIncome
+from database.models import CATRegion, HealthcareSite, CensusIncome, BroadbandCoverage
 from flask import Blueprint, request, jsonify
 from werkzeug.utils import secure_filename
 import os
@@ -33,6 +33,358 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def _to_float_or_none(value):
+    return float(value) if value is not None else None
+
+
+def _normalize_filter_value(value):
+    return str(value or '').strip().lower()
+
+
+def _region_group(region):
+    properties = region.properties or {}
+    return (
+        properties.get('region')
+        or properties.get('economic_region')
+        or properties.get('area')
+        or 'unknown'
+    )
+
+
+def _broadband_for_regions(db, region_codes):
+    if not region_codes:
+        return {}
+
+    records = db.query(BroadbandCoverage).filter(
+        BroadbandCoverage.region_code.in_(region_codes)
+    ).all()
+
+    lookup = {}
+    for record in records:
+        if record.region_code and record.region_code not in lookup:
+            lookup[record.region_code] = record
+    return lookup
+
+
+def _has_broadband_data_gap(record):
+    if record is None:
+        return True
+    return bool((record.data_gaps or '').strip())
+
+
+def _data_confidence(record):
+    if record is None:
+        return 'missing'
+    return (record.confidence or 'unknown').lower()
+
+
+def _nearest_income_record(region, census_records):
+    if region.centroid_lat is None or region.centroid_lon is None:
+        return None
+
+    nearest = None
+    min_dist = float('inf')
+    for record in census_records:
+        if record.centroid_lat is None or record.centroid_lon is None:
+            continue
+
+        distance = _haversine_km(
+            region.centroid_lat,
+            region.centroid_lon,
+            record.centroid_lat,
+            record.centroid_lon,
+        )
+        if distance < min_dist and distance < 55:
+            min_dist = distance
+            nearest = record
+
+    return nearest
+
+
+def _build_telehealth_context(db, regions):
+    """
+    Reuse the existing telehealth status ingredients in a compact lookup for
+    list endpoints. This mirrors the status formula used by /telehealth-status/all.
+    """
+    census_records = db.query(CensusIncome).filter(
+        CensusIncome.median_income.isnot(None),
+        CensusIncome.median_income > 0
+    ).all()
+    facilities = db.query(HealthcareSite).filter(
+        HealthcareSite.is_active == True,
+        HealthcareSite.latitude.isnot(None),
+        HealthcareSite.longitude.isnot(None)
+    ).all()
+    clinics = [
+        f for f in facilities
+        if f.site_type in ['clinic', 'hospital', 'health_center']
+    ]
+
+    context = {}
+    for region in regions:
+        status = 'DATA_UNAVAILABLE'
+        affordability_status = 'unknown'
+
+        if region.centroid_lat is not None and region.centroid_lon is not None:
+            best_zcta = _nearest_income_record(region, census_records)
+            has_income_data = best_zcta is not None
+            is_affordable = False
+            burden_pct = None
+            internet_cost = None
+
+            if best_zcta is not None:
+                internet_cost, _ = _get_regional_internet_cost(str(getattr(best_zcta, 'zcta', '')))
+                median_income = float(getattr(best_zcta, 'median_income', 0) or 0)
+                monthly_income = median_income / 12.0
+                burden_pct = float((internet_cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
+
+                t_conf = _ISP_CONFIG.get('thresholds', {})
+                t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
+                threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
+
+                is_affordable = bool(burden_pct < threshold) and bool(internet_cost < 400.0)
+                affordability_status = 'affordable' if is_affordable else 'unaffordable'
+            else:
+                internet_cost = 450
+                affordability_status = 'unknown'
+
+            access_modes = (region.properties or {}).get('primary_access_modes', '')
+            distance_threshold_km = 10 if 'road' in access_modes.lower() else 50
+
+            nearest_distance = float('inf')
+            for clinic in clinics:
+                distance = _haversine_km(
+                    region.centroid_lat,
+                    region.centroid_lon,
+                    clinic.latitude,
+                    clinic.longitude,
+                )
+                nearest_distance = min(nearest_distance, distance)
+
+            has_nearby_clinic = nearest_distance <= distance_threshold_km
+            is_extreme_cost = internet_cost and internet_cost >= 400
+
+            if not has_income_data:
+                if is_extreme_cost:
+                    status = 'COMMUNITY_ANCHOR' if has_nearby_clinic else 'CRITICAL_GAP'
+                elif has_nearby_clinic:
+                    status = 'COMMUNITY_ANCHOR'
+                else:
+                    status = 'DATA_UNAVAILABLE'
+            elif is_affordable:
+                status = 'TELEHEALTH_READY'
+            elif has_nearby_clinic:
+                status = 'COMMUNITY_ANCHOR'
+            else:
+                status = 'CRITICAL_GAP'
+
+        context[region.region_code] = {
+            'telehealth_status': status,
+            'affordability_status': affordability_status,
+        }
+
+    return context
+
+
+def _desert_score_for_region(db, region):
+    if region.centroid_lat is None or region.centroid_lon is None:
+        return None
+
+    try:
+        score_data = HealthcareDesertCalculator.calculate_healthcare_necessity_score(
+            db, region.region_code
+        )
+        return score_data.get('necessity_score') if score_data else None
+    except Exception:
+        return None
+
+
+def _build_region_summary(db, regions):
+    broadband_lookup = _broadband_for_regions(
+        db,
+        [region.region_code for region in regions if region.region_code]
+    )
+    telehealth_lookup = _build_telehealth_context(db, regions)
+
+    summaries = []
+    for region in regions:
+        broadband = broadband_lookup.get(region.region_code)
+        telehealth = telehealth_lookup.get(region.region_code, {})
+        summaries.append({
+            'id': region.id,
+            'region_code': region.region_code,
+            'name': region.region_name,
+            'lat': _to_float_or_none(region.centroid_lat),
+            'lon': _to_float_or_none(region.centroid_lon),
+            'cat_tier': region.tier_level if region.tier_level is not None else None,
+            'telehealth_status': telehealth.get('telehealth_status', 'DATA_UNAVAILABLE'),
+            'desert_score': _desert_score_for_region(db, region),
+            'affordability_status': telehealth.get('affordability_status', 'unknown'),
+            'data_confidence': _data_confidence(broadband),
+            'has_data_gap': _has_broadband_data_gap(broadband),
+            'region': _region_group(region),
+        })
+
+    return summaries
+
+
+def _parse_bool_filter(value):
+    normalized = _normalize_filter_value(value)
+    if normalized in {'true', '1', 'yes', 'missing', 'gap', 'gaps'}:
+        return True
+    if normalized in {'false', '0', 'no', 'complete', 'available'}:
+        return False
+    return None
+
+
+def _parse_desert_expression(value):
+    text = str(value or '').strip()
+    if not text:
+        return None
+
+    operator = None
+    if text[:2] in {'>=', '<='}:
+        operator = text[:2]
+        text = text[2:].strip()
+    elif text[:1] in {'>', '<'}:
+        operator = text[:1]
+        text = text[1:].strip()
+
+    try:
+        score = float(text)
+    except ValueError:
+        return None
+
+    return operator or 'range', score
+
+
+def _parse_region_search_args(args):
+    filters = {
+        'name': args.get('name') or '',
+        'tier': args.get('tier'),
+        'status': args.get('status'),
+        'desert_min': args.get('desert_min'),
+        'desert_max': args.get('desert_max'),
+        'data_gap': args.get('data_gap'),
+        'region': args.get('region'),
+    }
+
+    plain_terms = []
+    q = args.get('q') or ''
+    for token in q.split():
+        key, separator, value = token.partition(':')
+        key = key.lower()
+
+        if separator and key == 'tier':
+            filters['tier'] = value
+        elif separator and key == 'status':
+            filters['status'] = value
+        elif separator and key == 'data':
+            filters['data_gap'] = value
+        elif separator and key == 'desert':
+            parsed = _parse_desert_expression(value)
+            if parsed:
+                operator, score = parsed
+                if operator in {'>', '>='}:
+                    filters['desert_min'] = score
+                elif operator in {'<', '<='}:
+                    filters['desert_max'] = score
+        elif separator and key == 'region':
+            filters['region'] = value
+        else:
+            plain_terms.append(token)
+
+    if plain_terms:
+        filters['name'] = ' '.join(
+            term for term in [filters['name'], ' '.join(plain_terms)]
+            if term
+        )
+
+    return filters
+
+
+def _matches_status_filter(value, status_filter):
+    if not status_filter:
+        return True
+
+    normalized_status = _normalize_filter_value(value).replace('_', '')
+    normalized_filter = _normalize_filter_value(status_filter).replace('_', '')
+    allowed = {
+        'telehealthready',
+        'communityanchor',
+        'criticalgap',
+        'critical',
+        'dataunavailable',
+        'missing',
+        'unknown',
+    }
+    if normalized_filter not in allowed:
+        return True
+
+    return normalized_filter in normalized_status or normalized_status in normalized_filter
+
+
+def _filter_region_summaries(summaries, filters):
+    filtered = list(summaries)
+
+    name_filter = _normalize_filter_value(filters.get('name'))
+    if name_filter:
+        filtered = [
+            item for item in filtered
+            if name_filter in _normalize_filter_value(item.get('name'))
+            or name_filter in _normalize_filter_value(item.get('region_code'))
+        ]
+
+    try:
+        tier_filter = int(filters.get('tier')) if filters.get('tier') not in (None, '') else None
+    except (TypeError, ValueError):
+        tier_filter = None
+    if tier_filter in {1, 2, 3, 4}:
+        filtered = [item for item in filtered if item.get('cat_tier') == tier_filter]
+
+    status_filter = filters.get('status')
+    filtered = [
+        item for item in filtered
+        if _matches_status_filter(item.get('telehealth_status'), status_filter)
+    ]
+
+    try:
+        desert_min = float(filters.get('desert_min')) if filters.get('desert_min') not in (None, '') else None
+    except (TypeError, ValueError):
+        desert_min = None
+    if desert_min is not None:
+        filtered = [
+            item for item in filtered
+            if item.get('desert_score') is not None and item.get('desert_score') >= desert_min
+        ]
+
+    try:
+        desert_max = float(filters.get('desert_max')) if filters.get('desert_max') not in (None, '') else None
+    except (TypeError, ValueError):
+        desert_max = None
+    if desert_max is not None:
+        filtered = [
+            item for item in filtered
+            if item.get('desert_score') is not None and item.get('desert_score') <= desert_max
+        ]
+
+    data_gap_filter = _parse_bool_filter(filters.get('data_gap'))
+    if data_gap_filter is not None:
+        filtered = [
+            item for item in filtered
+            if item.get('has_data_gap') is data_gap_filter
+        ]
+
+    region_filter = _normalize_filter_value(filters.get('region'))
+    if region_filter:
+        filtered = [
+            item for item in filtered
+            if region_filter in _normalize_filter_value(item.get('region'))
+        ]
+
+    return filtered
 
 
 # Region endpoints
@@ -97,6 +449,63 @@ def get_regions():
             'total': len(result),
             'season': season,
             'season_display': get_season_display_name(season)
+        }), 200
+
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+    finally:
+        db.close()
+
+
+@cat_bp.route('/regions/summary', methods=['GET'])
+def get_regions_summary():
+    """
+    Return lightweight community records for sidebar lists.
+
+    This endpoint intentionally excludes geometry, GeoJSON, and popup detail
+    payloads so the frontend can populate navigation without downloading map
+    boundaries.
+    """
+    db = SessionLocal()
+    try:
+        regions = db.query(CATRegion).order_by(CATRegion.region_name).all()
+        summaries = _build_region_summary(db, regions)
+
+        return jsonify({
+            'regions': summaries,
+            'count': len(summaries)
+        }), 200
+
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+    finally:
+        db.close()
+
+
+@cat_bp.route('/regions/search', methods=['GET'])
+def search_regions():
+    """
+    Search lightweight community summaries for sidebar discovery.
+
+    Supports query params:
+        q/name, tier, status, desert_min, desert_max, data_gap, region
+
+    q also accepts compact filters like:
+        tier:4 status:critical desert:>70 data:missing Bethel
+    """
+    db = SessionLocal()
+    try:
+        filters = _parse_region_search_args(request.args)
+        regions = db.query(CATRegion).order_by(CATRegion.region_name).all()
+        summaries = _build_region_summary(db, regions)
+        filtered = _filter_region_summaries(summaries, filters)
+
+        return jsonify({
+            'regions': filtered,
+            'count': len(filtered),
+            'filters': filters
         }), 200
 
     except Exception as e:

--- a/backend/tests/test_region_discovery_api.py
+++ b/backend/tests/test_region_discovery_api.py
@@ -1,0 +1,199 @@
+import pytest
+
+from database.models import (
+    BroadbandCoverage,
+    CATRegion,
+    CensusIncome,
+    HealthcareSite,
+)
+
+
+@pytest.fixture()
+def client(db_session):
+    ready_region = CATRegion(
+        region_code="AK-ANCHORAGE",
+        region_name="Anchorage",
+        tier_level=1,
+        geometry='{"type":"Point","coordinates":[-149.9,61.2]}',
+        centroid_lat=61.2181,
+        centroid_lon=-149.9003,
+        access_score=95,
+        properties={
+            "primary_access_modes": "road",
+            "region": "Southcentral",
+        },
+    )
+    critical_region = CATRegion(
+        region_code="AK-EARECKSON",
+        region_name="Eareckson",
+        tier_level=4,
+        geometry='{"type":"Point","coordinates":[174.1,52.7]}',
+        centroid_lat=52.7123,
+        centroid_lon=174.114,
+        access_score=20,
+        properties={
+            "primary_access_modes": "air",
+            "region": "Aleutians",
+        },
+    )
+    missing_region = CATRegion(
+        region_code="AK-MISSING",
+        region_name="Missing Data",
+        tier_level=3,
+        geometry='{"type":"Point","coordinates":[0,0]}',
+        centroid_lat=None,
+        centroid_lon=None,
+        access_score=None,
+        properties={},
+    )
+    db_session.add_all([ready_region, critical_region, missing_region])
+    db_session.flush()
+
+    db_session.add(CensusIncome(
+        zcta="99501",
+        median_income=200000,
+        acs_year=2022,
+        centroid_lat=61.2181,
+        centroid_lon=-149.9003,
+    ))
+    db_session.add(HealthcareSite(
+        name="Anchorage Clinic",
+        site_type="clinic",
+        has_specialists=True,
+        latitude=61.2181,
+        longitude=-149.9003,
+        region_code="AK-ANCHORAGE",
+        is_active=True,
+    ))
+    db_session.add(BroadbandCoverage(
+        place_id="001",
+        place_name="Anchorage",
+        confidence="HIGH",
+        data_gaps=None,
+        telehealth_viable="YES",
+        primary_access="WIRED",
+        region_code="AK-ANCHORAGE",
+    ))
+    db_session.add(BroadbandCoverage(
+        place_id="002",
+        place_name="Eareckson",
+        confidence="LOW",
+        data_gaps="MISSING_WIRED_DATA;LOW_CONFIDENCE",
+        telehealth_viable="UNCERTAIN",
+        primary_access="SATELLITE",
+        region_code="AK-EARECKSON",
+    ))
+    db_session.commit()
+
+    from app import app
+
+    return app.test_client()
+
+
+def region_names(payload):
+    return {region["name"] for region in payload["regions"]}
+
+
+def test_regions_summary_returns_communities(client):
+    response = client.get("/api/cat/regions/summary")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 3
+    assert region_names(payload) == {"Anchorage", "Eareckson", "Missing Data"}
+
+
+def test_regions_summary_excludes_geometry(client):
+    response = client.get("/api/cat/regions/summary")
+
+    assert response.status_code == 200
+    for region in response.get_json()["regions"]:
+        assert "geometry" not in region
+        assert "geojson" not in region
+        assert set(region.keys()) == {
+            "id",
+            "region_code",
+            "name",
+            "lat",
+            "lon",
+            "cat_tier",
+            "telehealth_status",
+            "desert_score",
+            "affordability_status",
+            "data_confidence",
+            "has_data_gap",
+            "region",
+        }
+
+
+def test_regions_search_by_name(client):
+    response = client.get("/api/cat/regions/search?name=anchor")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 1
+    assert payload["regions"][0]["region_code"] == "AK-ANCHORAGE"
+
+
+def test_regions_search_filters_by_cat_tier(client):
+    response = client.get("/api/cat/regions/search?tier=4")
+
+    assert response.status_code == 200
+    assert region_names(response.get_json()) == {"Eareckson"}
+
+
+def test_regions_search_filters_by_telehealth_status(client):
+    response = client.get("/api/cat/regions/search?status=critical")
+
+    assert response.status_code == 200
+    assert region_names(response.get_json()) == {"Eareckson"}
+
+
+def test_regions_search_filters_by_desert_score_threshold(client):
+    response = client.get("/api/cat/regions/search?q=desert:>70")
+
+    assert response.status_code == 200
+    assert region_names(response.get_json()) == {"Eareckson"}
+
+
+def test_regions_search_filters_by_data_gap(client):
+    response = client.get("/api/cat/regions/search?q=data:missing")
+
+    assert response.status_code == 200
+    assert region_names(response.get_json()) == {"Eareckson", "Missing Data"}
+
+
+def test_regions_search_filters_by_region_syntax(client):
+    response = client.get("/api/cat/regions/search?q=region:aleutians")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 1
+    assert payload["regions"][0]["region_code"] == "AK-EARECKSON"
+
+
+def test_regions_search_invalid_filters_do_not_crash(client):
+    response = client.get(
+        "/api/cat/regions/search?q=tier:nope desert:>>bad&status=not-real&data_gap=maybe"
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 3
+    assert region_names(payload) == {"Anchorage", "Eareckson", "Missing Data"}
+
+
+def test_regions_summary_preserves_missing_data_labels(client):
+    response = client.get("/api/cat/regions/summary")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    missing = next(region for region in payload["regions"] if region["region_code"] == "AK-MISSING")
+
+    assert missing["lat"] is None
+    assert missing["lon"] is None
+    assert missing["desert_score"] is None
+    assert missing["telehealth_status"] == "DATA_UNAVAILABLE"
+    assert missing["affordability_status"] == "unknown"
+    assert missing["data_confidence"] == "missing"
+    assert missing["has_data_gap"] is True

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -28,6 +28,49 @@ export interface RegionsResponse {
     total: number;
 }
 
+export type TelehealthStatusName =
+    | 'TELEHEALTH_READY'
+    | 'COMMUNITY_ANCHOR'
+    | 'CRITICAL_GAP'
+    | 'DATA_UNAVAILABLE';
+
+export type AffordabilityStatusName = 'affordable' | 'unaffordable' | 'unknown';
+
+export interface RegionSummary {
+    id: number;
+    region_code: string;
+    name: string;
+    lat: number | null;
+    lon: number | null;
+    cat_tier: number | null;
+    telehealth_status: TelehealthStatusName | string;
+    desert_score: number | null;
+    affordability_status: AffordabilityStatusName | string;
+    data_confidence: 'high' | 'medium' | 'low' | 'missing' | 'unknown' | string;
+    has_data_gap: boolean;
+    region: string | null;
+}
+
+export interface RegionSummaryResponse {
+    regions: RegionSummary[];
+    count: number;
+}
+
+export interface RegionSearchParams {
+    q?: string;
+    name?: string;
+    tier?: number | string | null;
+    status?: string | null;
+    desert_min?: number | string | null;
+    desert_max?: number | string | null;
+    data_gap?: boolean | string | null;
+    region?: string | null;
+}
+
+export interface RegionSearchResponse extends RegionSummaryResponse {
+    filters?: Record<string, unknown>;
+}
+
 export interface StatisticsResponse {
     total_regions: number;
     total_data_points: number;
@@ -94,6 +137,41 @@ export async function fetchRegions(season: Season = 'year_round', tier?: number)
     }
 
     const data: RegionsResponse = await response.json();
+    return data.regions;
+}
+
+/**
+ * Fetch lightweight community summaries for sidebar navigation.
+ */
+export async function fetchRegionSummary(): Promise<RegionSummary[]> {
+    const response = await fetch(`${API_BASE}/regions/summary`);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch region summary: ${response.statusText}`);
+    }
+
+    const data: RegionSummaryResponse = await response.json();
+    return data.regions;
+}
+
+/**
+ * Search lightweight community summaries for sidebar discovery.
+ */
+export async function searchRegions(params: RegionSearchParams = {}): Promise<RegionSummary[]> {
+    const query = new URLSearchParams();
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            query.append(key, String(value));
+        }
+    });
+
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    const response = await fetch(`${API_BASE}/regions/search${suffix}`);
+    if (!response.ok) {
+        throw new Error(`Failed to search regions: ${response.statusText}`);
+    }
+
+    const data: RegionSearchResponse = await response.json();
     return data.regions;
 }
 


### PR DESCRIPTION
## Summary

This PR adds the backend and frontend API contract for lightweight region discovery in Phase 2.

## Changes

- Added `/api/cat/regions/summary` for lightweight community summary records.
- Added `/api/cat/regions/search` with filters for name, CAT tier, telehealth status, desert score, data gaps, and region grouping.
- Added frontend API types and helpers for region summary/search responses.
- Added backend tests for summary payloads, filtering behavior, invalid filters, and missing-data handling.

## Validation

- `python3 -m pytest backend/tests/test_region_discovery_api.py`
- `npm test`