### PR TITLE
Community reporting flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tenet-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "jspdf": "^4.2.1",
         "leaflet": "^1.9.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1445,12 +1446,25 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
@@ -1483,6 +1497,13 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1714,6 +1735,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.29.tgz",
@@ -1840,6 +1871,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1920,6 +1971,28 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -2099,6 +2172,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2280,6 +2363,23 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -2502,6 +2602,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -2567,6 +2681,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -2897,6 +3017,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
@@ -3110,6 +3247,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3139,6 +3282,13 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3244,6 +3394,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3316,6 +3476,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -3343,6 +3510,16 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rollup": {
       "version": "4.61.0",
@@ -3587,6 +3764,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -3644,12 +3831,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3819,6 +4026,16 @@
       "peerDependencies": {
         "react": ">=16",
         "supercluster": ">=8"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "jspdf": "^4.2.1",
     "leaflet": "^1.9.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/api/researchApi.ts
+++ b/frontend/src/api/researchApi.ts
@@ -1,0 +1,37 @@
+import { Season } from './catApi';
+import { ResearchProfile, ResearchProfilesResponse } from '../types/research';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
+
+export async function fetchResearchProfile(
+    regionCode: string,
+    season: Season = 'year_round',
+): Promise<ResearchProfile> {
+    const params = new URLSearchParams({ season });
+    const response = await fetch(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/research-profile?${params.toString()}`,
+    );
+
+    if (!response.ok) {
+        throw new Error(response.status === 404 ? 'Community not found' : 'Failed to fetch research profile');
+    }
+
+    return response.json();
+}
+
+export async function fetchResearchProfiles(
+    regionCodes: string[],
+    season: Season = 'year_round',
+): Promise<ResearchProfilesResponse> {
+    const params = new URLSearchParams({
+        codes: regionCodes.slice(0, 3).join(','),
+        season,
+    });
+    const response = await fetch(`${API_BASE}/regions/research-profiles?${params.toString()}`);
+
+    if (!response.ok) {
+        throw new Error('Failed to fetch comparison profiles');
+    }
+
+    return response.json();
+}

--- a/frontend/src/components/sidebar/SelectedRegionPanel.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.tsx
@@ -1,26 +1,68 @@
-import { RegionSummary } from '../../api/catApi';
+import { useEffect, useRef, useState } from 'react';
+import { RegionSummary, Season } from '../../api/catApi';
+import { useResearchProfile } from '../../hooks/useResearchProfile';
+import { exportResearchProfileReport } from '../../utils/reportExport';
+import { DATA_UNAVAILABLE, formatResearchValue } from '../../utils/formatResearchValue';
 import MetricTooltip from '../MetricTooltip';
 import { formatMissing, formatStatus, statusClassName } from './sidebarUtils';
 
 interface SelectedRegionPanelProps {
     region: RegionSummary | null;
+    season: Season;
+    focusKey?: number;
     pinned: boolean;
     pinDisabled: boolean;
     onTogglePin: (regionCode: string) => void;
 }
 
+function telehealthNeedLabel(score: number | null | undefined): string {
+    if (score === null || score === undefined || !Number.isFinite(score)) {
+        return DATA_UNAVAILABLE;
+    }
+    if (score <= 30) return `Low Need (${score.toFixed(1)})`;
+    if (score <= 60) return `Moderate Need (${score.toFixed(1)})`;
+    if (score <= 80) return `High Need (${score.toFixed(1)})`;
+    return `Critical Need (${score.toFixed(1)})`;
+}
+
 export default function SelectedRegionPanel({
     region,
+    season,
+    focusKey = 0,
     pinned,
     pinDisabled,
     onTogglePin,
 }: SelectedRegionPanelProps) {
+    const { profile, loading, error } = useResearchProfile(region?.region_code ?? null, season);
+    const panelRef = useRef<HTMLElement | null>(null);
+    const [highlight, setHighlight] = useState(false);
+
+    useEffect(() => {
+        if (!region || focusKey === 0) return;
+        panelRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        setHighlight(true);
+        const timeout = window.setTimeout(() => setHighlight(false), 1400);
+        return () => window.clearTimeout(timeout);
+    }, [focusKey, region]);
+
     if (!region) {
         return null;
     }
 
+    const handleDownloadReport = async () => {
+        if (!profile) return;
+        await exportResearchProfileReport(profile, document.querySelector('.leaflet-container'));
+    };
+
+    const handleCopyShareLink = async () => {
+        await navigator.clipboard?.writeText(window.location.href);
+    };
+
     return (
-        <section className="selected-region-panel">
+        <section
+            ref={panelRef}
+            className={`selected-region-panel ${highlight ? 'focused' : ''}`}
+        >
             <div className="selected-region-header">
                 <div>
                     <h2>{region.name}</h2>
@@ -36,6 +78,31 @@ export default function SelectedRegionPanel({
                     {pinned ? 'Pinned' : 'Pin'}
                 </button>
             </div>
+
+            <div className="selected-region-actions">
+                <button
+                    type="button"
+                    className="sidebar-action-button"
+                    disabled={loading || !profile}
+                    onClick={handleDownloadReport}
+                >
+                    Download Report
+                </button>
+                <button
+                    type="button"
+                    className="sidebar-action-button"
+                    onClick={handleCopyShareLink}
+                >
+                    Copy Share Link
+                </button>
+            </div>
+
+            {error && <div className="selected-region-note error">{error}</div>}
+            {profile?.region.has_data_gap && (
+                <div className="selected-region-note">
+                    {profile.region.data_confidence} confidence · {profile.region.missing_fields.length} data gaps
+                </div>
+            )}
 
             <div className="selected-detail-grid">
                 <span>
@@ -62,7 +129,15 @@ export default function SelectedRegionPanel({
                         Higher scores mean greater need for telehealth due to healthcare access barriers.
                     </MetricTooltip>
                 </span>
-                <strong>{region.desert_score ?? 'Unknown'}</strong>
+                <strong>{formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}</strong>
+
+                <span>
+                    Telehealth need
+                    <MetricTooltip term="Telehealth Need">
+                        Interprets healthcare desert score: 0-30 low, 31-60 moderate, 61-80 high, and 81-100 critical.
+                    </MetricTooltip>
+                </span>
+                <strong>{telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}</strong>
 
                 <span>
                     Affordability
@@ -70,7 +145,7 @@ export default function SelectedRegionPanel({
                         Whether monthly internet cost is affordable relative to income data.
                     </MetricTooltip>
                 </span>
-                <strong>{formatStatus(region.affordability_status)}</strong>
+                <strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong>
 
                 <span>
                     Data confidence
@@ -90,6 +165,48 @@ export default function SelectedRegionPanel({
 
                 <span>Region</span>
                 <strong>{formatMissing(region.region)}</strong>
+
+                <span>Download speed</span>
+                <strong>
+                    {profile
+                        ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 })
+                        : DATA_UNAVAILABLE}
+                </strong>
+
+                <span>Upload speed</span>
+                <strong>
+                    {profile
+                        ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 })
+                        : DATA_UNAVAILABLE}
+                </strong>
+
+                <span>Latency</span>
+                <strong>
+                    {profile
+                        ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 })
+                        : DATA_UNAVAILABLE}
+                </strong>
+
+                <span>Cost burden</span>
+                <strong>
+                    {profile
+                        ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 })
+                        : DATA_UNAVAILABLE}
+                </strong>
+
+                <span>Nearest care</span>
+                <strong>
+                    {profile
+                        ? formatResearchValue(profile.healthcare.nearest_facility_name)
+                        : DATA_UNAVAILABLE}
+                </strong>
+
+                <span>Facility distance</span>
+                <strong>
+                    {profile
+                        ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 })
+                        : DATA_UNAVAILABLE}
+                </strong>
             </div>
         </section>
     );

--- a/frontend/src/components/sidebar/SelectedRegionPanel.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.tsx
@@ -98,9 +98,9 @@ export default function SelectedRegionPanel({
             </div>
 
             {error && <div className="selected-region-note error">{error}</div>}
-            {profile?.region.has_data_gap && (
+            {profile?.region?.has_data_gap && (
                 <div className="selected-region-note">
-                    {profile.region.data_confidence} confidence · {profile.region.missing_fields.length} data gaps
+                    {profile.region?.data_confidence ?? DATA_UNAVAILABLE} confidence · {profile.region?.missing_fields?.length ?? 0} data gaps
                 </div>
             )}
 

--- a/frontend/src/components/sidebar/sidebar.css
+++ b/frontend/src/components/sidebar/sidebar.css
@@ -6,13 +6,14 @@
     height: 100vh;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     padding: 16px;
     box-sizing: border-box;
     background: #f8fafc;
     border-right: 1px solid #dbe3ea;
     box-shadow: 6px 0 18px rgba(15, 23, 42, 0.08);
     color: #172033;
+    overflow: hidden;
 }
 
 .tenet-sidebar.collapsed {
@@ -223,16 +224,34 @@
 }
 
 .pinned-section {
-    max-height: 184px;
-    overflow: auto;
+    flex: 0 0 auto;
+    max-height: min(22vh, 170px);
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     padding-bottom: 2px;
 }
 
+.pinned-section .region-list {
+    flex: 1 1 auto;
+}
+
 .selected-region-panel {
+    flex: 0 1 auto;
+    max-height: min(34vh, 320px);
+    overflow: auto;
     border: 1px solid #c7d0da;
     border-radius: 8px;
     background: #ffffff;
     padding: 12px;
+    transition: border-color 0.18s, box-shadow 0.18s, background 0.18s;
+    scroll-margin-block: 12px;
+}
+
+.selected-region-panel.focused {
+    border-color: #2563eb;
+    background: #eff6ff;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
 }
 
 .selected-region-panel.muted {
@@ -260,6 +279,35 @@
     font-size: 11px;
 }
 
+.selected-region-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.selected-region-actions .sidebar-action-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.selected-region-note {
+    margin-bottom: 10px;
+    border: 1px solid #fde68a;
+    border-radius: 6px;
+    background: #fffbeb;
+    color: #92400e;
+    padding: 7px 8px;
+    font-size: 11px;
+    line-height: 1.35;
+}
+
+.selected-region-note.error {
+    border-color: #fecaca;
+    background: #fef2f2;
+    color: #b91c1c;
+}
+
 .selected-detail-grid {
     display: grid;
     grid-template-columns: minmax(92px, 1fr) minmax(0, 1.2fr);
@@ -277,8 +325,8 @@
 }
 
 .sidebar-results {
-    min-height: 0;
-    flex: 1;
+    min-height: 170px;
+    flex: 1 1 220px;
     display: flex;
     flex-direction: column;
 }

--- a/frontend/src/hooks/useResearchProfile.ts
+++ b/frontend/src/hooks/useResearchProfile.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { Season } from '../api/catApi';
+import { fetchResearchProfile } from '../api/researchApi';
+import { ResearchProfile } from '../types/research';
+
+export function useResearchProfile(regionCode: string | null, season: Season) {
+    const [profile, setProfile] = useState<ResearchProfile | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!regionCode) {
+            setProfile(null);
+            setError(null);
+            setLoading(false);
+            return;
+        }
+
+        let active = true;
+        setLoading(true);
+        setError(null);
+
+        fetchResearchProfile(regionCode, season)
+            .then(data => {
+                if (active) setProfile(data);
+            })
+            .catch(err => {
+                if (active) {
+                    setProfile(null);
+                    setError(err instanceof Error ? err.message : 'Failed to load research profile');
+                }
+            })
+            .finally(() => {
+                if (active) setLoading(false);
+            });
+
+        return () => {
+            active = false;
+        };
+    }, [regionCode, season]);
+
+    return { profile, loading, error };
+}

--- a/frontend/src/hooks/useResearchProfile.ts
+++ b/frontend/src/hooks/useResearchProfile.ts
@@ -18,6 +18,7 @@ export function useResearchProfile(regionCode: string | null, season: Season) {
 
         let active = true;
         setLoading(true);
+        setProfile(null);
         setError(null);
 
         fetchResearchProfile(regionCode, season)

--- a/frontend/src/types/research.ts
+++ b/frontend/src/types/research.ts
@@ -1,0 +1,63 @@
+import { Season } from '../api/catApi';
+
+export type DataConfidence = 'HIGH' | 'MEDIUM' | 'LOW' | 'MISSING' | string;
+
+export interface ResearchProfile {
+    region: {
+        region_code: string;
+        name: string;
+        lat: number | null;
+        lon: number | null;
+        region: string | null;
+        cat_tier: number | null;
+        data_confidence: DataConfidence;
+        has_data_gap: boolean;
+        missing_fields: string[];
+    };
+    connectivity: {
+        fcc_coverage_25mbps_pct: number | null;
+        ookla_download_mbps: number | null;
+        ookla_upload_mbps: number | null;
+        latency_ms: number | null;
+        reliability_label: string | null;
+        isp_name: string | null;
+        data_source: string | null;
+    };
+    affordability: {
+        monthly_cost: number | null;
+        median_income: number | null;
+        burden_pct: number | null;
+        threshold_pct: number | null;
+        status: 'affordable' | 'unaffordable' | 'unknown';
+    };
+    healthcare: {
+        nearest_facility_name: string | null;
+        nearest_facility_distance_km: number | null;
+        nearest_facility_type: string | null;
+        emergency_services: boolean | null;
+        specialist_available: boolean | null;
+        facility_count: number | null;
+        desert_score: number | null;
+    };
+    telehealth: {
+        status: string;
+        label: string;
+        video_feasible: boolean | null;
+        audio_feasible: boolean | null;
+        clinic_supported: boolean | null;
+        season: Season;
+        season_note: string;
+    };
+    methodology: {
+        generated_at: string;
+        sources: string[];
+        confidence_notes: string[];
+    };
+}
+
+export interface ResearchProfilesResponse {
+    profiles: ResearchProfile[];
+    count: number;
+    missing_codes: string[];
+    season: Season;
+}

--- a/frontend/src/utils/formatResearchValue.ts
+++ b/frontend/src/utils/formatResearchValue.ts
@@ -1,0 +1,41 @@
+export const DATA_UNAVAILABLE = 'Data unavailable';
+
+export function formatResearchValue(
+    value: number | string | boolean | null | undefined,
+    options: {
+        suffix?: string;
+        prefix?: string;
+        digits?: number;
+        booleanLabels?: [string, string];
+    } = {},
+): string {
+    if (value === null || value === undefined || value === '') {
+        return DATA_UNAVAILABLE;
+    }
+
+    if (typeof value === 'boolean') {
+        const labels = options.booleanLabels ?? ['Yes', 'No'];
+        return value ? labels[0] : labels[1];
+    }
+
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return DATA_UNAVAILABLE;
+        }
+        const digits = options.digits ?? (Number.isInteger(value) ? 0 : 1);
+        return `${options.prefix ?? ''}${value.toLocaleString(undefined, {
+            maximumFractionDigits: digits,
+            minimumFractionDigits: 0,
+        })}${options.suffix ?? ''}`;
+    }
+
+    return value;
+}
+
+export function formatStatusText(value: string | null | undefined): string {
+    if (!value) return DATA_UNAVAILABLE;
+    return value
+        .replace(/_/g, ' ')
+        .toLowerCase()
+        .replace(/\b\w/g, char => char.toUpperCase());
+}

--- a/frontend/src/utils/reportExport.ts
+++ b/frontend/src/utils/reportExport.ts
@@ -371,8 +371,7 @@ export async function exportResearchProfileReport(
         { label: 'Facility Count', value: formatResearchValue(profile.healthcare.facility_count) },
         { label: 'Classification Reason', value: interpretation(profile) },
     ], MARGIN, y, CONTENT_WIDTH);
-
-    addFindings(pdf, profile, MARGIN, y, CONTENT_WIDTH);
+    addFooter(pdf, 1);
     addFooter(pdf, 1);
 
     pdf.addPage();

--- a/frontend/src/utils/reportExport.ts
+++ b/frontend/src/utils/reportExport.ts
@@ -372,7 +372,6 @@ export async function exportResearchProfileReport(
         { label: 'Classification Reason', value: interpretation(profile) },
     ], MARGIN, y, CONTENT_WIDTH);
     addFooter(pdf, 1);
-    addFooter(pdf, 1);
 
     pdf.addPage();
     addPageBase(pdf);
@@ -430,10 +429,13 @@ export async function exportResearchProfileReport(
         { label: 'Season Note', value: formatResearchValue(profile.telehealth.season_note) },
     ], rightX, rightY, colWidth, true);
 
-    addReportTable(pdf, 'Data Sources', [
+    rightY = addReportTable(pdf, 'Data Sources', [
         { label: 'Sources', value: safeJoin(profile.methodology.sources) },
         { label: 'Generated At', value: new Date(profile.methodology.generated_at).toLocaleString() },
     ], rightX, rightY, colWidth, true);
+
+    const finalY = Math.max(leftY, rightY);
+    addFindings(pdf, profile, MARGIN, finalY + 4, CONTENT_WIDTH);
 
     addFooter(pdf, 2);
     pdf.save(`tenet-community-report-${fileSafe(profile.region.name)}.pdf`);

--- a/frontend/src/utils/reportExport.ts
+++ b/frontend/src/utils/reportExport.ts
@@ -1,0 +1,441 @@
+import jsPDF from 'jspdf';
+import { ResearchProfile } from '../types/research';
+import { DATA_UNAVAILABLE, formatResearchValue, formatStatusText } from './formatResearchValue';
+
+const PAGE_WIDTH = 210;
+const PAGE_HEIGHT = 297;
+const MARGIN = 14;
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+
+const INK = '#151827';
+const MUTED = '#6b7280';
+const LINE = '#d7dde6';
+const ROW = '#f8fafc';
+const LABEL_BG = '#f0f2f5';
+const BRAND = '#1d2848';
+const GREEN = '#dff3e7';
+const GREEN_TEXT = '#17643a';
+const AMBER = '#fff3cf';
+const AMBER_TEXT = '#8a5a00';
+const RED = '#fee2e2';
+const RED_TEXT = '#9f1239';
+const BLUE = '#e7efff';
+const BLUE_TEXT = '#1d4ed8';
+
+type Tone = 'good' | 'warn' | 'bad' | 'neutral';
+
+interface ReportRow {
+    label: string;
+    value: string;
+    tone?: Tone;
+}
+
+function rgb(hex: string): [number, number, number] {
+    const value = hex.replace('#', '');
+    return [
+        Number.parseInt(value.slice(0, 2), 16),
+        Number.parseInt(value.slice(2, 4), 16),
+        Number.parseInt(value.slice(4, 6), 16),
+    ];
+}
+
+function setFill(pdf: jsPDF, color: string) {
+    const [r, g, b] = rgb(color);
+    pdf.setFillColor(r, g, b);
+}
+
+function setDraw(pdf: jsPDF, color: string) {
+    const [r, g, b] = rgb(color);
+    pdf.setDrawColor(r, g, b);
+}
+
+function setText(pdf: jsPDF, color: string) {
+    const [r, g, b] = rgb(color);
+    pdf.setTextColor(r, g, b);
+}
+
+function fileSafe(value: string) {
+    return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function clean(value: string | number | boolean | null | undefined): string {
+    const formatted = formatResearchValue(value);
+    if (!formatted || formatted === 'null' || formatted === 'undefined' || formatted === 'NaN') {
+        return DATA_UNAVAILABLE;
+    }
+    return formatted;
+}
+
+function safeText(value: string | number | boolean | null | undefined): string {
+    if (value === null || value === undefined || value === '') return DATA_UNAVAILABLE;
+    if (typeof value === 'number' && !Number.isFinite(value)) return DATA_UNAVAILABLE;
+    return String(value);
+}
+
+function safeJoin(values: string[]): string {
+    const filtered = values
+        .map(value => safeText(value))
+        .filter(value => value !== DATA_UNAVAILABLE);
+    return filtered.length ? filtered.join(', ') : DATA_UNAVAILABLE;
+}
+
+function coordinateText(profile: ResearchProfile): string {
+    if (profile.region.lat === null || profile.region.lon === null) {
+        return DATA_UNAVAILABLE;
+    }
+    return `${profile.region.lat.toFixed(4)}, ${profile.region.lon.toFixed(4)}`;
+}
+
+function accessTier(profile: ResearchProfile): string {
+    return profile.region.cat_tier === null ? DATA_UNAVAILABLE : `Tier ${profile.region.cat_tier}`;
+}
+
+function dataCompleteness(profile: ResearchProfile): string {
+    if (!profile.region.has_data_gap) return 'No gap flagged';
+    const count = profile.region.missing_fields.length;
+    return `${count} missing ${count === 1 ? 'field' : 'fields'} flagged`;
+}
+
+function affordabilityTone(status: ResearchProfile['affordability']['status']): Tone {
+    if (status === 'affordable') return 'good';
+    if (status === 'unaffordable') return 'bad';
+    return 'warn';
+}
+
+function telehealthTone(status: string): Tone {
+    if (status === 'TELEHEALTH_READY') return 'good';
+    if (status === 'CLINIC_SUPPORTED') return 'warn';
+    if (status === 'NOT_READY') return 'bad';
+    return 'neutral';
+}
+
+function confidenceTone(confidence: string): Tone {
+    if (confidence === 'HIGH') return 'good';
+    if (confidence === 'MEDIUM') return 'warn';
+    if (confidence === 'LOW' || confidence === 'MISSING') return 'bad';
+    return 'neutral';
+}
+
+function badgeColors(tone: Tone): [string, string] {
+    if (tone === 'good') return [GREEN, GREEN_TEXT];
+    if (tone === 'warn') return [AMBER, AMBER_TEXT];
+    if (tone === 'bad') return [RED, RED_TEXT];
+    return [BLUE, BLUE_TEXT];
+}
+
+function equityClassification(profile: ResearchProfile): string {
+    const telehealth = formatStatusText(profile.telehealth.status);
+    const affordability = formatStatusText(profile.affordability.status);
+    if (profile.telehealth.status === 'TELEHEALTH_READY' && profile.affordability.status === 'affordable') {
+        return 'Ready - Affordable';
+    }
+    if (profile.telehealth.status === 'CLINIC_SUPPORTED') {
+        return `Clinic Supported - ${affordability}`;
+    }
+    if (profile.telehealth.status === 'NOT_READY') {
+        return `Needs Intervention - ${affordability}`;
+    }
+    return `${telehealth} - ${affordability}`;
+}
+
+function equityTone(profile: ResearchProfile): Tone {
+    if (profile.telehealth.status === 'TELEHEALTH_READY' && profile.affordability.status === 'affordable') {
+        return 'good';
+    }
+    if (profile.telehealth.status === 'NOT_READY' || profile.affordability.status === 'unaffordable') {
+        return 'bad';
+    }
+    return 'warn';
+}
+
+function valueIndex(profile: ResearchProfile): string {
+    const cost = profile.affordability.monthly_cost;
+    const speed = profile.connectivity.ookla_download_mbps;
+    if (cost === null || speed === null || !Number.isFinite(cost) || !Number.isFinite(speed) || speed <= 0) {
+        return DATA_UNAVAILABLE;
+    }
+    return `$${(cost / speed).toFixed(2)}/Mbps`;
+}
+
+function telehealthNeed(profile: ResearchProfile): string {
+    const score = profile.healthcare.desert_score;
+    if (score === null || !Number.isFinite(score)) {
+        return DATA_UNAVAILABLE;
+    }
+    if (score <= 30) return `Low Need (${score.toFixed(1)})`;
+    if (score <= 60) return `Moderate Need (${score.toFixed(1)})`;
+    if (score <= 80) return `High Need (${score.toFixed(1)})`;
+    return `Critical Need (${score.toFixed(1)})`;
+}
+
+function telehealthNeedTone(profile: ResearchProfile): Tone {
+    const score = profile.healthcare.desert_score;
+    if (score === null || !Number.isFinite(score)) return 'neutral';
+    if (score <= 30) return 'good';
+    if (score <= 60) return 'warn';
+    return 'bad';
+}
+
+function generatedLine(profile: ResearchProfile): string {
+    const timestamp = new Date(profile.methodology.generated_at).toLocaleString();
+    return `Generated ${timestamp} UTC - Dataset Phase 3 - Season ${formatStatusText(profile.telehealth.season)}`;
+}
+
+function interpretation(profile: ResearchProfile): string {
+    const status = safeText(profile.telehealth.label);
+    const desert = formatResearchValue(profile.healthcare.desert_score, { digits: 1 });
+    const confidence = formatStatusText(profile.region.data_confidence);
+    const affordability = formatStatusText(profile.affordability.status);
+    return `${profile.region.name} is classified as ${status} for the selected season. The healthcare desert score is ${desert}, affordability is ${affordability}, and the evidence confidence is ${confidence}. Use this profile to decide whether telehealth can be delivered directly, needs clinic support, or requires follow-up data validation.`;
+}
+
+function keyFindings(profile: ResearchProfile): string[] {
+    const findings = [
+        `CAT tier: ${accessTier(profile)}.`,
+        `Telehealth status: ${safeText(profile.telehealth.label)}.`,
+        `Healthcare desert score: ${formatResearchValue(profile.healthcare.desert_score, { digits: 1 })}.`,
+        `Nearest facility: ${formatResearchValue(profile.healthcare.nearest_facility_name)}.`,
+        `Measured download speed: ${formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 })}.`,
+    ];
+
+    if (profile.region.has_data_gap) {
+        findings.push(`Data quality review needed for: ${safeJoin(profile.region.missing_fields)}.`);
+    } else {
+        findings.push('No data quality gaps are currently flagged.');
+    }
+
+    return findings;
+}
+
+function addPageBase(pdf: jsPDF) {
+    setFill(pdf, '#ffffff');
+    pdf.rect(0, 0, PAGE_WIDTH, PAGE_HEIGHT, 'F');
+}
+
+function addHeader(pdf: jsPDF, subtitle?: string) {
+    pdf.setFont('helvetica', 'bold');
+    pdf.setFontSize(21);
+    setText(pdf, INK);
+    pdf.text('TENeT Community Report', MARGIN, 18);
+
+    setDraw(pdf, INK);
+    pdf.setLineWidth(0.6);
+    pdf.line(MARGIN, 24, PAGE_WIDTH - MARGIN, 24);
+
+    if (subtitle) {
+        pdf.setFont('helvetica', 'normal');
+        pdf.setFontSize(8.5);
+        setText(pdf, MUTED);
+        pdf.text(pdf.splitTextToSize(subtitle, CONTENT_WIDTH), MARGIN, 32);
+    }
+}
+
+function addFooter(pdf: jsPDF, pageNumber: number) {
+    setDraw(pdf, LINE);
+    pdf.setLineWidth(0.2);
+    pdf.line(MARGIN, PAGE_HEIGHT - 15, PAGE_WIDTH - MARGIN, PAGE_HEIGHT - 15);
+
+    pdf.setFont('helvetica', 'normal');
+    pdf.setFontSize(7.5);
+    setText(pdf, MUTED);
+    pdf.text('TENeT community report. Planning support only; verify conditions with local providers and agencies.', MARGIN, PAGE_HEIGHT - 9);
+    pdf.text(`Page ${pageNumber} of 2`, PAGE_WIDTH - MARGIN, PAGE_HEIGHT - 9, { align: 'right' });
+    setText(pdf, INK);
+}
+
+function addSectionTitle(pdf: jsPDF, title: string, x: number, y: number): number {
+    pdf.setFont('helvetica', 'bold');
+    pdf.setFontSize(13);
+    setText(pdf, BRAND);
+    pdf.text(title, x, y);
+    return y + 5;
+}
+
+function addBadge(pdf: jsPDF, text: string, x: number, y: number, maxWidth: number, tone: Tone) {
+    const [bg, fg] = badgeColors(tone);
+    const label = safeText(text);
+    const badgeWidth = Math.min(maxWidth, Math.max(20, pdf.getTextWidth(label) + 7));
+
+    setFill(pdf, bg);
+    setDraw(pdf, bg);
+    pdf.roundedRect(x, y - 4.5, badgeWidth, 6.5, 3, 3, 'FD');
+    pdf.setFont('helvetica', 'bold');
+    pdf.setFontSize(8);
+    setText(pdf, fg);
+    pdf.text(pdf.splitTextToSize(label, badgeWidth - 5)[0], x + 3.5, y);
+    setText(pdf, INK);
+}
+
+function addReportTable(
+    pdf: jsPDF,
+    title: string,
+    rows: ReportRow[],
+    x: number,
+    y: number,
+    width: number,
+    compact = false,
+): number {
+    y = addSectionTitle(pdf, title, x, y);
+
+    const labelWidth = width * (compact ? 0.43 : 0.36);
+    const valueWidth = width - labelWidth;
+
+    rows.forEach((row, index) => {
+        const label = safeText(row.label);
+        const value = safeText(row.value);
+        const labelLines = pdf.splitTextToSize(label, labelWidth - 5);
+        const valueLines = pdf.splitTextToSize(value, valueWidth - 7);
+        const rowHeight = Math.max(compact ? 7.8 : 8.8, Math.max(labelLines.length, valueLines.length) * 4.2 + 4);
+
+        setFill(pdf, index % 2 === 0 ? ROW : '#ffffff');
+        setDraw(pdf, '#e7ebf0');
+        pdf.rect(x, y, width, rowHeight, 'FD');
+
+        setFill(pdf, LABEL_BG);
+        pdf.rect(x, y, labelWidth, rowHeight, 'F');
+
+        pdf.setFont('helvetica', 'bold');
+        pdf.setFontSize(compact ? 7.7 : 8.5);
+        setText(pdf, '#2f3542');
+        pdf.text(labelLines, x + 3, y + 5.4);
+
+        if (row.tone && value.length <= 32) {
+            addBadge(pdf, value, x + labelWidth + 3, y + 5.6, valueWidth - 6, row.tone);
+        } else {
+            pdf.setFont('helvetica', 'normal');
+            pdf.setFontSize(compact ? 7.7 : 8.5);
+            setText(pdf, INK);
+            pdf.text(valueLines, x + labelWidth + 3, y + 5.4);
+        }
+
+        y += rowHeight;
+    });
+
+    return y + 7;
+}
+
+function addFindings(pdf: jsPDF, profile: ResearchProfile, x: number, y: number, width: number): number {
+    y = addSectionTitle(pdf, 'Key Findings', x, y);
+    pdf.setFont('helvetica', 'normal');
+    pdf.setFontSize(8.3);
+    setText(pdf, INK);
+
+    keyFindings(profile).forEach(finding => {
+        const lines = pdf.splitTextToSize(`- ${finding}`, width - 4);
+        pdf.text(lines, x + 2, y);
+        y += lines.length * 4.3 + 1;
+    });
+
+    return y;
+}
+
+export async function exportResearchProfileReport(
+    profile: ResearchProfile,
+    _mapElement?: HTMLElement | null,
+) {
+    const pdf = new jsPDF({ unit: 'mm', format: 'a4', orientation: 'portrait' });
+    const missingFields = profile.region.has_data_gap
+        ? safeJoin(profile.region.missing_fields)
+        : 'No gap flagged';
+
+    addPageBase(pdf);
+    addHeader(pdf, generatedLine(profile));
+
+    pdf.setFont('helvetica', 'bold');
+    pdf.setFontSize(15);
+    setText(pdf, BRAND);
+    pdf.text(safeText(profile.region.name), MARGIN, 45);
+
+    let y = 55;
+    y = addReportTable(pdf, 'Community Overview', [
+        { label: 'Region', value: clean(profile.region.region) },
+        { label: 'Region Code', value: clean(profile.region.region_code) },
+        { label: 'Population', value: DATA_UNAVAILABLE },
+        { label: 'Coordinates', value: coordinateText(profile) },
+        { label: 'Access Tier (CAT)', value: accessTier(profile), tone: 'neutral' },
+        { label: 'Data Confidence', value: formatStatusText(profile.region.data_confidence), tone: confidenceTone(profile.region.data_confidence) },
+        { label: 'Data Completeness', value: dataCompleteness(profile), tone: profile.region.has_data_gap ? 'warn' : 'good' },
+        { label: 'Season', value: formatStatusText(profile.telehealth.season) },
+    ], MARGIN, y, CONTENT_WIDTH);
+
+    y = addReportTable(pdf, 'Digital Equity Analysis', [
+        { label: 'Equity Classification', value: equityClassification(profile), tone: equityTone(profile) },
+        { label: 'Telehealth Status', value: safeText(profile.telehealth.label), tone: telehealthTone(profile.telehealth.status) },
+        { label: 'Telehealth Need', value: telehealthNeed(profile), tone: telehealthNeedTone(profile) },
+        { label: 'Affordability Status', value: formatStatusText(profile.affordability.status), tone: affordabilityTone(profile.affordability.status) },
+        { label: 'Affordability Ratio', value: formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) },
+        { label: 'Value Index', value: valueIndex(profile) },
+        { label: 'Nearest Facility', value: formatResearchValue(profile.healthcare.nearest_facility_name) },
+        { label: 'Facility Distance', value: formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) },
+        { label: 'Community Anchor', value: formatResearchValue(profile.telehealth.clinic_supported, { booleanLabels: ['Yes', 'No'] }) },
+        { label: 'Facility Count', value: formatResearchValue(profile.healthcare.facility_count) },
+        { label: 'Classification Reason', value: interpretation(profile) },
+    ], MARGIN, y, CONTENT_WIDTH);
+
+    addFindings(pdf, profile, MARGIN, y, CONTENT_WIDTH);
+    addFooter(pdf, 1);
+
+    pdf.addPage();
+    addPageBase(pdf);
+    addHeader(pdf, `${safeText(profile.region.name)} - Evidence Detail`);
+
+    const leftX = MARGIN;
+    const rightX = MARGIN + CONTENT_WIDTH / 2 + 5;
+    const colWidth = CONTENT_WIDTH / 2 - 5;
+    let leftY = 45;
+    let rightY = 45;
+
+    leftY = addReportTable(pdf, 'Connectivity Metrics', [
+        { label: 'FCC 25 Mbps Coverage', value: formatResearchValue(profile.connectivity.fcc_coverage_25mbps_pct, { suffix: '%', digits: 1 }) },
+        { label: 'Ookla Download', value: formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 }) },
+        { label: 'Ookla Upload', value: formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 }) },
+        { label: 'Latency', value: formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 }) },
+        { label: 'Reliability', value: formatResearchValue(profile.connectivity.reliability_label) },
+        { label: 'ISP Name', value: formatResearchValue(profile.connectivity.isp_name) },
+        { label: 'Data Source', value: formatResearchValue(profile.connectivity.data_source) },
+    ], leftX, leftY, colWidth, true);
+
+    leftY = addReportTable(pdf, 'Affordability', [
+        { label: 'Monthly Cost', value: formatResearchValue(profile.affordability.monthly_cost, { prefix: '$', digits: 0 }) },
+        { label: 'Median Income', value: formatResearchValue(profile.affordability.median_income, { prefix: '$', digits: 0 }) },
+        { label: 'Income Burden', value: formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) },
+        { label: 'Threshold', value: formatResearchValue(profile.affordability.threshold_pct, { suffix: '%', digits: 1 }) },
+        { label: 'Status', value: formatStatusText(profile.affordability.status), tone: affordabilityTone(profile.affordability.status) },
+        { label: 'Value Index', value: valueIndex(profile) },
+    ], leftX, leftY, colWidth, true);
+
+    leftY = addReportTable(pdf, 'Data Quality and Missing Fields', [
+        { label: 'Data Confidence', value: formatStatusText(profile.region.data_confidence), tone: confidenceTone(profile.region.data_confidence) },
+        { label: 'Data Gap Flag', value: formatResearchValue(profile.region.has_data_gap, { booleanLabels: ['Yes', 'No'] }), tone: profile.region.has_data_gap ? 'warn' : 'good' },
+        { label: 'Missing Fields', value: missingFields },
+        { label: 'Confidence Notes', value: safeJoin(profile.methodology.confidence_notes) },
+    ], leftX, leftY, colWidth, true);
+
+    rightY = addReportTable(pdf, 'Healthcare Access', [
+        { label: 'Nearest Facility', value: formatResearchValue(profile.healthcare.nearest_facility_name) },
+        { label: 'Facility Type', value: formatResearchValue(profile.healthcare.nearest_facility_type) },
+        { label: 'Facility Distance', value: formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) },
+        { label: 'Emergency Services', value: formatResearchValue(profile.healthcare.emergency_services, { booleanLabels: ['Yes', 'No'] }) },
+        { label: 'Specialists', value: formatResearchValue(profile.healthcare.specialist_available, { booleanLabels: ['Yes', 'No'] }) },
+        { label: 'Facility Count', value: formatResearchValue(profile.healthcare.facility_count) },
+        { label: 'Desert Score', value: formatResearchValue(profile.healthcare.desert_score, { digits: 1 }) },
+    ], rightX, rightY, colWidth, true);
+
+    rightY = addReportTable(pdf, 'Telehealth Feasibility', [
+        { label: 'Status', value: safeText(profile.telehealth.label), tone: telehealthTone(profile.telehealth.status) },
+        { label: 'Telehealth Need', value: telehealthNeed(profile), tone: telehealthNeedTone(profile) },
+        { label: 'Video Feasible', value: formatResearchValue(profile.telehealth.video_feasible, { booleanLabels: ['Yes', 'No'] }) },
+        { label: 'Audio Feasible', value: formatResearchValue(profile.telehealth.audio_feasible, { booleanLabels: ['Yes', 'No'] }) },
+        { label: 'Clinic Supported', value: formatResearchValue(profile.telehealth.clinic_supported, { booleanLabels: ['Yes', 'No'] }) },
+        { label: 'Season', value: formatStatusText(profile.telehealth.season) },
+        { label: 'Season Note', value: formatResearchValue(profile.telehealth.season_note) },
+    ], rightX, rightY, colWidth, true);
+
+    addReportTable(pdf, 'Data Sources', [
+        { label: 'Sources', value: safeJoin(profile.methodology.sources) },
+        { label: 'Generated At', value: new Date(profile.methodology.generated_at).toLocaleString() },
+    ], rightX, rightY, colWidth, true);
+
+    addFooter(pdf, 2);
+    pdf.save(`tenet-community-report-${fileSafe(profile.region.name)}.pdf`);
+}


### PR DESCRIPTION
## Summary

This PR adds the frontend reporting workflow for selected communities. It introduces typed research profile fetching, safer value formatting, report export support, and sidebar actions for downloading reports and sharing community links.

## What Changed

- Added typed research profile models and API helpers.
- Added a research profile hook for selected-community data loading.
- Added consistent formatting helpers so missing values render as `Data unavailable`.
- Added client-side PDF report generation with a polished two-page A4 report layout.
- Added sidebar actions for downloading a community report and copying a share link.
- Improved the selected-community evidence panel so full details remain visible in the sidebar.

## Validation

- `npm run build`

## Note
The pdf template is temporary and can be changed as per maintainer's requirements

Current format - 
[tenet-community-report-fairbanks.pdf](https://github.com/user-attachments/files/28756268/tenet-community-report-fairbanks.pdf)

[tenet-community-report-anchorage.pdf](https://github.com/user-attachments/files/28756234/tenet-community-report-anchorage.pdf)
