### PR TITLE
Map comparison polish

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -258,6 +258,16 @@ function App() {
   }, [pinnedRegionCodes, regionSummaries, replacePinned, selectedRegionCode, summaryLoading]);
 
   useEffect(() => {
+    if (!urlNotice) return;
+
+    const timer = window.setTimeout(() => {
+      setUrlNotice(null);
+    }, 5000);
+
+    return () => window.clearTimeout(timer);
+  }, [urlNotice]);
+
+  useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const params = new URLSearchParams();
@@ -444,9 +454,30 @@ function App() {
           borderRadius: '8px',
           fontSize: '13px',
           fontWeight: '600',
-          border: '1px solid #f59e0b'
+          border: '1px solid #f59e0b',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px'
         }}>
-          {urlNotice}
+          <span>{urlNotice}</span>
+          <button
+            type="button"
+            aria-label="Dismiss notice"
+            onClick={() => setUrlNotice(null)}
+            style={{
+              appearance: 'none',
+              border: 0,
+              background: 'transparent',
+              color: '#92400e',
+              cursor: 'pointer',
+              fontSize: '16px',
+              fontWeight: 700,
+              lineHeight: 1,
+              padding: 0
+            }}
+          >
+            ×
+          </button>
         </div>
       )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { MapContainer, TileLayer, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, useMap, useMapEvents } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import { fetchRegions, CATRegion, RegionSummary, Season, AllTelehealthStatusResponse } from './api/catApi';
@@ -10,6 +10,8 @@ import DataCoveragePanel from './components/DataCoveragePanel';
 import PerformanceLayer from './components/PerformanceLayer';
 import AffordabilityLayer, { AffordabilityLegend } from './components/AffordabilityLayer';
 import Sidebar from './components/sidebar/Sidebar';
+import ResearchComparisonPanel from './components/ResearchComparisonPanel';
+import { usePinnedRegions } from './hooks/usePinnedRegions';
 import { useRegionSummary } from './hooks/useRegionSummary';
 
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -19,19 +21,118 @@ L.Icon.Default.mergeOptions({
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
 });
 
-// Alaska-specific coordinates
-const ALASKA_CENTER: [number, number] = [62.8, -146.0];
-const ALASKA_ZOOM = 5;
+// Alaska-specific coordinates. This framing keeps Alaska in focus and avoids
+// opening with too much far-west Russia in the visible map area.
+const ALASKA_CENTER: [number, number] = [62.2, -120.0];
+const ALASKA_ZOOM = 4;
+const STALE_DEFAULT_CENTERS: Array<[number, number]> = [
+  [62.9752, -154.95117],
+  [62.35, -146.75],
+  [62.2, -141.8],
+  [62.2, -170.8],
+  [62.35, -136.5],
+];
 
 const ALASKA_BOUNDS: [[number, number], [number, number]] = [
-  [51.0, -181.0],
-  [71.5, -129.0]
+  [51.0, -179.5],
+  [72.0, -95.0]
 ];
+
+type ActiveLayer = 'cat' | 'affordability' | 'gap';
+
+function parseInitialUrlState() {
+  if (typeof window === 'undefined') {
+    return {
+      region: null,
+      season: 'year_round' as Season,
+      layer: 'cat' as ActiveLayer,
+      pins: [] as string[],
+      center: ALASKA_CENTER,
+      zoom: ALASKA_ZOOM,
+    };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const seasonParam = params.get('season') as Season | null;
+  const layerParam = params.get('layer') as ActiveLayer | null;
+  const latParam = params.get('lat');
+  const lngParam = params.get('lng');
+  const zoomParam = params.get('zoom');
+  const lat = latParam === null ? NaN : Number(latParam);
+  const lng = lngParam === null ? NaN : Number(lngParam);
+  const zoom = zoomParam === null ? NaN : Number(zoomParam);
+  const hasSafeCenter = (
+    Number.isFinite(lat)
+    && Number.isFinite(lng)
+    && lat >= ALASKA_BOUNDS[0][0]
+    && lat <= ALASKA_BOUNDS[1][0]
+    && lng >= ALASKA_BOUNDS[0][1]
+    && lng <= ALASKA_BOUNDS[1][1]
+  );
+  const hasSafeZoom = Number.isFinite(zoom) && zoom >= 4 && zoom <= 18;
+  const hasStaleDefaultViewport = (
+    hasSafeCenter
+    && hasSafeZoom
+    && STALE_DEFAULT_CENTERS.some(([staleLat, staleLng]) => (
+      Math.abs(lat - staleLat) < 0.0001
+      && Math.abs(lng - staleLng) < 0.0001
+    ))
+    && zoom === ALASKA_ZOOM
+  );
+
+  return {
+    region: params.get('region'),
+    season: seasonParam && ['summer', 'winter', 'year_round'].includes(seasonParam)
+      ? seasonParam
+      : 'year_round',
+    layer: layerParam && ['cat', 'affordability', 'gap'].includes(layerParam)
+      ? layerParam
+      : 'cat',
+    pins: (params.get('pins') || '').split(',').map(pin => pin.trim()).filter(Boolean).slice(0, 3),
+    center: hasSafeCenter && !hasStaleDefaultViewport ? [lat, lng] as [number, number] : ALASKA_CENTER,
+    zoom: hasSafeZoom && !hasStaleDefaultViewport ? zoom : ALASKA_ZOOM,
+  };
+}
 
 interface SelectionControllerProps {
   selectedRegionCode: string | null;
   regionSummaries: RegionSummary[];
   markerRefs: React.MutableRefObject<Record<string, L.Marker | L.CircleMarker>>;
+}
+
+interface MapUrlControllerProps {
+  onViewportChange: (center: [number, number], zoom: number) => void;
+}
+
+interface ComparisonMapControllerProps {
+  active: boolean;
+}
+
+function MapUrlController({ onViewportChange }: MapUrlControllerProps) {
+  const map = useMapEvents({
+    moveend: () => {
+      const center = map.getCenter();
+      onViewportChange([Number(center.lat.toFixed(5)), Number(center.lng.toFixed(5))], map.getZoom());
+    },
+    zoomend: () => {
+      const center = map.getCenter();
+      onViewportChange([Number(center.lat.toFixed(5)), Number(center.lng.toFixed(5))], map.getZoom());
+    },
+  });
+
+  return null;
+}
+
+function ComparisonMapController({ active }: ComparisonMapControllerProps) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!active) return;
+    map.closePopup();
+    map.panBy([0, 96], { animate: true, duration: 0.25 });
+  }, [active, map]);
+
+  return null;
 }
 
 function SelectionController({
@@ -58,17 +159,29 @@ function SelectionController({
 }
 
 function App() {
+  const initialUrlState = useMemo(() => parseInitialUrlState(), []);
   const [regions, setRegions] = useState<CATRegion[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [season, setSeason] = useState<Season>('year_round');
-  const [performanceLayerVisible, setPerformanceLayerVisible] = useState(false);
-  const [affordabilityLayerVisible, setAffordabilityLayerVisible] = useState(false);
-  const [gapModeActive, setGapModeActive] = useState(false);
+  const [season, setSeason] = useState<Season>(initialUrlState.season);
+  const [performanceLayerVisible, setPerformanceLayerVisible] = useState(initialUrlState.layer === 'gap');
+  const [affordabilityLayerVisible, setAffordabilityLayerVisible] = useState(initialUrlState.layer === 'affordability');
+  const [gapModeActive, setGapModeActive] = useState(initialUrlState.layer === 'gap');
   const [affordabilitySummary, setAffordabilitySummary] = useState<AllTelehealthStatusResponse['summary'] | undefined>(undefined);
-  const [selectedRegionCode, setSelectedRegionCode] = useState<string | null>(null);
+  const [selectedRegionCode, setSelectedRegionCode] = useState<string | null>(initialUrlState.region);
+  const [detailsFocusKey, setDetailsFocusKey] = useState(0);
   const [visibleRegionCodes, setVisibleRegionCodes] = useState<string[] | null>(null);
+  const [mapCenter, setMapCenter] = useState<[number, number]>(initialUrlState.center);
+  const [mapZoom, setMapZoom] = useState(initialUrlState.zoom);
+  const [urlNotice, setUrlNotice] = useState<string | null>(null);
   const markerRefs = useRef<Record<string, L.Marker | L.CircleMarker>>({});
+  const {
+    pinnedRegionCodes,
+    isPinned,
+    togglePinned,
+    replacePinned,
+    maxPinnedRegions,
+  } = usePinnedRegions(initialUrlState.pins);
   const {
     regions: regionSummaries,
     loading: summaryLoading,
@@ -95,8 +208,19 @@ function App() {
     setSelectedRegionCode(regionCode);
   }, []);
 
+  const handleViewRegionDetails = useCallback((regionCode: string) => {
+    setSelectedRegionCode(regionCode);
+    setDetailsFocusKey(key => key + 1);
+    markerRefs.current[regionCode]?.closePopup();
+  }, []);
+
   const handleVisibleRegionsChange = useCallback((regionCodes: string[]) => {
     setVisibleRegionCodes(regionCodes);
+  }, []);
+
+  const handleViewportChange = useCallback((center: [number, number], zoom: number) => {
+    setMapCenter(center);
+    setMapZoom(zoom);
   }, []);
 
   const visibleRegionCodeSet = useMemo(
@@ -113,6 +237,41 @@ function App() {
     : affordabilityLayerVisible
       ? 'affordability'
       : 'cat';
+
+  useEffect(() => {
+    if (summaryLoading || regionSummaries.length === 0) return;
+
+    if (
+      selectedRegionCode
+      && !regionSummaries.some(region => region.region_code === selectedRegionCode)
+    ) {
+      setUrlNotice(`Community not found: ${selectedRegionCode}`);
+      setSelectedRegionCode(null);
+    }
+
+    const validPinned = pinnedRegionCodes.filter(code => (
+      regionSummaries.some(region => region.region_code === code)
+    ));
+    if (validPinned.length !== pinnedRegionCodes.length) {
+      replacePinned(validPinned);
+    }
+  }, [pinnedRegionCodes, regionSummaries, replacePinned, selectedRegionCode, summaryLoading]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams();
+    if (selectedRegionCode) params.set('region', selectedRegionCode);
+    if (activeSidebarLayer !== 'cat') params.set('layer', activeSidebarLayer);
+    if (season !== 'year_round') params.set('season', season);
+    if (pinnedRegionCodes.length) params.set('pins', pinnedRegionCodes.join(','));
+    if (mapCenter[0] !== ALASKA_CENTER[0]) params.set('lat', mapCenter[0].toFixed(5));
+    if (mapCenter[1] !== ALASKA_CENTER[1]) params.set('lng', mapCenter[1].toFixed(5));
+    if (mapZoom !== ALASKA_ZOOM) params.set('zoom', String(mapZoom));
+
+    const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+    window.history.replaceState(null, '', nextUrl);
+  }, [activeSidebarLayer, mapCenter, mapZoom, pinnedRegionCodes, season, selectedRegionCode]);
 
   const toggleAffordabilityLayer = () => {
     if (!affordabilityLayerVisible) {
@@ -164,15 +323,21 @@ function App() {
         loading={summaryLoading}
         error={summaryError}
         selectedRegionCode={selectedRegionCode}
+        season={season}
         activeLayer={activeSidebarLayer}
+        pinnedRegionCodes={pinnedRegionCodes}
+        maxPinnedRegions={maxPinnedRegions}
         onSelectRegion={handleSelectRegion}
+        detailsFocusKey={detailsFocusKey}
+        onTogglePin={togglePinned}
+        isPinned={isPinned}
         onVisibleRegionsChange={handleVisibleRegionsChange}
       />
 
       <div style={{ position: 'relative', flex: 1, minWidth: 0, height: '100vh' }}>
         <MapContainer
-          center={ALASKA_CENTER}
-          zoom={ALASKA_ZOOM}
+          center={mapCenter}
+          zoom={mapZoom}
           maxBounds={ALASKA_BOUNDS}
           maxBoundsViscosity={1.0}
           minZoom={4}
@@ -190,13 +355,17 @@ function App() {
             markerRefs={markerRefs}
           />
 
+          <MapUrlController onViewportChange={handleViewportChange} />
+
+          <ComparisonMapController active={pinnedRegionCodes.length >= 2} />
+
           {!gapModeActive && !affordabilityLayerVisible && mapRegions.map(region => (
             <RegionMarker
               key={region.region_code}
               region={region}
-              season={season}
               selected={region.region_code === selectedRegionCode}
               onSelect={handleSelectRegion}
+              onViewDetails={handleViewRegionDetails}
               onMarkerReady={registerMarker}
             />
           ))}
@@ -211,10 +380,17 @@ function App() {
             visible={affordabilityLayerVisible}
             selectedRegionCode={selectedRegionCode}
             onSelect={handleSelectRegion}
+            onViewDetails={handleViewRegionDetails}
             onMarkerReady={registerAffordabilityMarker}
             onDataLoad={setAffordabilitySummary}
           />
         </MapContainer>
+
+      <ResearchComparisonPanel
+        pinnedRegionCodes={pinnedRegionCodes}
+        season={season}
+        onSelectRegion={handleSelectRegion}
+      />
 
       {loading && (
         <div style={{
@@ -252,6 +428,25 @@ function App() {
           fontWeight: '500'
         }}>
           {error}
+        </div>
+      )}
+
+      {urlNotice && (
+        <div style={{
+          position: 'absolute',
+          top: '128px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 1000,
+          background: 'rgba(255, 251, 235, 0.96)',
+          color: '#92400e',
+          padding: '10px 18px',
+          borderRadius: '8px',
+          fontSize: '13px',
+          fontWeight: '600',
+          border: '1px solid #f59e0b'
+        }}>
+          {urlNotice}
         </div>
       )}
 

--- a/frontend/src/api/researchApi.ts
+++ b/frontend/src/api/researchApi.ts
@@ -1,0 +1,37 @@
+import { Season } from './catApi';
+import { ResearchProfile, ResearchProfilesResponse } from '../types/research';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
+
+export async function fetchResearchProfile(
+    regionCode: string,
+    season: Season = 'year_round',
+): Promise<ResearchProfile> {
+    const params = new URLSearchParams({ season });
+    const response = await fetch(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/research-profile?${params.toString()}`,
+    );
+
+    if (!response.ok) {
+        throw new Error(response.status === 404 ? 'Community not found' : 'Failed to fetch research profile');
+    }
+
+    return response.json();
+}
+
+export async function fetchResearchProfiles(
+    regionCodes: string[],
+    season: Season = 'year_round',
+): Promise<ResearchProfilesResponse> {
+    const params = new URLSearchParams({
+        codes: regionCodes.slice(0, 3).join(','),
+        season,
+    });
+    const response = await fetch(`${API_BASE}/regions/research-profiles?${params.toString()}`);
+
+    if (!response.ok) {
+        throw new Error('Failed to fetch comparison profiles');
+    }
+
+    return response.json();
+}

--- a/frontend/src/components/AffordabilityLayer.tsx
+++ b/frontend/src/components/AffordabilityLayer.tsx
@@ -10,6 +10,7 @@ interface AffordabilityLayerProps {
     visible: boolean;
     selectedRegionCode?: string | null;
     onSelect?: (regionCode: string) => void;
+    onViewDetails?: (regionCode: string) => void;
     onMarkerReady?: (regionCode: string, marker: L.CircleMarker | null) => void;
     onDataLoad?: (summary: AllTelehealthStatusResponse['summary']) => void;
 }
@@ -27,6 +28,7 @@ export default function AffordabilityLayer({
     visible,
     selectedRegionCode,
     onSelect,
+    onViewDetails,
     onMarkerReady,
     onDataLoad
 }: AffordabilityLayerProps) {
@@ -114,111 +116,79 @@ export default function AffordabilityLayer({
                     <Popup
                         autoPan
                         keepInView
-                        maxWidth={380}
-                        minWidth={280}
+                        maxWidth={260}
+                        minWidth={220}
                         autoPanPaddingTopLeft={[64, 120]}
-                        autoPanPaddingBottomRight={[64, 80]}
+                        autoPanPaddingBottomRight={[64, 210]}
                     >
                         <div style={{
-                            minWidth: '260px',
-                            maxWidth: '350px',
-                            maxHeight: 'min(64vh, 560px)',
-                            overflowY: 'auto',
-                            paddingRight: '4px'
+                            minWidth: '210px',
+                            maxWidth: '236px',
+                            color: '#172033',
+                            fontSize: '12px'
                         }}>
-                            <h4 style={{ margin: '0 0 8px 0', color: '#1e40af', fontSize: '16px' }}>
+                            <h4 style={{
+                                margin: '0 0 2px 0',
+                                color: '#111827',
+                                fontSize: '15px',
+                                lineHeight: 1.2
+                            }}>
                                 {region.region_name}
                             </h4>
+                            <div style={{
+                                marginBottom: '9px',
+                                color: '#64748b',
+                                fontSize: '11px',
+                                fontWeight: 700
+                            }}>
+                                {region.region_code}
+                            </div>
 
                             <div style={{
-                                display: 'inline-block',
-                                padding: '4px 12px',
-                                borderRadius: '12px',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                minHeight: '22px',
+                                padding: '3px 8px',
+                                borderRadius: '999px',
                                 backgroundColor: region.color,
                                 color: 'white',
-                                fontSize: '12px',
-                                fontWeight: '600',
-                                marginBottom: '12px'
+                                fontSize: '11px',
+                                fontWeight: 800,
+                                marginBottom: '10px'
                             }}>
                                 {region.status.replace(/_/g, ' ')}
                             </div>
 
-                            {/* Affordability Section */}
-                            <div style={{
-                                backgroundColor: '#f8fafc',
-                                border: '1px solid #e2e8f0',
-                                borderRadius: '6px',
-                                padding: '10px',
-                                marginBottom: '10px',
-                                fontSize: '12px'
-                            }}>
-                                <div style={{ fontWeight: '600', color: '#475569', marginBottom: '6px' }}>
-                                    Affordability
-                                </div>
-                                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px', color: '#374151' }}>
-                                    <span>Internet:</span>
-                                    <strong>${region.internet_cost}/mo ({region.isp_name || 'N/A'})</strong>
-
-                                    {region.median_income && (
-                                        <>
-                                            <span>Median Income:</span>
-                                            <strong>${(region.median_income).toLocaleString()}/yr</strong>
-                                        </>
-                                    )}
-
-                                    <span>Burden:</span>
-                                    <strong style={{ color: region.burden_pct && region.burden_pct < 2 ? '#16a34a' : '#dc2626' }}>
-                                        {region.burden_pct ? `${region.burden_pct}%` : 'N/A'}
-                                        {region.burden_pct && (region.burden_pct < 2 ? ' ✓' : ' (>2%)')}
-                                    </strong>
-                                </div>
-                            </div>
-
-                            {/* Healthcare Section */}
-                            <div style={{
-                                backgroundColor: '#f8fafc',
-                                border: '1px solid #e2e8f0',
-                                borderRadius: '6px',
-                                padding: '10px',
-                                marginBottom: '10px',
-                                fontSize: '12px'
-                            }}>
-                                <div style={{ fontWeight: '600', color: '#475569', marginBottom: '6px' }}>
-                                    Healthcare Safety Net
-                                </div>
-                                <div style={{ color: '#374151' }}>
-                                    {region.nearest_clinic_name ? (
-                                        <div>
-                                            <strong>Nearest:</strong> {region.nearest_clinic_name.substring(0, 30)}
-                                            {region.nearest_clinic_name.length > 30 ? '...' : ''}
-                                            ({region.nearest_clinic_km}km)
-                                        </div>
-                                    ) : (
-                                        <div style={{ color: '#dc2626' }}>No clinic data available</div>
-                                    )}
-                                    <div style={{ marginTop: '4px' }}>
-                                        <strong>Access:</strong> {region.access_mode || 'Unknown'}
-                                    </div>
-                                </div>
-                            </div>
-
-                            {/* Recommendation */}
-                            <div style={{
-                                backgroundColor: region.status === 'CRITICAL_GAP' ? '#fef2f2' :
-                                    region.status === 'TELEHEALTH_READY' ? '#f0fdf4' : '#fffbeb',
-                                border: `1px solid ${region.status === 'CRITICAL_GAP' ? '#fecaca' :
-                                    region.status === 'TELEHEALTH_READY' ? '#86efac' : '#fde68a'}`,
-                                borderRadius: '6px',
-                                padding: '10px',
-                                fontSize: '11px'
-                            }}>
-                                <div style={{ fontWeight: '600', color: '#475569', marginBottom: '4px' }}>
-                                    Recommendation
-                                </div>
-                                <div style={{ color: '#374151' }}>
-                                    {region.recommendation || 'No recommendation available'}
-                                </div>
-                            </div>
+                            <button
+                                type="button"
+                                onMouseDown={event => {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                }}
+                                onClick={event => {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    if (onViewDetails) {
+                                        onViewDetails(region.region_code);
+                                    } else {
+                                        onSelect?.(region.region_code);
+                                        markerRefs.current[region.region_code]?.closePopup();
+                                    }
+                                }}
+                                style={{
+                                    width: '100%',
+                                    border: '1px solid #c7d0da',
+                                    borderRadius: '6px',
+                                    background: '#ffffff',
+                                    color: '#334155',
+                                    padding: '6px 8px',
+                                    fontSize: '11px',
+                                    fontWeight: 800,
+                                    cursor: 'pointer'
+                                }}
+                            >
+                                View details
+                            </button>
                         </div>
                     </Popup>
                 </CircleMarker>

--- a/frontend/src/components/RegionMarker.tsx
+++ b/frontend/src/components/RegionMarker.tsx
@@ -1,45 +1,21 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import {
     CATRegion,
-    getTierColor,
-    getTierLabel,
     getNeedColor,
     getNeedLabel,
-    Season,
-    TelehealthPriorityResponse,
-    fetchTelehealthPriority,
-    getPriorityColor,
-    BroadbandCoverage,
-    getConfidenceColor,
-    getDataGapInfo,
-    HealthcareByRegion,
-    fetchHealthcareByRegion,
-    getFacilityTypeInfo,
-    RegionAffordability,
-    SafetyNetClassification,
-    fetchRegionAffordability,
-    fetchRegionSafetyNet,
-    TelehealthStatus,
-    fetchTelehealthStatus,
-    getTelehealthStatusColor
+    getTierColor,
 } from '../api/catApi';
 
 interface RegionMarkerProps {
     region: CATRegion;
-    season: Season;
     selected?: boolean;
     onSelect?: (regionCode: string) => void;
+    onViewDetails?: (regionCode: string) => void;
     onMarkerReady?: (regionCode: string, marker: L.Marker | null) => void;
 }
 
-// API base for fetching broadband data
-const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
-
-/**
- * Create a custom circle marker icon with dynamic color - "Gemstone" style
- */
 function createMarkerIcon(color: string, selected = false): L.DivIcon {
     const size = selected ? 16 : 10;
     const anchor = size / 2;
@@ -62,549 +38,125 @@ function createMarkerIcon(color: string, selected = false): L.DivIcon {
     });
 }
 
-/**
- * Marker component for a CAT region with color-coded tier display
- * and season-adjusted telehealth priority on popup open
- */
+function badgeStyle(backgroundColor: string) {
+    return {
+        display: 'inline-flex',
+        alignItems: 'center',
+        minHeight: 22,
+        padding: '3px 8px',
+        borderRadius: 999,
+        backgroundColor,
+        color: '#ffffff',
+        fontSize: 11,
+        fontWeight: 800,
+        lineHeight: 1.2,
+        whiteSpace: 'nowrap' as const,
+    };
+}
+
 export default function RegionMarker({
     region,
-    season,
     selected = false,
     onSelect,
+    onViewDetails,
     onMarkerReady,
 }: RegionMarkerProps) {
     const markerRef = useRef<L.Marker | null>(null);
-    const [priority, setPriority] = useState<TelehealthPriorityResponse | null>(null);
-    const [broadband, setBroadband] = useState<BroadbandCoverage | null>(null);
-    const [healthcare, setHealthcare] = useState<HealthcareByRegion | null>(null);
-    const [affordability, setAffordability] = useState<RegionAffordability | null>(null);
-    const [safetyNet, setSafetyNet] = useState<SafetyNetClassification | null>(null);
-    const [telehealthStatus, setTelehealthStatus] = useState<TelehealthStatus | null>(null);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-
-    // Fetch priority, broadband, and healthcare data when popup opens
-    const handlePopupOpen = useCallback(async () => {
-        setLoading(true);
-        setError(null);
-        try {
-            // Fetch telehealth priority
-            const priorityData = await fetchTelehealthPriority(region.region_code, season);
-            setPriority(priorityData);
-
-            // Try to fetch broadband data by matching region name
-            try {
-                const response = await fetch(`${API_BASE}/broadband`);
-                if (response.ok) {
-                    const data = await response.json();
-                    // Find matching place by name (case-insensitive partial match)
-                    const regionName = region.region_name.toLowerCase();
-                    const match = data.broadband?.find((b: BroadbandCoverage) =>
-                        b.place_name.toLowerCase().includes(regionName) ||
-                        regionName.includes(b.place_name.toLowerCase()) ||
-                        b.region_code === region.region_code
-                    );
-                    if (match) {
-                        setBroadband(match);
-                    }
-                }
-            } catch (bbErr) {
-                console.warn('Could not fetch broadband data:', bbErr);
-            }
-
-            // Fetch healthcare facilities near this region
-            try {
-                const healthcareData = await fetchHealthcareByRegion(region.region_code, 5);
-                setHealthcare(healthcareData);
-            } catch (hcErr) {
-                console.warn('Could not fetch healthcare data:', hcErr);
-            }
-
-            // Fetch affordability analysis
-            try {
-                const affordData = await fetchRegionAffordability(region.region_code);
-                setAffordability(affordData);
-            } catch (affErr) {
-                console.warn('Could not fetch affordability data:', affErr);
-            }
-
-            // Fetch safety net classification
-            try {
-                const safetyData = await fetchRegionSafetyNet(region.region_code);
-                setSafetyNet(safetyData);
-            } catch (snErr) {
-                console.warn('Could not fetch safety net data:', snErr);
-            }
-
-            // Fetch composite telehealth status (for marker color)
-            try {
-                const statusData = await fetchTelehealthStatus(region.region_code);
-                setTelehealthStatus(statusData);
-            } catch (tsErr) {
-                console.warn('Could not fetch telehealth status:', tsErr);
-            }
-        } catch (err) {
-            setError(err instanceof Error ? err.message : 'Failed to fetch priority');
-            console.error('Error fetching priority:', err);
-        } finally {
-            setLoading(false);
-        }
-    }, [region.region_code, region.region_name, season]);
 
     const markerRefCallback = useCallback((marker: L.Marker | null) => {
         markerRef.current = marker;
         onMarkerReady?.(region.region_code, marker);
     }, [onMarkerReady, region.region_code]);
 
-    // Skip regions without coordinates
     if (region.centroid_lat === null || region.centroid_lon === null) {
         return null;
     }
 
-    // Use need score to color marker
-    const markerColor = getNeedColor(region.necessity_score);
-    const icon = createMarkerIcon(markerColor, selected);
     const needColor = getNeedColor(region.necessity_score);
     const needLabel = getNeedLabel(region.necessity_score);
+    const tierColor = getTierColor(region.tier_level);
 
     return (
         <Marker
             ref={markerRefCallback}
             position={[region.centroid_lat, region.centroid_lon]}
-            icon={icon}
+            icon={createMarkerIcon(needColor, selected)}
             eventHandlers={{
                 click: () => onSelect?.(region.region_code),
-                popupopen: handlePopupOpen,
             }}
         >
             <Popup
                 autoPan
                 keepInView
-                maxWidth={420}
-                minWidth={320}
+                maxWidth={260}
+                minWidth={220}
                 autoPanPaddingTopLeft={[64, 120]}
-                autoPanPaddingBottomRight={[64, 80]}
+                autoPanPaddingBottomRight={[64, 210]}
             >
                 <div style={{
-                    minWidth: '300px',
-                    maxWidth: '390px',
-                    maxHeight: 'min(68vh, 620px)',
-                    overflowY: 'auto',
-                    paddingRight: '4px'
+                    minWidth: 210,
+                    maxWidth: 236,
+                    color: '#172033',
+                    fontSize: 12,
                 }}>
                     <h3 style={{
-                        margin: '0 0 8px 0',
-                        color: '#1e40af',
-                        fontSize: '16px',
-                        fontWeight: 'bold'
+                        margin: '0 0 2px',
+                        color: '#111827',
+                        fontSize: 15,
+                        lineHeight: 1.2,
+                        fontWeight: 800,
                     }}>
                         {region.region_name}
                     </h3>
+                    <div style={{
+                        marginBottom: 9,
+                        color: '#64748b',
+                        fontSize: 11,
+                        fontWeight: 700,
+                    }}>
+                        {region.region_code}
+                    </div>
 
                     <div style={{
-                        display: 'inline-block',
-                        padding: '2px 8px',
-                        borderRadius: '12px',
-                        backgroundColor: needColor,
-                        color: 'white',
-                        fontSize: '12px',
-                        fontWeight: '600',
-                        marginBottom: '8px'
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 6,
+                        marginBottom: 10,
                     }}>
-                        Telehealth Need Score: {region.necessity_score}
+                        <span style={badgeStyle(tierColor)}>CAT {region.tier_level}</span>
+                        <span style={badgeStyle(needColor)}>{needLabel}</span>
                     </div>
 
-                    <div style={{ fontSize: '13px', color: '#374151' }}>
-                        <strong>Telehealth Priority:</strong> {needLabel}
-                    </div>
-
-                    {/* AFFORDABILITY & SAFETY NET BADGES */}
-                    {!loading && (affordability || safetyNet) && (
-                        <div style={{
-                            display: 'flex',
-                            gap: '6px',
-                            flexWrap: 'wrap',
-                            marginTop: '8px'
-                        }}>
-                            {/* Affordability Badge */}
-                            {affordability && (
-                                <div style={{
-                                    display: 'inline-block',
-                                    padding: '2px 8px',
-                                    borderRadius: '12px',
-                                    backgroundColor: affordability.has_income_data
-                                        ? (affordability.is_affordable ? '#22c55e' : '#ef4444')
-                                        : '#6b7280',
-                                    color: 'white',
-                                    fontSize: '10px',
-                                    fontWeight: '600'
-                                }}>
-                                    {affordability.has_income_data
-                                        ? (affordability.is_affordable
-                                            ? `✓ Affordable (${affordability.burden_pct}%)`
-                                            : `✗ Unaffordable (${affordability.burden_pct}%)`)
-                                        : '? Income Data N/A'}
-                                </div>
-                            )}
-
-                            {/* Safety Net Badge */}
-                            {safetyNet && (
-                                <div style={{
-                                    display: 'inline-block',
-                                    padding: '2px 8px',
-                                    borderRadius: '12px',
-                                    backgroundColor: safetyNet.classification_color,
-                                    color: 'white',
-                                    fontSize: '10px',
-                                    fontWeight: '600'
-                                }}>
-                                    {safetyNet.classification === 'COMMUNITY_SUPPORTED'
-                                        ? `Clinic ${safetyNet.nearest_clinic?.distance_km}km`
-                                        : 'No Nearby Clinic'}
-                                </div>
-                            )}
-                        </div>
-                    )}
-
-                    {/* Affordability Details (when data available) */}
-                    {!loading && affordability?.has_income_data && (
-                        <div style={{
-                            marginTop: '8px',
-                            padding: '8px',
-                            backgroundColor: affordability.is_affordable ? '#f0fdf4' : '#fef2f2',
-                            border: `1px solid ${affordability.is_affordable ? '#86efac' : '#fecaca'}`,
-                            borderRadius: '6px',
-                            fontSize: '11px'
-                        }}>
-                            <div style={{ fontWeight: '600', color: '#374151', marginBottom: '4px' }}>
-                                Affordability Gap Analysis
-                            </div>
-                            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px' }}>
-                                <span>Median Income:</span>
-                                <strong>${(affordability.median_income ?? 0).toLocaleString()}/yr</strong>
-                                <span>Internet Cost:</span>
-                                <strong>${affordability.internet_cost}/mo ({affordability.isp})</strong>
-                                <span>Burden:</span>
-                                <strong style={{ color: affordability.is_affordable ? '#166534' : '#dc2626' }}>
-                                    {affordability.burden_pct}% of income
-                                </strong>
-                            </div>
-                            <div style={{ marginTop: '4px', fontSize: '10px', color: '#6b7280' }}>
-                                Source: ZCTA {affordability.zcta} ({affordability.distance_km}km away)
-                            </div>
-                        </div>
-                    )}
-
-                    {/* Season-Adjusted Priority Section */}
-                    <div style={{
-                        marginTop: '12px',
-                        paddingTop: '10px',
-                        borderTop: '1px solid #e5e7eb'
-                    }}>
-                        <div style={{
-                            fontSize: '12px',
-                            fontWeight: '600',
-                            color: '#6b7280',
-                            marginBottom: '6px',
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '4px'
-                        }}>
-                            📊 Telehealth Priority
-                            {priority?.season_scenario && (
-                                <span style={{
-                                    fontSize: '10px',
-                                    fontWeight: 'normal',
-                                    color: '#9ca3af'
-                                }}>
-                                    ({priority.season_scenario.season_display})
-                                </span>
-                            )}
-                        </div>
-
-                        {loading && (
-                            <div style={{
-                                fontSize: '12px',
-                                color: '#6b7280',
-                                fontStyle: 'italic'
-                            }}>
-                                Loading...
-                            </div>
-                        )}
-
-                        {error && (
-                            <div style={{
-                                fontSize: '12px',
-                                color: '#dc2626'
-                            }}>
-                                {error}
-                            </div>
-                        )}
-
-                        {priority && !loading && (
-                            <>
-                                {/* Priority Badge */}
-                                <div style={{
-                                    display: 'inline-block',
-                                    padding: '4px 10px',
-                                    borderRadius: '4px',
-                                    backgroundColor: getPriorityColor(priority.priority),
-                                    color: 'white',
-                                    fontSize: '12px',
-                                    fontWeight: '600',
-                                    marginBottom: '8px'
-                                }}>
-                                    {priority.label}
-                                </div>
-
-                                {/* Scores */}
-                                <div style={{
-                                    fontSize: '12px',
-                                    color: '#374151',
-                                    display: 'grid',
-                                    gridTemplateColumns: '1fr',
-                                    gap: '4px',
-                                    marginBottom: '8px'
-                                }}>
-                                    <div>
-                                        <strong>Telehealth Need Score:</strong> {priority.necessity_score}
-                                    </div>
-                                </div>
-
-                                {/* Recommendation */}
-                                <div style={{
-                                    fontSize: '11px',
-                                    color: '#6b7280',
-                                    backgroundColor: '#f3f4f6',
-                                    padding: '6px 8px',
-                                    borderRadius: '4px',
-                                    lineHeight: '1.4'
-                                }}>
-                                    {priority.recommendation}
-                                </div>
-
-                                {/* Season Note */}
-                                <div style={{
-                                    fontSize: '10px',
-                                    color: '#9ca3af',
-                                    marginTop: '6px',
-                                    fontStyle: 'italic'
-                                }}>
-                                    {priority.season_scenario?.season_display} scenario applied
-                                </div>
-                            </>
-                        )}
-                    </div>
-
-                    {/* Broadband Data Gaps Section */}
-                    {broadband && (
-                        <div style={{
-                            marginTop: '12px',
-                            paddingTop: '10px',
-                            borderTop: '1px solid #e5e7eb'
-                        }}>
-                            <div style={{
-                                fontSize: '12px',
-                                fontWeight: '600',
-                                color: '#6b7280',
-                                marginBottom: '6px',
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '4px'
-                            }}>
-                                Broadband Data
-                                <span style={{
-                                    fontSize: '10px',
-                                    padding: '1px 6px',
-                                    borderRadius: '4px',
-                                    backgroundColor: getConfidenceColor(broadband.confidence),
-                                    color: 'white',
-                                    fontWeight: '500'
-                                }}>
-                                    {broadband.confidence}
-                                </span>
-                            </div>
-
-                            {/* Coverage Stats */}
-                            <div style={{
-                                fontSize: '11px',
-                                color: '#374151',
-                                marginBottom: '6px'
-                            }}>
-                                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '2px' }}>
-                                    <span>Primary Access:</span>
-                                    <strong>{broadband.primary_access === 'SATELLITE' ? 'Satellite' : 'Wired'}</strong>
-                                </div>
-                                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '2px' }}>
-                                    <span>25 Mbps Coverage:</span>
-                                    <strong>{broadband.coverage.any_tech_25mbps_pct !== null
-                                        ? `${Math.round(broadband.coverage.any_tech_25mbps_pct * 100)}%`
-                                        : 'N/A'}</strong>
-                                </div>
-                                {broadband.residential_units && (
-                                    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                                        <span>Residential Units:</span>
-                                        <strong>{broadband.residential_units.toLocaleString()}</strong>
-                                    </div>
-                                )}
-                            </div>
-
-                            {/* Data Gaps */}
-                            {broadband.data_gaps && broadband.data_gaps.length > 0 && (
-                                <div style={{
-                                    backgroundColor: '#fef3c7',
-                                    border: '1px solid #f59e0b',
-                                    borderRadius: '4px',
-                                    padding: '6px 8px',
-                                    fontSize: '10px'
-                                }}>
-                                    <div style={{ fontWeight: '600', color: '#92400e', marginBottom: '4px' }}>
-                                        Data Quality Issues:
-                                    </div>
-                                    {broadband.data_gaps.map((gap, idx) => {
-                                        const info = getDataGapInfo(gap);
-                                        return (
-                                            <div key={idx} style={{ color: '#78350f', marginLeft: '8px' }}>
-                                                {info.icon} {info.label}
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            )}
-
-                            {/* No Gaps */}
-                            {(!broadband.data_gaps || broadband.data_gaps.length === 0) && (
-                                <div style={{
-                                    backgroundColor: '#dcfce7',
-                                    border: '1px solid #22c55e',
-                                    borderRadius: '4px',
-                                    padding: '6px 8px',
-                                    fontSize: '10px',
-                                    color: '#166534'
-                                }}>
-                                    ✓ Broadband data complete
-                                </div>
-                            )}
-                        </div>
-                    )}
-
-                    {/* DYNAMIC DATA AVAILABILITY SECTION */}
-                    <div style={{
-                        marginTop: '12px',
-                        paddingTop: '10px',
-                        borderTop: '1px solid #e5e7eb'
-                    }}>
-                        <div style={{
-                            fontSize: '12px',
-                            fontWeight: '600',
-                            color: '#374151',
-                            marginBottom: '6px'
-                        }}>
-                            Data Availability for {region.region_name}
-                        </div>
-                        <div style={{
-                            backgroundColor: '#f9fafb',
-                            border: '1px solid #e5e7eb',
-                            borderRadius: '4px',
-                            padding: '8px',
-                            fontSize: '10px'
-                        }}>
-                            {/* Broadband Data */}
-                            <div style={{ marginBottom: '6px' }}>
-                                <strong style={{ color: '#374151' }}>Broadband Coverage:</strong>
-                                {broadband ? (
-                                    <div style={{ marginLeft: '8px', color: '#166534' }}>
-                                        <div>✅ Speed coverage data (FCC)</div>
-                                        <div>✅ Technology type ({broadband.primary_access})</div>
-                                        <div>✅ Residential units ({broadband.residential_units?.toLocaleString() || 'N/A'})</div>
-                                        {broadband.coverage.wired_25mbps_pct !== null && broadband.coverage.wired_25mbps_pct > 0 && (
-                                            <div>✅ Wired coverage: {Math.round(broadband.coverage.wired_25mbps_pct * 100)}%</div>
-                                        )}
-                                        {(broadband.coverage.wired_25mbps_pct === null || broadband.coverage.wired_25mbps_pct === 0) && (
-                                            <div style={{ color: '#dc2626' }}>❌ No wired infrastructure data</div>
-                                        )}
-                                    </div>
-                                ) : (
-                                    <div style={{ marginLeft: '8px', color: '#dc2626' }}>
-                                        <div>❌ No FCC broadband data available</div>
-                                    </div>
-                                )}
-                            </div>
-
-                            {/* Network Quality */}
-                            <div style={{ marginBottom: '6px' }}>
-                                <strong style={{ color: '#374151' }}>Network Quality:</strong>
-                                <div style={{ marginLeft: '8px' }}>
-                                    {priority?.connectivity_details?.latency_ms ? (
-                                        <div style={{ color: '#166534' }}>✅ Latency: {priority.connectivity_details.latency_ms}ms</div>
-                                    ) : (
-                                        <div style={{ color: '#dc2626' }}>❌ Latency data missing <em>(need RIPE Atlas)</em></div>
-                                    )}
-                                    {priority?.connectivity_details?.bandwidth_mbps ? (
-                                        <div style={{ color: '#166534' }}>✅ Bandwidth: {priority.connectivity_details.bandwidth_mbps} Mbps</div>
-                                    ) : (
-                                        <div style={{ color: '#dc2626' }}>❌ Real bandwidth test missing <em>(need Ookla)</em></div>
-                                    )}
-                                    <div style={{ color: '#dc2626' }}>❌ Packet loss rate missing <em>(need monitoring)</em></div>
-                                </div>
-                            </div>
-
-                            {/* Healthcare Access - Now using real OSM data */}
-                            <div style={{ marginBottom: '6px' }}>
-                                <strong style={{ color: '#374151' }}>Healthcare Access:</strong>
-                                <div style={{ marginLeft: '8px' }}>
-                                    {healthcare?.nearest_clinic ? (
-                                        <div style={{ color: '#166534' }}>
-                                            Nearest clinic: {healthcare.nearest_clinic.name.substring(0, 25)}{healthcare.nearest_clinic.name.length > 25 ? '...' : ''} ({healthcare.nearest_clinic.distance_km} km)
-                                        </div>
-                                    ) : (
-                                        <div style={{ color: '#dc2626' }}>❌ No clinic data available</div>
-                                    )}
-                                    {healthcare?.nearest_hospital ? (
-                                        <div style={{ color: '#166534' }}>
-                                            ✅ Nearest hospital: {healthcare.nearest_hospital.name.substring(0, 25)}{healthcare.nearest_hospital.name.length > 25 ? '...' : ''} ({healthcare.nearest_hospital.distance_km} km)
-                                        </div>
-                                    ) : (
-                                        <div style={{ color: '#dc2626' }}>❌ No hospital data available</div>
-                                    )}
-                                    {healthcare?.facilities && healthcare.facilities.some(f => f.has_emergency) ? (
-                                        <div style={{ color: '#166534' }}>
-                                            ✅ Emergency services: Yes ({healthcare.facilities.filter(f => f.has_emergency).length} facilities)
-                                        </div>
-                                    ) : (
-                                        <div style={{ color: '#f97316' }}>⚠️ No emergency services found nearby</div>
-                                    )}
-                                </div>
-                            </div>
-
-                            {/* Demographics */}
-                            <div>
-                                <strong style={{ color: '#374151' }}>Demographics:</strong>
-                                <div style={{ marginLeft: '8px' }}>
-                                    {region.population ? (
-                                        <div style={{ color: '#166534' }}>✅ Population: {region.population.toLocaleString()}</div>
-                                    ) : (
-                                        <div style={{ color: '#dc2626' }}>❌ Population data missing <em>(need Census)</em></div>
-                                    )}
-                                    <div style={{ color: '#dc2626' }}>❌ Age distribution missing <em>(need Census ACS)</em></div>
-                                    <div style={{ color: '#dc2626' }}>❌ Health conditions missing <em>(need health records)</em></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-
-                    <div style={{
-                        fontSize: '11px',
-                        color: '#9ca3af',
-                        marginTop: '8px',
-                        borderTop: '1px solid #e5e7eb',
-                        paddingTop: '6px'
-                    }}>
-                        Code: {region.region_code}
-
-
-                    </div>
+                    <button
+                        type="button"
+                        onMouseDown={event => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                        }}
+                        onClick={event => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            if (onViewDetails) {
+                                onViewDetails(region.region_code);
+                            } else {
+                                onSelect?.(region.region_code);
+                                markerRef.current?.closePopup();
+                            }
+                        }}
+                        style={{
+                            width: '100%',
+                            border: '1px solid #c7d0da',
+                            borderRadius: 6,
+                            background: '#ffffff',
+                            color: '#334155',
+                            padding: '6px 8px',
+                            fontSize: 11,
+                            fontWeight: 800,
+                            cursor: 'pointer',
+                        }}
+                    >
+                        View details
+                    </button>
                 </div>
             </Popup>
         </Marker>

--- a/frontend/src/components/ResearchComparisonPanel.css
+++ b/frontend/src/components/ResearchComparisonPanel.css
@@ -1,0 +1,235 @@
+.research-comparison-panel {
+    position: absolute;
+    left: 24px;
+    right: 24px;
+    bottom: 16px;
+    z-index: 650;
+    max-height: min(34vh, 340px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid #c7d0da;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 14px 36px rgba(15, 23, 42, 0.18);
+    color: #172033;
+}
+
+.research-comparison-panel.collapsed {
+    left: auto;
+    width: min(420px, calc(100% - 48px));
+}
+
+.research-comparison-reopen {
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    z-index: 650;
+    border: 1px solid #c7d0da;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.16);
+    color: #334155;
+    padding: 10px 12px;
+    font-size: 12px;
+    font-weight: 800;
+    cursor: pointer;
+}
+
+.research-comparison-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 14px;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.research-comparison-header h2 {
+    margin: 0;
+    color: #111827;
+    font-size: 16px;
+    line-height: 1.2;
+}
+
+.research-comparison-header p {
+    margin: 3px 0 0;
+    color: #64748b;
+    font-size: 12px;
+}
+
+.research-comparison-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.research-comparison-actions button {
+    border: 1px solid #c7d0da;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #334155;
+    padding: 5px 8px;
+    font-size: 11px;
+    font-weight: 800;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.research-comparison-actions button:hover,
+.research-comparison-reopen:hover {
+    background: #f8fbff;
+    border-color: #93c5fd;
+}
+
+.research-comparison-body {
+    min-height: 0;
+    overflow: auto;
+}
+
+.comparison-muted,
+.comparison-error {
+    margin: 12px 14px;
+    border-radius: 6px;
+    padding: 9px 10px;
+    font-size: 12px;
+}
+
+.comparison-muted {
+    border: 1px solid #dbe3ea;
+    background: #f8fafc;
+    color: #64748b;
+}
+
+.comparison-error {
+    border: 1px solid #fecaca;
+    background: #fef2f2;
+    color: #b91c1c;
+}
+
+.comparison-table {
+    min-width: 560px;
+}
+
+.comparison-grid {
+    display: grid;
+    grid-template-columns: 116px repeat(3, minmax(132px, 1fr));
+    gap: 8px;
+    align-items: stretch;
+    padding: 9px 14px;
+    border-bottom: 1px solid #edf2f7;
+}
+
+.comparison-grid:last-child {
+    border-bottom: 0;
+}
+
+.comparison-grid-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: #f8fafc;
+    color: #536176;
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.comparison-grid-header button {
+    min-width: 0;
+    border: 0;
+    background: transparent;
+    color: #2563eb;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    text-transform: none;
+}
+
+.comparison-metric-label {
+    align-self: center;
+    color: #475569;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.comparison-cell {
+    min-width: 0;
+}
+
+.comparison-value-line {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+}
+
+.comparison-value-line strong {
+    min-width: 0;
+    color: #111827;
+    font-size: 12px;
+    overflow-wrap: anywhere;
+}
+
+.comparison-badge {
+    flex-shrink: 0;
+    border-radius: 999px;
+    padding: 2px 6px;
+    color: #ffffff;
+    font-size: 9px;
+    font-style: normal;
+    font-weight: 800;
+}
+
+.comparison-badge.best {
+    background: #0f766e;
+}
+
+.comparison-badge.worst {
+    background: #b91c1c;
+}
+
+.comparison-bar-track {
+    height: 6px;
+    margin-top: 5px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #e2e8f0;
+}
+
+.comparison-bar-track span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: #2563eb;
+}
+
+.comparison-cell small {
+    display: block;
+    margin-top: 4px;
+    color: #64748b;
+    font-size: 10px;
+    line-height: 1.3;
+}
+
+@media (max-width: 900px) {
+    .research-comparison-panel {
+        left: 10px;
+        right: 10px;
+        bottom: 10px;
+        width: auto;
+        max-height: 32vh;
+    }
+
+    .research-comparison-panel.collapsed {
+        left: 10px;
+        width: auto;
+    }
+
+    .research-comparison-reopen {
+        left: 10px;
+        right: 10px;
+        width: auto;
+    }
+}

--- a/frontend/src/components/ResearchComparisonPanel.tsx
+++ b/frontend/src/components/ResearchComparisonPanel.tsx
@@ -62,6 +62,7 @@ function badgeFor(value: number | null, values: Array<number | null>, higherIsBe
     if (numeric.length < 2) return null;
     const best = higherIsBetter ? Math.max(...numeric) : Math.min(...numeric);
     const worst = higherIsBetter ? Math.min(...numeric) : Math.max(...numeric);
+    if (best === worst) return null;
     if (value === best) return 'Best';
     if (value === worst) return 'Worst';
     return null;

--- a/frontend/src/components/ResearchComparisonPanel.tsx
+++ b/frontend/src/components/ResearchComparisonPanel.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Season } from '../api/catApi';
+import { useComparisonProfiles } from '../hooks/useComparisonProfiles';
+import { ResearchProfile } from '../types/research';
+import { DATA_UNAVAILABLE, formatResearchValue } from '../utils/formatResearchValue';
+import './ResearchComparisonPanel.css';
+
+interface ResearchComparisonPanelProps {
+    pinnedRegionCodes: string[];
+    season: Season;
+    onSelectRegion: (regionCode: string) => void;
+}
+
+interface MetricConfig {
+    key: string;
+    label: string;
+    higherIsBetter: boolean;
+    getValue: (profile: ResearchProfile) => number | null;
+    format: (value: number | null) => string;
+}
+
+const METRICS: MetricConfig[] = [
+    {
+        key: 'download',
+        label: 'Download',
+        higherIsBetter: true,
+        getValue: profile => profile.connectivity.ookla_download_mbps,
+        format: value => formatResearchValue(value, { suffix: ' Mbps', digits: 1 }),
+    },
+    {
+        key: 'burden',
+        label: 'Cost burden',
+        higherIsBetter: false,
+        getValue: profile => profile.affordability.burden_pct,
+        format: value => formatResearchValue(value, { suffix: '%', digits: 2 }),
+    },
+    {
+        key: 'desert',
+        label: 'Desert score',
+        higherIsBetter: false,
+        getValue: profile => profile.healthcare.desert_score,
+        format: value => formatResearchValue(value, { digits: 1 }),
+    },
+    {
+        key: 'facilities',
+        label: 'Facilities',
+        higherIsBetter: true,
+        getValue: profile => profile.healthcare.facility_count,
+        format: value => formatResearchValue(value, { digits: 0 }),
+    },
+];
+
+function metricAverage(values: Array<number | null>) {
+    const numeric = values.filter((value): value is number => value !== null);
+    if (!numeric.length) return null;
+    return numeric.reduce((sum, value) => sum + value, 0) / numeric.length;
+}
+
+function badgeFor(value: number | null, values: Array<number | null>, higherIsBetter: boolean) {
+    if (value === null) return null;
+    const numeric = values.filter((item): item is number => item !== null);
+    if (numeric.length < 2) return null;
+    const best = higherIsBetter ? Math.max(...numeric) : Math.min(...numeric);
+    const worst = higherIsBetter ? Math.min(...numeric) : Math.max(...numeric);
+    if (value === best) return 'Best';
+    if (value === worst) return 'Worst';
+    return null;
+}
+
+export default function ResearchComparisonPanel({
+    pinnedRegionCodes,
+    season,
+    onSelectRegion,
+}: ResearchComparisonPanelProps) {
+    const { profiles, missingCodes, loading, error } = useComparisonProfiles(pinnedRegionCodes, season);
+    const [collapsed, setCollapsed] = useState(false);
+    const [closed, setClosed] = useState(false);
+    const pinnedKey = useMemo(() => pinnedRegionCodes.join('|'), [pinnedRegionCodes]);
+
+    useEffect(() => {
+        setCollapsed(false);
+        setClosed(false);
+    }, [pinnedKey]);
+
+    if (pinnedRegionCodes.length < 2) {
+        return null;
+    }
+
+    if (closed) {
+        return (
+            <button
+                type="button"
+                className="research-comparison-reopen"
+                onClick={() => {
+                    setClosed(false);
+                    setCollapsed(false);
+                }}
+            >
+                Compare pinned communities
+            </button>
+        );
+    }
+
+    return (
+        <section
+            className={`research-comparison-panel ${collapsed ? 'collapsed' : ''}`}
+            aria-label="Pinned community comparison"
+            aria-expanded={!collapsed}
+        >
+            <div className="research-comparison-header">
+                <div>
+                    <h2>Community Comparison</h2>
+                    <p>{profiles.length} pinned communities</p>
+                </div>
+                <div className="research-comparison-actions">
+                    <button
+                        type="button"
+                        onClick={() => setCollapsed(value => !value)}
+                        aria-label={collapsed ? 'Expand comparison panel' : 'Collapse comparison panel'}
+                    >
+                        {collapsed ? 'Expand' : 'Collapse'}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setClosed(true)}
+                        aria-label="Close comparison panel"
+                    >
+                        Close
+                    </button>
+                </div>
+            </div>
+
+            {!collapsed && (
+                <div className="research-comparison-body">
+                    {loading && <div className="comparison-muted">Loading comparison...</div>}
+                    {error && <div className="comparison-error">{error}</div>}
+                    {!loading && missingCodes.length > 0 && (
+                        <div className="comparison-muted">Missing: {missingCodes.join(', ')}</div>
+                    )}
+
+                    {!loading && !error && profiles.length >= 2 && (
+                        <div className="comparison-table">
+                            <div
+                                className="comparison-grid comparison-grid-header"
+                                style={{ gridTemplateColumns: `116px repeat(${profiles.length}, minmax(132px, 1fr))` }}
+                            >
+                                <span>Metric</span>
+                                {profiles.map(profile => (
+                                    <button
+                                        type="button"
+                                        key={profile.region.region_code}
+                                        onClick={() => onSelectRegion(profile.region.region_code)}
+                                    >
+                                        {profile.region.name}
+                                    </button>
+                                ))}
+                            </div>
+
+                            {METRICS.map(metric => {
+                                const values = profiles.map(metric.getValue);
+                                const average = metricAverage(values);
+                                const max = Math.max(...values.filter((value): value is number => value !== null), 0);
+                                return (
+                                    <div
+                                        className="comparison-grid"
+                                        key={metric.key}
+                                        style={{ gridTemplateColumns: `116px repeat(${profiles.length}, minmax(132px, 1fr))` }}
+                                    >
+                                        <span className="comparison-metric-label">{metric.label}</span>
+                                        {profiles.map(profile => {
+                                            const value = metric.getValue(profile);
+                                            const badge = badgeFor(value, values, metric.higherIsBetter);
+                                            const delta = value !== null && average !== null ? value - average : null;
+                                            const barWidth = value !== null && max > 0 ? Math.max(6, (value / max) * 100) : 0;
+                                            return (
+                                                <div className="comparison-cell" key={profile.region.region_code}>
+                                                    <div className="comparison-value-line">
+                                                        <strong>{metric.format(value)}</strong>
+                                                        {badge && <em className={`comparison-badge ${badge.toLowerCase()}`}>{badge}</em>}
+                                                    </div>
+                                                    <div className="comparison-bar-track">
+                                                        <span style={{ width: `${barWidth}%` }} />
+                                                    </div>
+                                                    <small>
+                                                        {delta === null
+                                                            ? DATA_UNAVAILABLE
+                                                            : `${delta >= 0 ? '+' : ''}${metric.format(delta)} vs group avg`}
+                                                    </small>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { RegionSummary } from '../../api/catApi';
+import { Season } from '../../api/catApi';
 import { usePinnedRegions } from '../../hooks/usePinnedRegions';
 import FilterControls from './FilterControls';
 import RegionList from './RegionList';
@@ -19,8 +20,14 @@ interface SidebarProps {
     loading: boolean;
     error: string | null;
     selectedRegionCode: string | null;
+    detailsFocusKey?: number;
+    season?: Season;
     activeLayer?: 'cat' | 'affordability' | 'gap';
+    pinnedRegionCodes?: string[];
+    maxPinnedRegions?: number;
     onSelectRegion: (regionCode: string) => void;
+    onTogglePin?: (regionCode: string) => void;
+    isPinned?: (regionCode: string) => boolean;
     onVisibleRegionsChange?: (regionCodes: string[]) => void;
 }
 
@@ -39,8 +46,14 @@ export default function Sidebar({
     loading,
     error,
     selectedRegionCode,
+    detailsFocusKey = 0,
+    season = 'year_round',
     activeLayer = 'cat',
+    pinnedRegionCodes,
+    maxPinnedRegions,
     onSelectRegion,
+    onTogglePin,
+    isPinned,
     onVisibleRegionsChange,
 }: SidebarProps) {
     const [query, setQuery] = useState('');
@@ -48,12 +61,11 @@ export default function Sidebar({
     const [sortMode, setSortMode] = useState<RegionSortMode>('name');
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(360);
-    const {
-        pinnedRegionCodes,
-        isPinned,
-        togglePinned,
-        maxPinnedRegions,
-    } = usePinnedRegions();
+    const localPinned = usePinnedRegions();
+    const activePinnedRegionCodes = pinnedRegionCodes ?? localPinned.pinnedRegionCodes;
+    const activeMaxPinnedRegions = maxPinnedRegions ?? localPinned.maxPinnedRegions;
+    const activeTogglePin = onTogglePin ?? localPinned.togglePinned;
+    const activeIsPinned = isPinned ?? localPinned.isPinned;
     const showCatTools = activeLayer === 'cat';
 
     const selectedRegion = useMemo(
@@ -62,10 +74,10 @@ export default function Sidebar({
     );
 
     const pinnedRegions = useMemo(
-        () => pinnedRegionCodes
+        () => activePinnedRegionCodes
             .map(code => regions.find(region => region.region_code === code))
             .filter((region): region is RegionSummary => Boolean(region)),
-        [pinnedRegionCodes, regions],
+        [activePinnedRegionCodes, regions],
     );
 
     const visibleRegions = useMemo(() => {
@@ -173,29 +185,29 @@ export default function Sidebar({
             {showCatTools && pinnedRegions.length > 0 && (
                 <section className="pinned-section">
                     <div className="sidebar-section-title">
-                        Pinned {pinnedRegions.length}/{maxPinnedRegions}
+                        Pinned {pinnedRegions.length}/{activeMaxPinnedRegions}
                     </div>
                     <RegionList
                         regions={pinnedRegions}
                         selectedRegionCode={selectedRegionCode}
-                        pinnedRegionCodes={pinnedRegionCodes}
-                        maxPinnedRegions={maxPinnedRegions}
+                        pinnedRegionCodes={activePinnedRegionCodes}
+                        maxPinnedRegions={activeMaxPinnedRegions}
                         showCatDetails={showCatTools}
                         showPin={showCatTools}
                         onSelectRegion={onSelectRegion}
-                        onTogglePin={togglePinned}
+                        onTogglePin={activeTogglePin}
                     />
                 </section>
             )}
 
-            {showCatTools && (
-                <SelectedRegionPanel
-                    region={selectedRegion}
-                    pinned={selectedRegion ? isPinned(selectedRegion.region_code) : false}
-                    pinDisabled={pinnedRegionCodes.length >= maxPinnedRegions}
-                    onTogglePin={togglePinned}
-                />
-            )}
+            <SelectedRegionPanel
+                region={selectedRegion}
+                season={season}
+                focusKey={detailsFocusKey}
+                pinned={selectedRegion ? activeIsPinned(selectedRegion.region_code) : false}
+                pinDisabled={activePinnedRegionCodes.length >= activeMaxPinnedRegions}
+                onTogglePin={activeTogglePin}
+            />
 
             <section className="sidebar-results">
                 <div className="sidebar-section-title">Results</div>
@@ -205,12 +217,12 @@ export default function Sidebar({
                     <RegionList
                         regions={visibleRegions}
                         selectedRegionCode={selectedRegionCode}
-                        pinnedRegionCodes={pinnedRegionCodes}
-                        maxPinnedRegions={maxPinnedRegions}
+                        pinnedRegionCodes={activePinnedRegionCodes}
+                        maxPinnedRegions={activeMaxPinnedRegions}
                         showCatDetails={showCatTools}
                         showPin={showCatTools}
                         onSelectRegion={onSelectRegion}
-                        onTogglePin={togglePinned}
+                        onTogglePin={activeTogglePin}
                     />
                 )}
             </section>

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { Season } from '../../api/catApi';
-import { usePinnedRegions } from '../../hooks/usePinnedRegions';
 import FilterControls from './FilterControls';
 import RegionList from './RegionList';
 import SearchBar from './SearchBar';

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -61,11 +61,10 @@ export default function Sidebar({
     const [sortMode, setSortMode] = useState<RegionSortMode>('name');
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(360);
-    const localPinned = usePinnedRegions();
-    const activePinnedRegionCodes = pinnedRegionCodes ?? localPinned.pinnedRegionCodes;
-    const activeMaxPinnedRegions = maxPinnedRegions ?? localPinned.maxPinnedRegions;
-    const activeTogglePin = onTogglePin ?? localPinned.togglePinned;
-    const activeIsPinned = isPinned ?? localPinned.isPinned;
+    const activePinnedRegionCodes = pinnedRegionCodes ?? [];
+    const activeMaxPinnedRegions = maxPinnedRegions ?? 3;
+    const activeTogglePin = onTogglePin ?? (() => {});
+    const activeIsPinned = isPinned ?? (() => false);
     const showCatTools = activeLayer === 'cat';
 
     const selectedRegion = useMemo(

--- a/frontend/src/components/sidebar/sidebar.css
+++ b/frontend/src/components/sidebar/sidebar.css
@@ -6,13 +6,14 @@
     height: 100vh;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     padding: 16px;
     box-sizing: border-box;
     background: #f8fafc;
     border-right: 1px solid #dbe3ea;
     box-shadow: 6px 0 18px rgba(15, 23, 42, 0.08);
     color: #172033;
+    overflow: hidden;
 }
 
 .tenet-sidebar.collapsed {
@@ -223,16 +224,34 @@
 }
 
 .pinned-section {
-    max-height: 184px;
-    overflow: auto;
+    flex: 0 0 auto;
+    max-height: min(22vh, 170px);
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     padding-bottom: 2px;
 }
 
+.pinned-section .region-list {
+    flex: 1 1 auto;
+}
+
 .selected-region-panel {
+    flex: 0 1 auto;
+    max-height: min(34vh, 320px);
+    overflow: auto;
     border: 1px solid #c7d0da;
     border-radius: 8px;
     background: #ffffff;
     padding: 12px;
+    transition: border-color 0.18s, box-shadow 0.18s, background 0.18s;
+    scroll-margin-block: 12px;
+}
+
+.selected-region-panel.focused {
+    border-color: #2563eb;
+    background: #eff6ff;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
 }
 
 .selected-region-panel.muted {
@@ -260,6 +279,35 @@
     font-size: 11px;
 }
 
+.selected-region-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.selected-region-actions .sidebar-action-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.selected-region-note {
+    margin-bottom: 10px;
+    border: 1px solid #fde68a;
+    border-radius: 6px;
+    background: #fffbeb;
+    color: #92400e;
+    padding: 7px 8px;
+    font-size: 11px;
+    line-height: 1.35;
+}
+
+.selected-region-note.error {
+    border-color: #fecaca;
+    background: #fef2f2;
+    color: #b91c1c;
+}
+
 .selected-detail-grid {
     display: grid;
     grid-template-columns: minmax(92px, 1fr) minmax(0, 1.2fr);
@@ -277,8 +325,8 @@
 }
 
 .sidebar-results {
-    min-height: 0;
-    flex: 1;
+    min-height: 170px;
+    flex: 1 1 220px;
     display: flex;
     flex-direction: column;
 }

--- a/frontend/src/hooks/useComparisonProfiles.ts
+++ b/frontend/src/hooks/useComparisonProfiles.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { Season } from '../api/catApi';
+import { fetchResearchProfiles } from '../api/researchApi';
+import { ResearchProfile } from '../types/research';
+
+export function useComparisonProfiles(regionCodes: string[], season: Season) {
+    const codesKey = regionCodes.slice(0, 3).join(',');
+    const [profiles, setProfiles] = useState<ResearchProfile[]>([]);
+    const [missingCodes, setMissingCodes] = useState<string[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const codes = codesKey.split(',').filter(Boolean);
+        if (codes.length < 2) {
+            setProfiles([]);
+            setMissingCodes([]);
+            setError(null);
+            setLoading(false);
+            return;
+        }
+
+        let active = true;
+        setLoading(true);
+        setError(null);
+
+        fetchResearchProfiles(codes, season)
+            .then(data => {
+                if (active) {
+                    setProfiles(data.profiles);
+                    setMissingCodes(data.missing_codes);
+                }
+            })
+            .catch(err => {
+                if (active) {
+                    setProfiles([]);
+                    setMissingCodes([]);
+                    setError(err instanceof Error ? err.message : 'Failed to load comparison');
+                }
+            })
+            .finally(() => {
+                if (active) setLoading(false);
+            });
+
+        return () => {
+            active = false;
+        };
+    }, [codesKey, season]);
+
+    return { profiles, missingCodes, loading, error };
+}

--- a/frontend/src/hooks/usePinnedRegions.ts
+++ b/frontend/src/hooks/usePinnedRegions.ts
@@ -13,9 +13,10 @@ function readPinnedRegions(): string[] {
     }
 }
 
-export function usePinnedRegions() {
+export function usePinnedRegions(initialPinnedRegionCodes?: string[]) {
     const [pinnedRegionCodes, setPinnedRegionCodes] = useState<string[]>(
-        () => readPinnedRegions().slice(0, MAX_PINNED_REGIONS)
+        () => (initialPinnedRegionCodes?.length ? initialPinnedRegionCodes : readPinnedRegions())
+            .slice(0, MAX_PINNED_REGIONS)
     );
 
     useEffect(() => {
@@ -39,10 +40,18 @@ export function usePinnedRegions() {
         });
     }, []);
 
+    const replacePinned = useCallback((regionCodes: string[]) => {
+        const uniqueCodes = regionCodes.filter((code, index) => (
+            typeof code === 'string' && code && regionCodes.indexOf(code) === index
+        ));
+        setPinnedRegionCodes(uniqueCodes.slice(0, MAX_PINNED_REGIONS));
+    }, []);
+
     return {
         pinnedRegionCodes,
         isPinned,
         togglePinned,
+        replacePinned,
         maxPinnedRegions: MAX_PINNED_REGIONS,
     };
 }

--- a/frontend/src/types/research.ts
+++ b/frontend/src/types/research.ts
@@ -1,0 +1,63 @@
+import { Season } from '../api/catApi';
+
+export type DataConfidence = 'HIGH' | 'MEDIUM' | 'LOW' | 'MISSING' | string;
+
+export interface ResearchProfile {
+    region: {
+        region_code: string;
+        name: string;
+        lat: number | null;
+        lon: number | null;
+        region: string | null;
+        cat_tier: number | null;
+        data_confidence: DataConfidence;
+        has_data_gap: boolean;
+        missing_fields: string[];
+    };
+    connectivity: {
+        fcc_coverage_25mbps_pct: number | null;
+        ookla_download_mbps: number | null;
+        ookla_upload_mbps: number | null;
+        latency_ms: number | null;
+        reliability_label: string | null;
+        isp_name: string | null;
+        data_source: string | null;
+    };
+    affordability: {
+        monthly_cost: number | null;
+        median_income: number | null;
+        burden_pct: number | null;
+        threshold_pct: number | null;
+        status: 'affordable' | 'unaffordable' | 'unknown';
+    };
+    healthcare: {
+        nearest_facility_name: string | null;
+        nearest_facility_distance_km: number | null;
+        nearest_facility_type: string | null;
+        emergency_services: boolean | null;
+        specialist_available: boolean | null;
+        facility_count: number | null;
+        desert_score: number | null;
+    };
+    telehealth: {
+        status: string;
+        label: string;
+        video_feasible: boolean | null;
+        audio_feasible: boolean | null;
+        clinic_supported: boolean | null;
+        season: Season;
+        season_note: string;
+    };
+    methodology: {
+        generated_at: string;
+        sources: string[];
+        confidence_notes: string[];
+    };
+}
+
+export interface ResearchProfilesResponse {
+    profiles: ResearchProfile[];
+    count: number;
+    missing_codes: string[];
+    season: Season;
+}

--- a/frontend/src/utils/formatResearchValue.ts
+++ b/frontend/src/utils/formatResearchValue.ts
@@ -1,0 +1,41 @@
+export const DATA_UNAVAILABLE = 'Data unavailable';
+
+export function formatResearchValue(
+    value: number | string | boolean | null | undefined,
+    options: {
+        suffix?: string;
+        prefix?: string;
+        digits?: number;
+        booleanLabels?: [string, string];
+    } = {},
+): string {
+    if (value === null || value === undefined || value === '') {
+        return DATA_UNAVAILABLE;
+    }
+
+    if (typeof value === 'boolean') {
+        const labels = options.booleanLabels ?? ['Yes', 'No'];
+        return value ? labels[0] : labels[1];
+    }
+
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return DATA_UNAVAILABLE;
+        }
+        const digits = options.digits ?? (Number.isInteger(value) ? 0 : 1);
+        return `${options.prefix ?? ''}${value.toLocaleString(undefined, {
+            maximumFractionDigits: digits,
+            minimumFractionDigits: 0,
+        })}${options.suffix ?? ''}`;
+    }
+
+    return value;
+}
+
+export function formatStatusText(value: string | null | undefined): string {
+    if (!value) return DATA_UNAVAILABLE;
+    return value
+        .replace(/_/g, ' ')
+        .toLowerCase()
+        .replace(/\b\w/g, char => char.toUpperCase());
+}


### PR DESCRIPTION
## Summary

This PR improves the map and comparison experience for pinned communities. It keeps map popups lightweight, moves heavier evidence into the sidebar, adds a bottom comparison dock, and prevents pinned communities from squeezing the results list.

## What Changed

- Added typed comparison profile loading for pinned communities.
- Added a bottom-docked community comparison panel with internal scrolling.
- Simplified map popups to show only the community name, region code, CAT badge, telehealth status, and a view-details action.
- Kept selected community state centralized through `selectedRegionCode`.
- Updated marker and sidebar interactions so map clicks, sidebar clicks, and popup actions stay in sync.
- Adjusted sidebar layout so pinned communities do not make the results list unusable.
- Tuned map framing so the view focuses more naturally on Alaska and Canada.

<img width="1710" height="987" alt="image" src="https://github.com/user-attachments/assets/a0340ae9-93cc-45bf-81ab-49f33641f5e9" />
