### PR TITLE
feat(scenario): add client state hooks

### DIFF
--- a/frontend/src/api/scenarioApi.ts
+++ b/frontend/src/api/scenarioApi.ts
@@ -1,0 +1,39 @@
+/**
+ * Scenario API client – POST /api/cat/scenarios/preview
+ */
+
+import type { Season } from './catApi';
+import type { ScenarioPreviewResponse, ScenarioThresholds } from '../types/scenario';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
+
+export interface ScenarioPreviewRequest {
+    mode: 'preview';
+    season: Season;
+    thresholds: ScenarioThresholds;
+    region_codes: string[] | null;
+}
+
+/**
+ * Fetch a scenario preview from the backend.
+ *
+ * Supports `AbortSignal` so callers can cancel stale requests.
+ */
+export async function fetchScenarioPreview(
+    request: ScenarioPreviewRequest,
+    signal?: AbortSignal,
+): Promise<ScenarioPreviewResponse> {
+    const response = await fetch(`${API_BASE}/scenarios/preview`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal,
+    });
+
+    if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || `Scenario preview failed: ${response.statusText}`);
+    }
+
+    return response.json();
+}

--- a/frontend/src/hooks/useScenarioPreview.ts
+++ b/frontend/src/hooks/useScenarioPreview.ts
@@ -1,0 +1,144 @@
+/**
+ * useScenarioPreview – fetches scenario preview with debounce, abort, and cache
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchScenarioPreview } from '../api/scenarioApi';
+import type { Season } from '../api/catApi';
+import type {
+    ScenarioMode,
+    ScenarioPreviewResponse,
+    ScenarioThresholds,
+} from '../types/scenario';
+
+const DEBOUNCE_MS = 500;
+
+function cacheKey(
+    season: Season,
+    thresholds: ScenarioThresholds,
+    regionCodes: string[] | null,
+): string {
+    return JSON.stringify({ season, thresholds, regionCodes });
+}
+
+export interface ScenarioPreviewState {
+    data: ScenarioPreviewResponse | null;
+    loading: boolean;
+    error: string | null;
+}
+
+export function useScenarioPreview(
+    mode: ScenarioMode,
+    thresholds: ScenarioThresholds,
+    season: Season,
+    regionCodes: string[] | null = null,
+    setMode?: (mode: ScenarioMode) => void,
+): ScenarioPreviewState {
+    const [data, setData] = useState<ScenarioPreviewResponse | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const cacheRef = useRef<Map<string, ScenarioPreviewResponse>>(new Map());
+    const abortRef = useRef<AbortController | null>(null);
+    const timerRef = useRef<number | null>(null);
+
+    const fetchPreview = useCallback(async (
+        currentThresholds: ScenarioThresholds,
+        currentSeason: Season,
+        currentRegionCodes: string[] | null,
+    ) => {
+        const key = cacheKey(currentSeason, currentThresholds, currentRegionCodes);
+
+        // Check cache
+        const cached = cacheRef.current.get(key);
+        if (cached) {
+            setData(cached);
+            setLoading(false);
+            setError(null);
+            setMode?.('active');
+            return;
+        }
+
+        // Abort previous
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        setLoading(true);
+        setError(null);
+        setMode?.('calculating');
+
+        try {
+            const result = await fetchScenarioPreview(
+                {
+                    mode: 'preview',
+                    season: currentSeason,
+                    thresholds: currentThresholds,
+                    region_codes: currentRegionCodes,
+                },
+                controller.signal,
+            );
+
+            if (!controller.signal.aborted) {
+                cacheRef.current.set(key, result);
+                // Keep cache bounded
+                if (cacheRef.current.size > 20) {
+                    const firstKey = cacheRef.current.keys().next().value;
+                    if (firstKey !== undefined) {
+                        cacheRef.current.delete(firstKey);
+                    }
+                }
+                setData(result);
+                setLoading(false);
+                setError(null);
+                setMode?.('active');
+            }
+        } catch (err: any) {
+            if (err?.name === 'AbortError') return;
+            if (!controller.signal.aborted) {
+                setError(err?.message || 'Scenario preview failed');
+                setLoading(false);
+                setMode?.('active');
+            }
+        }
+    }, [setMode]);
+
+    // Debounced fetch
+    useEffect(() => {
+        if (mode === 'off') {
+            setData(null);
+            setError(null);
+            setLoading(false);
+            abortRef.current?.abort();
+            if (timerRef.current) {
+                window.clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+            return;
+        }
+
+        if (timerRef.current) {
+            window.clearTimeout(timerRef.current);
+        }
+
+        timerRef.current = window.setTimeout(() => {
+            fetchPreview(thresholds, season, regionCodes);
+        }, DEBOUNCE_MS);
+
+        return () => {
+            if (timerRef.current) {
+                window.clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, [mode, thresholds, season, regionCodes, fetchPreview]);
+
+    // Cleanup on unmount
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+            if (timerRef.current) window.clearTimeout(timerRef.current);
+        };
+    }, []);
+
+    return { data, loading, error };
+}

--- a/frontend/src/hooks/useScenarioPreview.ts
+++ b/frontend/src/hooks/useScenarioPreview.ts
@@ -46,9 +46,12 @@ export function useScenarioPreview(
         currentSeason: Season,
         currentRegionCodes: string[] | null,
     ) => {
+        abortRef.current?.abort();
+        abortRef.current = null;
+
         const key = cacheKey(currentSeason, currentThresholds, currentRegionCodes);
 
-        // Check cache
+        // Check cache after cancelling any stale in-flight request, so older responses cannot win.
         const cached = cacheRef.current.get(key);
         if (cached) {
             setData(cached);
@@ -58,8 +61,6 @@ export function useScenarioPreview(
             return;
         }
 
-        // Abort previous
-        abortRef.current?.abort();
         const controller = new AbortController();
         abortRef.current = controller;
 
@@ -78,26 +79,30 @@ export function useScenarioPreview(
                 controller.signal,
             );
 
-            if (!controller.signal.aborted) {
-                cacheRef.current.set(key, result);
-                // Keep cache bounded
-                if (cacheRef.current.size > 20) {
-                    const firstKey = cacheRef.current.keys().next().value;
-                    if (firstKey !== undefined) {
-                        cacheRef.current.delete(firstKey);
-                    }
-                }
-                setData(result);
-                setLoading(false);
-                setError(null);
-                setMode?.('active');
+            if (controller.signal.aborted || abortRef.current !== controller) {
+                return;
             }
+
+            cacheRef.current.set(key, result);
+            // Keep cache bounded
+            if (cacheRef.current.size > 20) {
+                const firstKey = cacheRef.current.keys().next().value;
+                if (firstKey !== undefined) {
+                    cacheRef.current.delete(firstKey);
+                }
+            }
+            setData(result);
+            setLoading(false);
+            setError(null);
+            setMode?.('active');
+            abortRef.current = null;
         } catch (err: any) {
             if (err?.name === 'AbortError') return;
-            if (!controller.signal.aborted) {
+            if (!controller.signal.aborted && abortRef.current === controller) {
                 setError(err?.message || 'Scenario preview failed');
                 setLoading(false);
                 setMode?.('active');
+                abortRef.current = null;
             }
         }
     }, [setMode]);
@@ -109,6 +114,7 @@ export function useScenarioPreview(
             setError(null);
             setLoading(false);
             abortRef.current?.abort();
+            abortRef.current = null;
             if (timerRef.current) {
                 window.clearTimeout(timerRef.current);
                 timerRef.current = null;

--- a/frontend/src/hooks/useScenarioState.test.tsx
+++ b/frontend/src/hooks/useScenarioState.test.tsx
@@ -5,22 +5,30 @@ import { useScenarioState } from './useScenarioState';
 
 describe('useScenarioState URL sync', () => {
     it('restores scenario params and removes them when scenario mode is deactivated', async () => {
-        window.history.replaceState(null, '', '/?scenario=1&bd=100&up=20&aff=4&clinic=30&preset=equity');
+        window.history.replaceState(
+            null,
+            '',
+            '/?scenario=1&bd=100&up=20&latency=90&aff=4&clinic=30&preset=equity',
+        );
 
         const { result } = renderHook(() => useScenarioState('year_round'));
 
         expect(result.current.mode).toBe('active');
         expect(result.current.thresholds.min_download_mbps).toBe(100);
         expect(result.current.thresholds.min_upload_mbps).toBe(20);
+        expect(result.current.thresholds.max_latency_ms).toBe(90);
         expect(result.current.thresholds.affordability_burden_pct).toBe(4);
         expect(result.current.thresholds.clinic_proximity_km).toBe(30);
 
         act(() => {
             result.current.setThreshold('min_download_mbps', 75);
+            result.current.setThreshold('max_latency_ms', 120);
         });
 
         await waitFor(() => {
-            expect(new URLSearchParams(window.location.search).get('bd')).toBe('75');
+            const params = new URLSearchParams(window.location.search);
+            expect(params.get('bd')).toBe('75');
+            expect(params.get('latency')).toBe('120');
         });
 
         act(() => {
@@ -31,6 +39,7 @@ describe('useScenarioState URL sync', () => {
             const params = new URLSearchParams(window.location.search);
             expect(params.has('scenario')).toBe(false);
             expect(params.has('bd')).toBe(false);
+            expect(params.has('latency')).toBe(false);
         });
         expect(result.current.thresholds).toEqual(BASELINE_THRESHOLDS);
     });

--- a/frontend/src/hooks/useScenarioState.test.tsx
+++ b/frontend/src/hooks/useScenarioState.test.tsx
@@ -1,0 +1,37 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BASELINE_THRESHOLDS } from '../types/scenario';
+import { useScenarioState } from './useScenarioState';
+
+describe('useScenarioState URL sync', () => {
+    it('restores scenario params and removes them when scenario mode is deactivated', async () => {
+        window.history.replaceState(null, '', '/?scenario=1&bd=100&up=20&aff=4&clinic=30&preset=equity');
+
+        const { result } = renderHook(() => useScenarioState('year_round'));
+
+        expect(result.current.mode).toBe('active');
+        expect(result.current.thresholds.min_download_mbps).toBe(100);
+        expect(result.current.thresholds.min_upload_mbps).toBe(20);
+        expect(result.current.thresholds.affordability_burden_pct).toBe(4);
+        expect(result.current.thresholds.clinic_proximity_km).toBe(30);
+
+        act(() => {
+            result.current.setThreshold('min_download_mbps', 75);
+        });
+
+        await waitFor(() => {
+            expect(new URLSearchParams(window.location.search).get('bd')).toBe('75');
+        });
+
+        act(() => {
+            result.current.deactivate();
+        });
+
+        await waitFor(() => {
+            const params = new URLSearchParams(window.location.search);
+            expect(params.has('scenario')).toBe(false);
+            expect(params.has('bd')).toBe(false);
+        });
+        expect(result.current.thresholds).toEqual(BASELINE_THRESHOLDS);
+    });
+});

--- a/frontend/src/hooks/useScenarioState.ts
+++ b/frontend/src/hooks/useScenarioState.ts
@@ -1,0 +1,170 @@
+/**
+ * useScenarioState – manages scenario thresholds, presets, and URL state
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Season } from '../api/catApi';
+import {
+    BASELINE_THRESHOLDS,
+    SCENARIO_PRESETS,
+    type ScenarioMode,
+    type ScenarioPreset,
+    type ScenarioThresholds,
+} from '../types/scenario';
+
+function thresholdsEqual(a: ScenarioThresholds, b: ScenarioThresholds): boolean {
+    return (
+        a.min_download_mbps === b.min_download_mbps &&
+        a.min_upload_mbps === b.min_upload_mbps &&
+        a.max_latency_ms === b.max_latency_ms &&
+        a.clinic_proximity_km === b.clinic_proximity_km &&
+        a.affordability_burden_pct === b.affordability_burden_pct
+    );
+}
+
+function parseScenarioUrlParams(): {
+    active: boolean;
+    thresholds: Partial<ScenarioThresholds>;
+    preset: string | null;
+} {
+    if (typeof window === 'undefined') {
+        return { active: false, thresholds: {}, preset: null };
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('scenario') !== '1') {
+        return { active: false, thresholds: {}, preset: null };
+    }
+
+    const partial: Partial<ScenarioThresholds> = {};
+    const bd = params.get('bd');
+    if (bd !== null && !isNaN(Number(bd))) partial.min_download_mbps = Number(bd);
+    const up = params.get('up');
+    if (up !== null && !isNaN(Number(up))) partial.min_upload_mbps = Number(up);
+    const aff = params.get('aff');
+    if (aff !== null && !isNaN(Number(aff))) partial.affordability_burden_pct = Number(aff);
+    const clinic = params.get('clinic');
+    if (clinic !== null && clinic !== 'baseline') {
+        if (!isNaN(Number(clinic))) partial.clinic_proximity_km = Number(clinic);
+    }
+
+    return {
+        active: true,
+        thresholds: partial,
+        preset: params.get('preset'),
+    };
+}
+
+export interface ScenarioState {
+    mode: ScenarioMode;
+    thresholds: ScenarioThresholds;
+    activePreset: string | null;
+    isBaselineEquivalent: boolean;
+
+    /** Turn scenario mode on */
+    activate: () => void;
+    /** Turn scenario mode off and clean URL params */
+    deactivate: () => void;
+    /** Update a single threshold value */
+    setThreshold: <K extends keyof ScenarioThresholds>(key: K, value: ScenarioThresholds[K]) => void;
+    /** Apply a preset */
+    applyPreset: (presetId: string) => void;
+    /** Reset to baseline */
+    resetToBaseline: () => void;
+    /** Set mode directly (e.g. for 'calculating') */
+    setMode: (mode: ScenarioMode) => void;
+}
+
+export function useScenarioState(season: Season): ScenarioState {
+    const initialUrl = useMemo(() => parseScenarioUrlParams(), []);
+
+    const [mode, setMode] = useState<ScenarioMode>(initialUrl.active ? 'active' : 'off');
+    const [thresholds, setThresholds] = useState<ScenarioThresholds>(() => ({
+        ...BASELINE_THRESHOLDS,
+        ...initialUrl.thresholds,
+    }));
+    const [activePreset, setActivePreset] = useState<string | null>(initialUrl.preset);
+
+    const isBaselineEquivalent = useMemo(
+        () => thresholdsEqual(thresholds, BASELINE_THRESHOLDS),
+        [thresholds],
+    );
+
+    // ── URL state sync ─────────────────────────────────────────────────
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+
+        const params = new URLSearchParams(window.location.search);
+
+        // Remove all scenario params first
+        params.delete('scenario');
+        params.delete('bd');
+        params.delete('up');
+        params.delete('aff');
+        params.delete('clinic');
+        params.delete('preset');
+
+        if (mode !== 'off') {
+            params.set('scenario', '1');
+            params.set('bd', String(thresholds.min_download_mbps));
+            params.set('up', String(thresholds.min_upload_mbps));
+            params.set('aff', String(thresholds.affordability_burden_pct));
+            if (thresholds.clinic_proximity_km !== null) {
+                params.set('clinic', String(thresholds.clinic_proximity_km));
+            } else {
+                params.set('clinic', 'baseline');
+            }
+            if (activePreset) params.set('preset', activePreset);
+        }
+
+        const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+        window.history.replaceState(null, '', nextUrl);
+    }, [mode, thresholds, activePreset]);
+
+    // ── Actions ────────────────────────────────────────────────────────
+    const activate = useCallback(() => setMode('active'), []);
+
+    const deactivate = useCallback(() => {
+        setMode('off');
+        setThresholds({ ...BASELINE_THRESHOLDS });
+        setActivePreset(null);
+    }, []);
+
+    const setThreshold = useCallback(<K extends keyof ScenarioThresholds>(
+        key: K,
+        value: ScenarioThresholds[K],
+    ) => {
+        setThresholds(prev => ({ ...prev, [key]: value }));
+        setActivePreset(null); // Clear preset when user manually adjusts
+    }, []);
+
+    const applyPreset = useCallback((presetId: string) => {
+        if (presetId === 'baseline') {
+            setThresholds({ ...BASELINE_THRESHOLDS });
+            setActivePreset('baseline');
+            return;
+        }
+        const preset = SCENARIO_PRESETS.find(p => p.id === presetId);
+        if (preset) {
+            setThresholds(prev => ({ ...BASELINE_THRESHOLDS, ...preset.thresholds }));
+            setActivePreset(presetId);
+        }
+    }, []);
+
+    const resetToBaseline = useCallback(() => {
+        setThresholds({ ...BASELINE_THRESHOLDS });
+        setActivePreset('baseline');
+    }, []);
+
+    return {
+        mode,
+        thresholds,
+        activePreset,
+        isBaselineEquivalent,
+        activate,
+        deactivate,
+        setThreshold,
+        applyPreset,
+        resetToBaseline,
+        setMode,
+    };
+}

--- a/frontend/src/hooks/useScenarioState.ts
+++ b/frontend/src/hooks/useScenarioState.ts
@@ -1,7 +1,7 @@
 /**
  * useScenarioState – manages scenario thresholds, presets, and URL state
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Season } from '../api/catApi';
 import {
     BASELINE_THRESHOLDS,
@@ -10,6 +10,8 @@ import {
     type ScenarioPreset,
     type ScenarioThresholds,
 } from '../types/scenario';
+
+const URL_SYNC_DEBOUNCE_MS = 300;
 
 function thresholdsEqual(a: ScenarioThresholds, b: ScenarioThresholds): boolean {
     return (
@@ -40,6 +42,14 @@ function parseScenarioUrlParams(): {
     if (bd !== null && !isNaN(Number(bd))) partial.min_download_mbps = Number(bd);
     const up = params.get('up');
     if (up !== null && !isNaN(Number(up))) partial.min_upload_mbps = Number(up);
+    const latency = params.get('latency');
+    if (latency !== null) {
+        if (latency === 'baseline') {
+            partial.max_latency_ms = null;
+        } else if (!isNaN(Number(latency))) {
+            partial.max_latency_ms = Number(latency);
+        }
+    }
     const aff = params.get('aff');
     if (aff !== null && !isNaN(Number(aff))) partial.affordability_burden_pct = Number(aff);
     const clinic = params.get('clinic');
@@ -83,6 +93,7 @@ export function useScenarioState(season: Season): ScenarioState {
         ...initialUrl.thresholds,
     }));
     const [activePreset, setActivePreset] = useState<string | null>(initialUrl.preset);
+    const urlSyncTimerRef = useRef<number | null>(null);
 
     const isBaselineEquivalent = useMemo(
         () => thresholdsEqual(thresholds, BASELINE_THRESHOLDS),
@@ -93,31 +104,51 @@ export function useScenarioState(season: Season): ScenarioState {
     useEffect(() => {
         if (typeof window === 'undefined') return;
 
-        const params = new URLSearchParams(window.location.search);
-
-        // Remove all scenario params first
-        params.delete('scenario');
-        params.delete('bd');
-        params.delete('up');
-        params.delete('aff');
-        params.delete('clinic');
-        params.delete('preset');
-
-        if (mode !== 'off') {
-            params.set('scenario', '1');
-            params.set('bd', String(thresholds.min_download_mbps));
-            params.set('up', String(thresholds.min_upload_mbps));
-            params.set('aff', String(thresholds.affordability_burden_pct));
-            if (thresholds.clinic_proximity_km !== null) {
-                params.set('clinic', String(thresholds.clinic_proximity_km));
-            } else {
-                params.set('clinic', 'baseline');
-            }
-            if (activePreset) params.set('preset', activePreset);
+        if (urlSyncTimerRef.current) {
+            window.clearTimeout(urlSyncTimerRef.current);
         }
 
-        const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-        window.history.replaceState(null, '', nextUrl);
+        urlSyncTimerRef.current = window.setTimeout(() => {
+            const params = new URLSearchParams(window.location.search);
+
+            // Remove all scenario params first
+            params.delete('scenario');
+            params.delete('bd');
+            params.delete('up');
+            params.delete('latency');
+            params.delete('aff');
+            params.delete('clinic');
+            params.delete('preset');
+
+            if (mode !== 'off') {
+                params.set('scenario', '1');
+                params.set('bd', String(thresholds.min_download_mbps));
+                params.set('up', String(thresholds.min_upload_mbps));
+                if (thresholds.max_latency_ms !== null) {
+                    params.set('latency', String(thresholds.max_latency_ms));
+                } else {
+                    params.set('latency', 'baseline');
+                }
+                params.set('aff', String(thresholds.affordability_burden_pct));
+                if (thresholds.clinic_proximity_km !== null) {
+                    params.set('clinic', String(thresholds.clinic_proximity_km));
+                } else {
+                    params.set('clinic', 'baseline');
+                }
+                if (activePreset) params.set('preset', activePreset);
+            }
+
+            const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+            window.history.replaceState(null, '', nextUrl);
+            urlSyncTimerRef.current = null;
+        }, URL_SYNC_DEBOUNCE_MS);
+
+        return () => {
+            if (urlSyncTimerRef.current) {
+                window.clearTimeout(urlSyncTimerRef.current);
+                urlSyncTimerRef.current = null;
+            }
+        };
     }, [mode, thresholds, activePreset]);
 
     // ── Actions ────────────────────────────────────────────────────────

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -1,0 +1,136 @@
+/**
+ * Scenario Analysis types
+ */
+import { Season, TelehealthStatusName } from '../api/catApi';
+
+/** Scenario lifecycle states */
+export type ScenarioMode = 'off' | 'calculating' | 'active';
+
+/** User-adjustable thresholds */
+export interface ScenarioThresholds {
+    min_download_mbps: number;
+    min_upload_mbps: number;
+    max_latency_ms: number | null;
+    clinic_proximity_km: number | null;
+    affordability_burden_pct: number;
+}
+
+/** Status delta direction */
+export type StatusDelta = 'improved' | 'worsened' | 'unchanged';
+
+/** Per-region scenario result */
+export interface ScenarioRegion {
+    region_code: string;
+    name: string;
+    lat: number | null;
+    lon: number | null;
+    baseline_status: string;
+    scenario_status: string;
+    status_delta: StatusDelta;
+    baseline_need_score: number;
+    scenario_need_score: number;
+    need_score_delta: number;
+    changed: boolean;
+    has_data_gap: boolean;
+    missing_fields: string[];
+    data_confidence: string;
+    reason_codes: string[];
+    explanation: string;
+}
+
+/** Summary statistics */
+export interface ScenarioSummary {
+    total_regions: number;
+    status_changed_regions: number;
+    score_changed_regions: number;
+    improved_count: number;
+    worsened_count: number;
+    unchanged_count: number;
+    telehealth_ready: number;
+    community_anchor: number;
+    limited_telehealth: number;
+    critical_gap: number;
+    data_unavailable: number;
+}
+
+/** Full preview response */
+export interface ScenarioPreviewResponse {
+    scenario: {
+        season: Season;
+        thresholds: ScenarioThresholds;
+        is_baseline_equivalent: boolean;
+    };
+    summary: ScenarioSummary;
+    regions: ScenarioRegion[];
+}
+
+/** Preset definitions */
+export interface ScenarioPreset {
+    id: string;
+    label: string;
+    thresholds: Partial<ScenarioThresholds>;
+}
+
+/** Cache key for scenario results */
+export interface ScenarioCacheKey {
+    season: Season;
+    thresholds: ScenarioThresholds;
+    region_codes: string[] | null;
+}
+
+/** Preset options */
+export const SCENARIO_PRESETS: ScenarioPreset[] = [
+    {
+        id: 'fcc',
+        label: 'FCC Standard',
+        thresholds: {
+            min_download_mbps: 25,
+            min_upload_mbps: 3,
+            affordability_burden_pct: 2,
+        },
+    },
+    {
+        id: 'equity',
+        label: 'Broadband Equity Goal',
+        thresholds: {
+            min_download_mbps: 100,
+            min_upload_mbps: 20,
+        },
+    },
+    {
+        id: 'clinic_access',
+        label: 'Universal Clinic Access',
+        thresholds: {
+            clinic_proximity_km: 25,
+        },
+    },
+];
+
+/** Default baseline thresholds */
+export const BASELINE_THRESHOLDS: ScenarioThresholds = {
+    min_download_mbps: 25,
+    min_upload_mbps: 3,
+    max_latency_ms: 150,
+    clinic_proximity_km: null,
+    affordability_burden_pct: 2,
+};
+
+/** Status color helper */
+export function getScenarioStatusColor(status: string): string {
+    switch (status) {
+        case 'TELEHEALTH_READY': return '#22c55e';
+        case 'LIMITED_TELEHEALTH': return '#eab308';
+        case 'COMMUNITY_ANCHOR': return '#f97316';
+        case 'CRITICAL_GAP': return '#ef4444';
+        case 'DATA_UNAVAILABLE': return '#6b7280';
+        default: return '#6b7280';
+    }
+}
+
+export function getScenarioDeltaColor(delta: StatusDelta): string {
+    switch (delta) {
+        case 'improved': return '#22c55e';
+        case 'worsened': return '#ef4444';
+        case 'unchanged': return '#94a3b8';
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the frontend Scenario Mode data layer.

It introduces the TypeScript types, API client, debounced preview hook, and URL state management needed before rendering Scenario Mode in the UI.

## What Changed

- Added scenario TypeScript contracts
- Added scenario API client
- Added `useScenarioPreview`
- Added `useScenarioState`
- Added URL state support for scenario thresholds
- Added frontend caching for repeated scenario previews
- Added stale request cancellation with `AbortController`
- Added a focused URL state test

## Why This Matters

Scenario sliders can generate many rapid updates. The frontend needs to debounce requests, cancel stale ones, and avoid applying old responses after the user has already changed thresholds.

## User-Facing Impact

No visible UI is added in this PR. This is frontend infrastructure only.

## Verification

```bash
npm run test
npm run typecheck