### PR TITLE
test(e2e): add playwright smoke coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,6 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
-<<<<<<< experimental-dakshhhhh16
 # Node.js / Frontend
 node_modules/
 npm-debug.log*
@@ -213,11 +212,18 @@ yarn-error.log*
 frontend/dist/
 frontend/build/
 frontend/.vite/
+frontend/playwright-report/
+frontend/test-results/
 
 # Frontend environment
 frontend/.env
 frontend/.env.local
 frontend/.env.production
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
 
 # OS files
 .DS_Store
@@ -228,15 +234,3 @@ Thumbs.db
 *.swp
 *.swo
 *~
-=======
-# Marimo
-marimo/_static/
-marimo/_lsp/
-__marimo__/
-
-# Node.js dependencies (shared)
-node_modules/
-
-# OS generated files
-.DS_Store
->>>>>>> main

--- a/frontend/e2e/phase5-smoke.spec.ts
+++ b/frontend/e2e/phase5-smoke.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Phase 5 public dashboard smoke', () => {
+  test('searches a community, selects it, and downloads a non-empty report', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('community-search')).toBeVisible();
+
+    await page.getByTestId('community-search').fill('Anchorage');
+    await page.getByTestId('sidebar-search-result').first().click();
+    await expect(page.getByRole('heading', { name: 'Anchorage' })).toBeVisible();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('download-report').click();
+    const download = await downloadPromise;
+    const stream = await download.createReadStream();
+
+    expect(download.suggestedFilename().toLowerCase()).toContain('anchorage');
+    if (!stream) {
+      throw new Error('Expected PDF download stream');
+    }
+
+    let bytes = 0;
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', chunk => {
+        bytes += chunk.length;
+      });
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    });
+    expect(bytes).toBeGreaterThan(0);
+  });
+
+  test('scenario controls update the modeled impact summary and shareable URL state', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('scenario-button').click();
+    await expect(page.getByTestId('scenario-panel')).toBeVisible();
+
+    await page.getByLabel('Download threshold').evaluate(element => {
+      const input = element as HTMLInputElement;
+      input.value = '75';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await expect(page.getByTestId('scenario-summary')).toBeVisible();
+    await expect(page).toHaveURL(/scenario=1/);
+    await expect(page).toHaveURL(/bd=75/);
+
+    await page.getByTestId('season-selector').selectOption('winter');
+    await expect(page).toHaveURL(/season=winter/);
+  });
+
+  test('pinned communities open the comparison panel', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('community-search')).toBeVisible();
+
+    await page.getByTestId('community-search').fill('Anchorage');
+    await page.getByRole('button', { name: 'Pin Anchorage' }).click();
+
+    await page.getByTestId('community-search').fill('Bethel');
+    await page.getByRole('button', { name: 'Pin Bethel' }).click();
+
+    await expect(page.getByTestId('comparison-panel')).toBeVisible();
+    await expect(page.getByText('Community Comparison')).toBeVisible();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "use-supercluster": "^1.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.3.1",
         "@types/leaflet": "^1.9.8",
@@ -89,7 +90,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -438,7 +438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -462,7 +461,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -906,6 +904,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -1472,7 +1486,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1775,7 +1788,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2955,7 +2967,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -3044,8 +3055,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/lodash": {
       "version": "4.18.1",
@@ -3297,6 +3307,53 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3409,7 +3466,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3422,7 +3478,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3813,7 +3868,6 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "kdbush": "^4.0.2"
       }
@@ -4044,7 +4098,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "jspdf": "^4.2.1",
@@ -19,6 +22,7 @@
     "use-supercluster": "^1.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
     "@types/leaflet": "^1.9.8",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/test/setup.ts',
+    exclude: ['node_modules', 'dist', 'e2e'],
   },
 })


### PR DESCRIPTION

## Summary

This PR adds Playwright smoke testing for the most important end-to-end user journeys.

The suite is intentionally small and stable. It checks that the app works as a connected system without introducing fragile visual comparisons.

## What Changed

- Added Playwright dependency
- Added Playwright config
- Added E2E smoke tests for:
  - community search and report download
  - Scenario Mode summary and URL state
  - pinned community comparison panel
- Added E2E scripts
- Ensured Playwright output artifacts are ignored

## Why This Matters

Unit and component tests are useful, but TENeT also needs confidence that the full dashboard works together: sidebar, map, PDF export, scenario controls, and comparison panel.

## Testing Philosophy

The PDF E2E test verifies:

- download is triggered
- file is non-empty
- filename is reasonable

Detailed PDF content remains covered by unit tests to avoid brittle visual PDF testing.

## Verification

```bash
npm run e2e -- --list