### PR TITLE
docs: add deployment and testing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to TENeT
+
+TENeT is a public-facing planning dashboard for Alaska telehealth access. Changes should keep the app reproducible, readable, and honest about missing or modeled data.
+
+## Local Setup
+
+```bash
+cp .env.example .env
+make dev
+```
+
+Open:
+
+- Frontend: http://localhost:5173
+- Backend health: http://localhost:5001/api/health
+
+The Docker workflow is the primary development path. It builds both services and seeds `backend/data/tenet.db` when the local database is missing.
+
+## Before Opening a PR
+
+Run the checks that match your change:
+
+```bash
+make backend-test      # backend logic and API tests
+make frontend-test     # frontend component and hook tests
+make frontend-build    # production build
+make smoke             # lightweight running-app verification
+```
+
+For UI workflow changes, also run:
+
+```bash
+make e2e
+```
+
+`make e2e` expects the app to already be running at http://localhost:5173.
+
+## PR Checklist
+
+- Existing formulas are preserved unless the PR explicitly changes them.
+- Missing API values remain `null`; UI/PDF labels render them as `Data unavailable`.
+- Scenario outputs are clearly labeled as modeled estimates.
+- Gap Hunter remains raw observed measurement data.
+- New tests fill coverage gaps and do not duplicate existing tests for the same function or component behavior.
+- Any new user-facing control has an accessible label or clear text.
+- Docker startup still works from a fresh clone.
+
+## Branch and Commit Guidance
+
+Use short human-readable branch names that describe the work, for example:
+
+- `testing-quality-gates`
+- `deployment-docs`
+- `scenario-e2e-smoke`
+
+Keep commits grouped by behavior. Avoid mixing unrelated docs, UI, backend, and CI changes in one commit when they can be reviewed separately.
+
+## Known Project Constraints
+
+- SQLite is the current database and public demo data is seeded/read-only.
+- The frontend should not duplicate backend data-quality logic.
+- Scenario Mode must not mutate baseline TENeT data.
+- Dynamic Weather API integration is a stretch item and should not be added without mentor approval.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -117,4 +117,4 @@ If deployment fails:
 - SQLite public demo data is seeded/read-only.
 - Scenario Mode is modeled analysis, not observed field data.
 - Gap Hunter remains raw observed measurement data.
-- Weather API integration is not part of core Phase 5 deployment unless mentors approve it.
+- Weather API integration is not part of the core public demo deployment unless mentors approve it.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,120 @@
+# TENeT Deployment Guide
+
+This guide describes a public demo deployment for TENeT. The app should not depend on a local laptop database or untracked files.
+
+## Deployment Decision
+
+For the public demo, SQLite is treated as read-only seeded data.
+
+Use one of these reproducible strategies:
+
+1. Run the deterministic seed command during deployment startup/build.
+2. Ship a stable seeded database artifact produced by the same seed workflow.
+
+Do not deploy by copying an untracked local `backend/data/tenet.db` from a developer machine.
+
+## Recommended Shape
+
+- Backend: Dockerized Flask API web service.
+- Frontend: static Vite build served by a static host.
+- Frontend API base URL points to the deployed backend.
+- Backend CORS allows the deployed frontend origin.
+
+This can be hosted on common student-friendly platforms such as Render, Vercel, Fly.io, Railway, or a university-provided container host. Confirm platform and free-tier constraints with mentors before final deployment.
+
+## Required Environment Variables
+
+Backend:
+
+| Variable | Example | Purpose |
+|----------|---------|---------|
+| `FLASK_DEBUG` | `0` | Disable debug mode in production |
+| `FLASK_HOST` | `0.0.0.0` | Bind inside the container |
+| `FLASK_PORT` | platform-provided or `5001` | API port |
+| `DB_TYPE` | `sqlite` | Current database backend |
+| `DB_PATH` | `/app/data/tenet.db` | SQLite path inside backend container |
+| `CORS_ALLOWED_ORIGINS` | `https://tenet.example.org` | Comma-separated frontend origins |
+
+Frontend:
+
+| Variable | Example | Purpose |
+|----------|---------|---------|
+| `VITE_API_BASE_URL` | `https://tenet-api.example.org/api/cat` | Deployed CAT API base URL |
+
+## Backend Deployment Steps
+
+1. Build the backend Docker image from `backend/Dockerfile`.
+2. Set production environment variables.
+3. Seed the database if the deployed DB path is empty:
+
+   ```bash
+   python -c "from database.init_db import main; main()"
+   ```
+
+4. Start the API:
+
+   ```bash
+   python app.py
+   ```
+
+5. Verify:
+
+   ```bash
+   curl -fsS https://<backend-host>/api/health
+   ```
+
+Expected response:
+
+```json
+{
+  "status": "ok",
+  "service": "tenet-api"
+}
+```
+
+## Frontend Deployment Steps
+
+1. Set `VITE_API_BASE_URL` to the deployed backend CAT API base.
+2. Install dependencies:
+
+   ```bash
+   npm ci
+   ```
+
+3. Build:
+
+   ```bash
+   npm run build
+   ```
+
+4. Serve the `frontend/dist` directory as a static site.
+5. Open the live frontend and verify the map loads communities.
+
+## Smoke Test Checklist
+
+- Backend health returns `status: ok`.
+- `/api/cat/regions/summary` returns communities.
+- Frontend loads without console-breaking API errors.
+- Search/sidebar works.
+- PDF export downloads a report.
+- Comparison panel opens with pinned communities.
+- Shareable URL reload restores state.
+- Scenario Mode opens and updates the impact summary.
+- Gap Hunter still displays observed data.
+
+## Rollback
+
+If deployment fails:
+
+1. Revert to the previous platform deployment.
+2. Confirm the backend health endpoint.
+3. Confirm `VITE_API_BASE_URL` points to the working API.
+4. Re-run the seed command only if the database path is empty or intentionally reset.
+
+## Known Limitations
+
+- Free-tier services may cold start.
+- SQLite public demo data is seeded/read-only.
+- Scenario Mode is modeled analysis, not observed field data.
+- Gap Hunter remains raw observed measurement data.
+- Weather API integration is not part of core Phase 5 deployment unless mentors approve it.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ seeds local development data, and starts the backend plus frontend together.
 | `make build` | Rebuild containers without cache |
 | `make seed` | Seed the database with local CAT, healthcare, broadband, income, and performance data |
 | `make reset-db` | Delete and re-seed the database |
-| `make test` | Run backend pytest and frontend build check |
+| `make test` | Run backend pytest and frontend Vitest |
 | `make backend-test` | Run only backend pytest |
-| `make frontend-test` | Run only frontend build check |
+| `make frontend-test` | Run only frontend Vitest |
+| `make frontend-build` | Run the frontend production build |
+| `make frontend-typecheck` | Run TypeScript checks |
+| `make docker-build` | Build backend and frontend Docker images |
+| `make e2e` | Run Playwright smoke tests against a running app |
+| `make smoke` | Run lightweight deployment smoke checks |
 | `make logs` | Tail container logs |
 | `make clean` | Remove containers, volumes, and images |
 | `make help` | Show all available commands |
@@ -87,8 +92,10 @@ Common local variables:
 | `FRONTEND_PORT` | `5173` | Host port for Vite |
 | `FLASK_HOST` | `0.0.0.0` | Backend bind address inside Docker |
 | `FLASK_PORT` | `5001` | Backend container port |
+| `FLASK_DEBUG` | `1` | Flask debug mode for local Docker |
 | `DB_PATH` | `/app/data/tenet.db` | SQLite path inside the backend container |
 | `VITE_API_BASE_URL` | `/api/cat` | Frontend API base URL proxied by nginx in Docker |
+| `CORS_ALLOWED_ORIGINS` | `*` | Comma-separated frontend origins allowed by the API |
 
 ### Troubleshooting
 
@@ -135,6 +142,11 @@ npm run dev
 | **Broadband Reality Check** | Side-by-side comparison of FCC-claimed speeds vs. Ookla-measured speeds - exposing the real connectivity gap |
 | **Internet Affordability** | Monthly broadband cost as a percentage of local household income - because 25 Mbps means nothing if no one can afford it |
 | **Seasonal Adjustment** | Toggle between summer and winter to see how access changes when roads freeze and rivers shut down |
+| **Sidebar Discovery** | Search, filter, sort, pin, and inspect communities without moving heavy map geometry |
+| **Research Reports** | Download community PDF summaries with safe missing-data labels |
+| **Region Comparison** | Compare 2–3 pinned communities side by side |
+| **Shareable URLs** | Restore selected region, layer, season, pins, map view, and scenario state |
+| **What-If Scenarios** | Model broadband, clinic proximity, and affordability thresholds without changing baseline data |
 
 ---
 
@@ -184,10 +196,15 @@ TENeT/
 | Endpoint | What it returns |
 |----------|-----------------|
 | `GET /api/cat/regions?season=summer` | All communities with tier levels, adjusted for season |
+| `GET /api/cat/regions/summary` | Lightweight sidebar community summaries without geometry |
+| `GET /api/cat/regions/search` | Search/filter community summaries |
+| `GET /api/cat/regions/<region_code>/research-profile` | Export-ready profile for one community |
+| `GET /api/cat/regions/research-profiles` | Batch profiles for pinned comparison |
+| `POST /api/cat/scenarios/preview` | Modeled scenario preview for selected thresholds |
 | `GET /api/cat/telehealth-priority` | Telehealth priority rankings per community |
 | `GET /api/cat/performance` | Measured broadband speeds (Ookla data) |
 | `GET /api/cat/affordability` | Internet cost burden per community |
-| `GET /api/health` | Backend health check |
+| `GET /api/health` | Backend health check: `{"status":"ok","service":"tenet-api"}` |
 
 ---
 
@@ -231,15 +248,18 @@ The transport tier feeds into the Telehealth Need Score alongside healthcare des
 
 ---
 
-## Upcoming Features
+## Quality, Deployment, and Contribution Docs
 
-- **Sidebar Search** - Find any community by name, fly-to on map
-- **PDF Reports** - One-click downloadable summaries for grant applications
-- **Region Comparison** - Compare 2–3 communities side by side
-- **What-If Sliders** - Model "what happens if broadband improves here?"
-- **Shareable URLs** - Bookmark and share specific map views
-- **CI/CD Pipeline** - Automated tests via GitHub Actions
-- **Cloud Deployment** - Public URL for direct stakeholder access
+- [Testing guide](./TESTING.md) - backend, frontend, E2E, smoke, accessibility, and performance checks
+- [Deployment guide](./DEPLOY.md) - public demo deployment with seeded SQLite data
+- [Contribution guide](./CONTRIBUTING.md) - local workflow and PR checklist
+
+## Known Limitations
+
+- Scenario Mode shows modeled estimates based on selected thresholds. It does not represent observed ground truth and does not modify baseline data.
+- Gap Hunter remains raw observed measurement data and is not recolored by Scenario Mode.
+- Public demo deployments use deterministic seeded SQLite data and should not depend on local untracked database files.
+- Dynamic Weather API integration is a stretch exploration item only unless mentors approve implementation.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,138 @@
+# TENeT Testing Guide
+
+Phase 5 uses layered testing: unit tests for formulas, integration tests for API contracts, component tests for UI behavior, Playwright smoke tests for full journeys, and CI checks for repeatability.
+
+## Test Coverage Audit
+
+Before adding new tests, check existing coverage so we do not duplicate the same behavior:
+
+- Backend formula tests: affordability and healthcare desert calculations.
+- Backend API tests: discovery, research profiles, scenario preview, cache behavior.
+- Frontend tests: sidebar discovery, legends/tooltips, missing-data labels.
+
+New tests should cover gaps or distinct edge cases only.
+
+## Local Commands
+
+The Docker workflow should match CI as closely as possible.
+
+```bash
+make backend-test       # pytest in the backend Docker environment
+make frontend-test      # Vitest in the frontend Docker environment
+make test               # backend + frontend tests
+make frontend-build     # production frontend build
+make frontend-typecheck # TypeScript typecheck
+make docker-build       # Docker image build checks
+make smoke              # lightweight running-app smoke checks
+make e2e                # Playwright smoke suite against a running app
+```
+
+`make smoke` expects the backend to be running at `http://127.0.0.1:5001` unless `API_URL` is overridden.
+
+## Backend Testing
+
+Backend tests should verify:
+
+- `/api/health` returns:
+
+  ```json
+  {
+    "status": "ok",
+    "service": "tenet-api"
+  }
+  ```
+
+- Summary/search endpoints avoid heavy geometry.
+- Invalid filters do not crash.
+- Missing values remain `null` in API responses.
+- Research profiles include data quality and missing-field metadata.
+- Scenario default thresholds preserve baseline statuses.
+- Scenario cache behavior is tested functionally, not with strict timing.
+- Season behavior uses fixed known communities instead of asserting every community changes.
+
+Avoid brittle timing assertions such as “must respond under 50ms.”
+
+## Frontend Testing
+
+Vitest/React Testing Library should cover:
+
+- Sidebar search, filters, sort, reset, selection, and pinning.
+- Missing data renders as `Data unavailable`, `Unknown`, or `Data incomplete`.
+- PDF report generation does not emit blank/null/undefined fields.
+- Shareable URL state serializes/restores scenario parameters.
+- Comparison math and best/worst labels.
+- Scenario panel off/calculating/active states.
+- Gap Hunter remains observed data and unaffected by Scenario Mode.
+
+## Playwright E2E Smoke
+
+Playwright tests live under `frontend/e2e`.
+
+The smoke suite verifies:
+
+- Search -> select community -> download PDF.
+- Scenario slider -> impact summary -> shareable URL params.
+- Pin communities -> comparison panel opens.
+
+PDF E2E checks only that a download is triggered, the file is non-empty, and the filename is reasonable. Detailed PDF content belongs in unit/component tests.
+
+Use stable selectors for E2E:
+
+- `data-testid="community-search"`
+- `data-testid="sidebar-result"`
+- `data-testid="download-report"`
+- `data-testid="comparison-panel"`
+- `data-testid="scenario-button"`
+- `data-testid="scenario-summary"`
+- `data-testid="copy-share-link"`
+
+## Accessibility Smoke Checks
+
+Phase 5 does not claim full WCAG certification, but the final app should pass basic checks:
+
+- Important statuses are not color-only.
+- Buttons have accessible labels.
+- Sidebar controls are keyboard reachable.
+- Scenario controls are keyboard reachable.
+- PDF/share/comparison buttons are readable by screen readers where practical.
+
+## Performance Sanity Checks
+
+Do not add strict benchmarks in CI. Instead verify obvious regressions:
+
+- Sidebar search remains responsive with all communities.
+- Scenario slider debounce prevents excessive API calls.
+- PDF generation does not freeze the UI for normal reports.
+- Comparison panel remains usable with 3 pinned communities.
+
+## CI Expectations
+
+GitHub Actions should run:
+
+- Backend pytest.
+- Frontend typecheck, Vitest, and build.
+- Docker Compose validation and image build checks.
+- Playwright smoke tests after the browser suite is stable.
+
+If Playwright fails in CI, screenshots, videos, and traces should be uploaded as artifacts.
+
+## Final Demo Checklist
+
+- Fresh clone setup works.
+- `make dev` or documented Docker startup works.
+- `make test` passes.
+- `make smoke` passes.
+- CI is green.
+- Live demo URL works.
+- Search/sidebar works.
+- Filters and reset work.
+- PDF export works.
+- Comparison panel works.
+- Shareable URL restore works.
+- Scenario Mode works.
+- Gap Hunter still shows observed data correctly.
+- Basic accessibility smoke checks pass.
+- Performance sanity checks pass.
+- README links are current.
+- Deployment docs are usable by a maintainer.
+- Known limitations are documented.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # TENeT Testing Guide
 
-Phase 5 uses layered testing: unit tests for formulas, integration tests for API contracts, component tests for UI behavior, Playwright smoke tests for full journeys, and CI checks for repeatability.
+TENeT uses layered testing: unit tests for formulas, integration tests for API contracts, component tests for UI behavior, Playwright smoke tests for full journeys, and CI checks for repeatability.
 
 ## Test Coverage Audit
 
@@ -50,7 +50,7 @@ Backend tests should verify:
 - Scenario cache behavior is tested functionally, not with strict timing.
 - Season behavior uses fixed known communities instead of asserting every community changes.
 
-Avoid brittle timing assertions such as “must respond under 50ms.”
+Avoid brittle timing assertions such as "must respond under 50ms."
 
 ## Frontend Testing
 
@@ -88,7 +88,7 @@ Use stable selectors for E2E:
 
 ## Accessibility Smoke Checks
 
-Phase 5 does not claim full WCAG certification, but the final app should pass basic checks:
+TENeT does not claim full WCAG certification, but the final app should pass basic checks:
 
 - Important statuses are not color-only.
 - Buttons have accessible labels.


### PR DESCRIPTION

## Summary

This PR adds Phase 5 maintainer documentation for testing, deployment, contribution workflow, and final evaluation.

It also updates the README so completed Phase 2-4 features are no longer listed as upcoming work.

## What Changed

- Updated README with current implemented features
- Added `CONTRIBUTING.md`
- Added `DEPLOY.md`
- Added `TESTING.md`
- Documented seeded SQLite deployment decision
- Added final demo checklist
- Added known limitations
- Documented test commands and CI expectations

## Why This Matters

The project should be usable by maintainers after GSoC. These docs explain how to run, test, deploy, troubleshoot, and evaluate TENeT without depending on local hidden setup.

## Deployment Decision

For the public demo, SQLite is treated as read-only seeded data.

Deployment should either:

- run the deterministic seed command during build/startup, or
- ship a stable seeded database artifact produced by the same seed workflow

It should not depend on an untracked local `backend/data/tenet.db`.

## Known Limitations Documented

- Scenario Mode is modeled analysis, not observed ground truth.
- Gap Hunter remains raw observed measurement data.
- Public demo deployments use seeded read-only SQLite data.
- Weather API integration remains a stretch item unless mentors approve it.

## Verification

Docs review checklist:

- Fresh clone instructions are clear
- Docker startup is documented
- Test commands are accurate
- Deployment env vars are listed
- Final demo checklist is included