### PR TITLE
Fix: Re-write winter tier penalty logic to properly map surviving transport modes

### DIFF
--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -706,20 +706,24 @@ def _calculate_seasonal_tier(base_tier: int, base_score: float, properties: dict
         
         # Water is mostly unavailable in winter
         if has_water and not has_air:
-            tier_penalty += 1
             score_penalty += 25
             restricted_modes.append('water (frozen)')
         elif has_water:
             score_penalty += 10
             restricted_modes.append('water (limited)')
         
-        # Seasonal roads are unavailable
+        # Seasonal roads are harder, and if water freezes and they have no air, they rely solely on roads (Tier 3 max)
         if has_road:
             score_penalty += 5  # Roads harder but not impossible
+            if not has_air:
+                tier_penalty = max(tier_penalty, 3 - base_tier)
         
-        # No air = significant penalty
-        if not has_air and base_tier < 4:
-            tier_penalty += 1
+        # If a community has no road and no air, they are completely isolated in winter (water freezes)
+        elif not has_air:
+            tier_penalty = max(tier_penalty, 4 - base_tier)
+            
+        # No air = significant penalty for all tiers
+        if not has_air:
             score_penalty += 20
         
         adjusted_tier = min(4, int(base_tier) + int(tier_penalty))

--- a/backend/tests/test_cat_routes.py
+++ b/backend/tests/test_cat_routes.py
@@ -1,0 +1,39 @@
+import sys
+import os
+import pytest
+
+# Ensure backend directory is in path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from routes.cat_routes import _calculate_seasonal_tier
+
+@pytest.mark.parametrize("base_tier, base_score, properties, expected_tier, expected_score", [
+    # Test 1: Tier 1 (Road + Water + Air) -> Stays Tier 1, minor penalties
+    (1, 100.0, {'primary_access_modes': 'road,water,air'}, 1, 85.0), 
+    
+    # Test 2: Tier 1 (Road + Water, No Air) -> Drops to Tier 3, heavy score penalty
+    (1, 90.0, {'primary_access_modes': 'road,water'}, 3, 40.0), 
+    
+    # Test 3: Tier 3 (Road only, No Air) -> Stays Tier 3 (Fixes the road-only bug!)
+    (3, 80.0, {'primary_access_modes': 'road'}, 3, 55.0), 
+    
+    # Test 4: Tier 3 (Water only, No Air) -> Drops to Tier 4
+    (3, 70.0, {'primary_access_modes': 'water'}, 4, 25.0), 
+    
+    # Test 5: Tier 4 (No road, no water, no air) -> Stays Tier 4, receives -20 penalty intentionally
+    (4, 50.0, {'primary_access_modes': ''}, 4, 30.0), 
+    
+    # Test 6: Tier 2 (Air only) -> Stays Tier 2
+    (2, 90.0, {'primary_access_modes': 'air'}, 2, 90.0)
+])
+def test_calculate_seasonal_tier_winter(base_tier, base_score, properties, expected_tier, expected_score):
+    """
+    Test winter penalty matrix across all tiers to verify road-only bug fix 
+    and consistent application of the 20-point no-air penalty.
+    """
+    adjusted_tier, adjusted_score, explanation = _calculate_seasonal_tier(
+        base_tier, base_score, properties, 'winter'
+    )
+    
+    assert adjusted_tier == expected_tier
+    assert adjusted_score == expected_score


### PR DESCRIPTION
Closes #101

**Summary of Changes:**
This PR fixes a domain logic bug in `_calculate_seasonal_tier()` where the winter penalty state machine was corrupting Community Access Tiers.

I identified this discrepancy while reviewing the seasonal adjustment logic. The original code used overlapping penalties (`has_water and not has_air` stacked with `not has_air`) to force `Road+Water` communities to drop from Tier 1 to Tier 3. However, this stacked hack had the unintended side effect of forcing `Road-only` communities to drop to Tier 4, incorrectly classifying highway towns as having "No direct scheduled access".

**Changes made:**
- Rewrote the winter penalty block in `cat_routes.py` to explicitly handle the `has_road` vs `not has_road` tier transitions when water freezes, rather than stacking arbitrary +1 penalties.
- Preserved the severe 20-point score penalty for lacking an airport, while unlinking it from the Tier drop logic.
- The new logic strictly follows the documented definitions.

**Testing:**
- [x] Verified full truth table against expected tier definitions
- [x] Added automated test case covering the road-only winter scenario
- [x] All tests pass
