### PR TITLE
Fix: Align healthcare necessity score weighting math with documented 40/20/20/20 split

### DIFF
--- a/backend/services/healthcare_desert_calculator.py
+++ b/backend/services/healthcare_desert_calculator.py
@@ -200,9 +200,9 @@ class HealthcareDesertCalculator:
         
         # Calculate weighted score
         necessity_score = float(
-            0.50 * distance_score +
-            0.15 * density_score +
-            0.15 * specialist_score +
+            0.40 * distance_score +
+            0.20 * density_score +
+            0.20 * specialist_score +
             0.20 * transport_score
         )
         

--- a/backend/tests/test_healthcare_calculator.py
+++ b/backend/tests/test_healthcare_calculator.py
@@ -27,7 +27,7 @@ class TestHealthcareCalculator(unittest.TestCase):
         # (100 * 0.20) = 20.0
         db.query().filter().count.side_effect = [
             0,      # num_sites (density)
-            False,  # has_specialists
+            0,      # has_specialists
         ]
         
         # 3. Specialist: False => 100 points

--- a/backend/tests/test_healthcare_calculator.py
+++ b/backend/tests/test_healthcare_calculator.py
@@ -1,0 +1,51 @@
+import unittest
+import sys
+import os
+
+# Ensure backend directory is in path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.healthcare_desert_calculator import HealthcareDesertCalculator
+from unittest.mock import MagicMock, patch
+
+class TestHealthcareCalculator(unittest.TestCase):
+    
+    @patch('services.healthcare_desert_calculator.HealthcareDesertCalculator.get_nearest_facility_distances')
+    def test_calculate_healthcare_necessity_score_weights(self, mock_distances):
+        """
+        Verify that the Healthcare Necessity Score strictly follows the documented
+        40/20/20/20 weighting split (Distance, Density, Specialist, Transport).
+        """
+        # Mock database session
+        db = MagicMock()
+        
+        # 1. Distance (clinic=300km, hospital=500km) => 100 points
+        # (100 * 0.40) = 40.0
+        mock_distances.return_value = {'clinic': 300.0, 'hospital': 500.0}
+        
+        # 2. Density: 0 sites => 100 points 
+        # (100 * 0.20) = 20.0
+        db.query().filter().count.side_effect = [
+            0,      # num_sites (density)
+            False,  # has_specialists
+        ]
+        
+        # 3. Specialist: False => 100 points
+        # (100 * 0.20) = 20.0
+        
+        # 4. Transport: Empty mock data_point falls back to default 
+        # year-round moderate => 50 points
+        # (50 * 0.20) = 10.0
+        db.query().filter().first.return_value = None
+        
+        result = HealthcareDesertCalculator.calculate_healthcare_necessity_score(db, "REGION_TEST", "year_round", "local")
+        
+        # Total expected: 40 + 20 + 20 + 10 = 90.0
+        self.assertEqual(result['necessity_score'], 90.0)
+        self.assertEqual(result['breakdown']['distance_component'], 100.0)
+        self.assertEqual(result['breakdown']['density_component'], 100.0)
+        self.assertEqual(result['breakdown']['specialist_component'], 100.0)
+        self.assertEqual(result['breakdown']['transport_component'], 50.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #102

**Summary of Changes:**
This PR resolves the domain logic mismatch identified in the linked issue where the `HealthcareDesertCalculator` was unintentionally applying a `50 / 15 / 15 / 20` weighting split instead of the documented `40 / 20 / 20 / 20` split. 

By fixing this, the scoring algorithm will properly value regional clinic density and specialist availability, preventing raw distance from unintentionally overriding those factors.

**Changes made:**
- Updated the mathematical multipliers in `calculate_healthcare_necessity_score` to match the documented design (0.40, 0.20, 0.20, 0.20).
- Added a new unit test suite (`test_healthcare_calculator.py`) with mocked database dependencies to mathematically verify the final score calculation perfectly adheres to the 40/20/20/20 ratio.

**Testing:**
- [x] Verified calculation manually
- [x] Added automated test case
- [x] All tests pass
