### PR TITLE
Centralize frontend domain semantics and metric presentation

### DIFF
--- a/frontend/ENGINEERING.md
+++ b/frontend/ENGINEERING.md
@@ -1,0 +1,27 @@
+# Frontend engineering boundaries
+
+Keep frontend changes small, behavior-preserving, and easy to review.
+
+## Ownership boundaries
+
+- `src/api` owns HTTP calls and the frontend contracts for backend responses. Components should not call endpoints directly.
+- `src/hooks` owns reusable state, data-loading, and orchestration logic. Hooks should not own presentation.
+- `src/components/ui` owns shared visual primitives; feature folders own feature composition and feature-specific styling.
+- `src/types` owns shared domain types that span more than one feature. Keep local-only props and types beside their consumer.
+
+## Change rules
+
+- Maintain one shared design system in `src/components/ui`. Extend or migrate the existing primitives instead of creating a parallel set.
+- Do not present inferred, partial, modeled, or unavailable data as an observed metric. Labels and supporting text must state the source or limitation clearly enough to avoid misleading users.
+- When a shared primitive exists, use it instead of introducing raw styling for the same UI role. Dynamic values that cannot be represented by an existing class or token may remain inline.
+- Every new abstraction must replace and delete or migrate the old code in the same change. Do not layer a second path over an obsolete one.
+
+## Quality gates
+
+- `npm run typecheck` checks the strict TypeScript project without emitting files.
+- `npm run test` runs the Vitest unit and component tests once.
+- `npm run build` creates the production Vite bundle.
+- `npm run validate` runs typecheck, tests, and build in sequence.
+- End-to-end coverage is available separately through `npm run e2e` because it requires a browser and an application/API environment.
+
+ESLint and Prettier are not currently installed. No lint or format-check script is declared until those tools and an agreed configuration are added; a script that only aliases typechecking would be misleading.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,9 +14,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-leaflet-cluster": "^2.1.0",
-        "supercluster": "^8.0.1",
-        "use-supercluster": "^1.2.0"
+        "react-leaflet-cluster": "^2.1.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -25,7 +23,6 @@
         "@types/leaflet": "^1.9.8",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
-        "@types/supercluster": "^7.1.3",
         "@vitejs/plugin-react": "^4.2.1",
         "jsdom": "^24.1.3",
         "typescript": "^5.2.2",
@@ -394,6 +391,380 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -1153,14 +1524,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "license": "MIT",
@@ -1899,13 +2262,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3079,10 +3435,6 @@
         "html2canvas": "^1.0.0-rc.5"
       }
     },
-    "node_modules/kdbush": {
-      "version": "4.1.0",
-      "license": "ISC"
-    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "license": "BSD-2-Clause"
@@ -3934,13 +4286,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
-    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "license": "MIT",
@@ -4084,33 +4429,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/use-deep-compare-effect": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "dequal": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13"
-      }
-    },
-    "node_modules/use-supercluster": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-deep-compare-effect": "^1.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "supercluster": ">=8"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "validate": "npm run typecheck && npm run test && npm run build",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed"
   },
@@ -19,9 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "react-leaflet-cluster": "^2.1.0",
-    "supercluster": "^8.0.1",
-    "use-supercluster": "^1.2.0"
+    "react-leaflet-cluster": "^2.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
@@ -30,7 +29,6 @@
     "@types/leaflet": "^1.9.8",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@types/supercluster": "^7.1.3",
     "@vitejs/plugin-react": "^4.2.1",
     "jsdom": "^24.1.3",
     "typescript": "^5.2.2",

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -43,7 +43,7 @@ export interface RegionSummary {
     lat: number | null;
     lon: number | null;
     cat_tier: number | null;
-    telehealth_status: TelehealthStatusName | string;
+    telehealth_status: TelehealthStatusName;
     desert_score: number | null;
     affordability_status: AffordabilityStatusName | string;
     data_confidence: 'high' | 'medium' | 'low' | 'missing' | 'unknown' | string;
@@ -354,8 +354,8 @@ export async function fetchBroadbandCoverage(filters?: {
 /**
  * Fetch data gaps summary for dashboard display
  */
-export async function fetchDataGapsSummary(): Promise<DataGapsSummary> {
-    const response = await fetch(`${API_BASE}/data-gaps`);
+export async function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
+    const response = await fetch(`${API_BASE}/data-gaps`, { signal });
     if (!response.ok) {
         throw new Error(`Failed to fetch data gaps: ${response.statusText}`);
     }

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,119 @@
+export type QueryValue = string | number | boolean | null | undefined;
+
+export class ApiError extends Error {
+    readonly status: number;
+    readonly statusText: string;
+    readonly url: string;
+    readonly body: unknown;
+
+    constructor({
+        message,
+        status,
+        statusText,
+        url,
+        body,
+        cause,
+    }: {
+        message: string;
+        status: number;
+        statusText: string;
+        url: string;
+        body?: unknown;
+        cause?: unknown;
+    }) {
+        super(message);
+        if (cause !== undefined) {
+            (this as Error & { cause?: unknown }).cause = cause;
+        }
+        this.name = 'ApiError';
+        this.status = status;
+        this.statusText = statusText;
+        this.url = url;
+        this.body = body;
+    }
+}
+
+function responseErrorDetail(body: unknown): string | null {
+    if (!body || typeof body !== 'object') return null;
+    const candidate = body as { error?: unknown; message?: unknown };
+    if (typeof candidate.error === 'string' && candidate.error.trim()) return candidate.error;
+    if (typeof candidate.message === 'string' && candidate.message.trim()) return candidate.message;
+    return null;
+}
+
+async function readErrorBody(response: Response): Promise<unknown> {
+    const contentType = response.headers.get('content-type') ?? '';
+    try {
+        return contentType.includes('application/json')
+            ? await response.json()
+            : await response.text();
+    } catch {
+        return null;
+    }
+}
+
+export async function fetchJson<T>(
+    url: string,
+    init: RequestInit = {},
+    errorMessage = 'This data source is currently unavailable',
+): Promise<T> {
+    let response: Response;
+    try {
+        response = await fetch(url, init);
+    } catch (cause: unknown) {
+        if (isAbortError(cause)) throw cause;
+        throw new ApiError({
+            message: `${errorMessage}: network request failed`,
+            status: 0,
+            statusText: '',
+            url,
+            cause,
+        });
+    }
+
+    if (!response.ok) {
+        const body = await readErrorBody(response);
+        const detail = responseErrorDetail(body) || response.statusText;
+        throw new ApiError({
+            message: detail ? `${errorMessage}: ${detail}` : errorMessage,
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url || url,
+            body,
+        });
+    }
+
+    try {
+        return await response.json() as T;
+    } catch (cause: unknown) {
+        throw new ApiError({
+            message: `${errorMessage}: invalid JSON response`,
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url || url,
+            cause,
+        });
+    }
+}
+
+export function withQuery<T extends object>(url: string, params: T): string {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]: [string, QueryValue]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            query.set(key, String(value));
+        }
+    });
+    const suffix = query.toString();
+    return suffix ? `${url}?${suffix}` : url;
+}
+
+export function isAbortError(error: unknown): boolean {
+    return error instanceof DOMException
+        ? error.name === 'AbortError'
+        : error instanceof Error && error.name === 'AbortError';
+}
+
+export function errorMessage(error: unknown, fallback = 'This data source is currently unavailable.'): string {
+    if (error instanceof Error && error.message.trim()) return error.message;
+    return fallback;
+}

--- a/frontend/src/components/DataCoveragePanel.css
+++ b/frontend/src/components/DataCoveragePanel.css
@@ -1,49 +1,233 @@
-.data-coverage-hover {
-    position: absolute;
-    left: 20px;
-    bottom: 80px;
-    z-index: 1000;
+.data-coverage-popover {
+  position: absolute;
+  bottom: var(--spacing-6);
+  left: var(--spacing-4);
+  z-index: var(--z-overlay);
 }
 
 .data-coverage-trigger {
-    border: 1px solid rgba(148, 163, 184, 0.75);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.94);
-    color: #1e293b;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.16);
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 800;
-    cursor: help;
+  box-shadow: var(--shadow-md);
 }
 
 .data-coverage-panel {
-    position: absolute;
-    left: 0;
-    bottom: calc(100% + 10px);
-    width: min(280px, calc(100vw - 32px));
-    max-height: min(70vh, 620px);
-    overflow: auto;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-    transition: opacity 0.16s ease, transform 0.16s ease;
+  position: absolute;
+  bottom: calc(100% + var(--spacing-2));
+  left: 0;
+  width: min(300px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-text);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.data-coverage-hover:hover .data-coverage-panel,
-.data-coverage-hover:focus-within .data-coverage-panel {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
+.data-coverage-panel[hidden] {
+  display: none;
+}
+
+.data-coverage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-2);
+}
+
+.data-coverage-header h4 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.data-coverage-header span,
+.data-coverage-source {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-state {
+  padding: var(--spacing-5) 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  text-align: center;
+}
+
+.data-coverage-state--error {
+  color: var(--color-danger);
+}
+
+.data-coverage-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+}
+
+.data-coverage-stats > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-3);
+}
+
+.data-coverage-stats span,
+.data-coverage-stats small {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-stats strong {
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+}
+
+.data-coverage-stat--alert strong,
+.data-coverage-stat--alert small {
+  color: var(--color-danger);
+}
+
+.data-coverage-section {
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-3);
+}
+
+.data-coverage-section h5 {
+  margin-bottom: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.data-coverage-distribution {
+  display: flex;
+  gap: 2px;
+  height: 8px;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-muted);
+}
+
+.data-coverage-distribution span {
+  min-width: 3px;
+}
+
+.data-coverage-distribution .is-high,
+.data-coverage-key .is-high {
+  background: var(--color-status-ready);
+}
+
+.data-coverage-distribution .is-medium,
+.data-coverage-key .is-medium {
+  background: #d97706;
+}
+
+.data-coverage-distribution .is-low,
+.data-coverage-key .is-low {
+  background: var(--color-status-gap);
+}
+
+.data-coverage-key {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-key span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.data-coverage-key i {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.data-coverage-access {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+}
+
+.data-coverage-access div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-2);
+}
+
+.data-coverage-access strong {
+  color: var(--color-text);
+  font-size: var(--font-base);
+}
+
+.data-coverage-access span {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-gaps {
+  display: grid;
+  gap: var(--spacing-1);
+}
+
+.data-coverage-gaps > div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-1);
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+}
+
+.data-coverage-gaps strong {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.data-coverage-gaps strong.is-error {
+  color: var(--color-danger);
+}
+
+.data-coverage-gaps strong.is-warning {
+  color: var(--color-status-anchor);
+}
+
+.data-coverage-source {
+  margin-top: var(--spacing-3);
 }
 
 @media (max-width: 900px) {
-    .data-coverage-hover {
-        left: 12px;
-        bottom: 14px;
-    }
+  .data-coverage-popover {
+    bottom: calc(46vh + var(--spacing-5));
+    left: var(--spacing-3);
+  }
 
-    .data-coverage-panel {
-        max-height: 52vh;
-    }
+  .data-coverage-panel {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 700px) {
+  .data-coverage-panel {
+    max-height: max(140px, calc(54dvh - 214px));
+  }
 }

--- a/frontend/src/components/DataCoveragePanel.tsx
+++ b/frontend/src/components/DataCoveragePanel.tsx
@@ -1,10 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import {
-    DataGapsSummary,
+    type DataGapsSummary,
     fetchDataGapsSummary,
-    getConfidenceColor,
-    getDataGapInfo
 } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+import {
+    DATA_CONFIDENCE_LEVELS,
+    DATA_CONFIDENCE_PRESENTATION,
+    getDataGapPresentation,
+} from '../domain/metrics';
+import Button from './ui/Button';
+import IconButton from './ui/IconButton';
 import './DataCoveragePanel.css';
 
 interface DataCoveragePanelProps {
@@ -13,250 +19,197 @@ interface DataCoveragePanelProps {
     totalRegions?: number;
 }
 
-/**
- * Panel showing data coverage and data gaps summary
- * Supports the 'data coverage/confidence' layer visualization
- */
-export default function DataCoveragePanel({ isExpanded = false, onToggle, totalRegions }: DataCoveragePanelProps) {
+export default function DataCoveragePanel({
+    isExpanded = false,
+    onToggle,
+}: DataCoveragePanelProps) {
     const [summary, setSummary] = useState<DataGapsSummary | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [open, setOpen] = useState(false);
+    const shellRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelId = useId();
 
     useEffect(() => {
+        const controller = new AbortController();
         async function loadData() {
             try {
                 setLoading(true);
-                const data = await fetchDataGapsSummary();
+                const data = await fetchDataGapsSummary(controller.signal);
                 setSummary(data);
                 setError(null);
-            } catch (err) {
-                setError(err instanceof Error ? err.message : 'Failed to load data gaps');
-                console.error('Error loading data gaps:', err);
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to load data gaps'));
+                }
             } finally {
-                setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             }
         }
         loadData();
+        return () => controller.abort();
     }, []);
 
-    const renderShell = (content: React.ReactNode) => (
-        <div className="data-coverage-hover">
-            <button type="button" className="data-coverage-trigger" aria-label="Show data coverage layer legend">
-                Data
-            </button>
-            <div className="data-coverage-panel" style={panelStyle}>
-                {content}
+    useEffect(() => {
+        if (!open) return;
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!shellRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            setOpen(false);
+            triggerRef.current?.focus();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [open]);
+
+    const close = () => {
+        setOpen(false);
+        triggerRef.current?.focus();
+    };
+
+    const totalPlaces = summary?.total_places ?? 0;
+    const gapsPercentage = summary && summary.total_places > 0
+        ? Math.round((summary.places_with_gaps / summary.total_places) * 100)
+        : 0;
+    const satellitePercent = summary && summary.total_places > 0
+        ? Math.round(((summary.primary_access.SATELLITE ?? 0) / summary.total_places) * 100)
+        : null;
+
+    return (
+        <div ref={shellRef} className="data-coverage-popover">
+            <Button
+                ref={triggerRef}
+                size="small"
+                className="data-coverage-trigger"
+                aria-label={open ? 'Close data coverage summary' : 'Open data coverage summary'}
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => setOpen(value => !value)}
+            >
+                Data coverage
+            </Button>
+
+            <div
+                id={panelId}
+                className="data-coverage-panel"
+                role="region"
+                aria-label="Data coverage summary"
+                hidden={!open}
+            >
+                <div className="data-coverage-header">
+                    <div>
+                        <h4>Data Coverage</h4>
+                        <span>Availability and confidence</span>
+                    </div>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        aria-label="Close data coverage summary"
+                        onClick={close}
+                    />
+                </div>
+
+                {loading && <div className="data-coverage-state" role="status">Loading coverage data…</div>}
+
+                {!loading && (error || !summary) && (
+                    <div className="data-coverage-state data-coverage-state--error" role="alert">
+                        {error || 'No data available'}
+                    </div>
+                )}
+
+                {!loading && summary && (
+                    <>
+                        <div className="data-coverage-stats">
+                            <div>
+                                <span>Broadband places</span>
+                                <strong>{totalPlaces}</strong>
+                            </div>
+                            <div className="data-coverage-stat--alert">
+                                <span>With data gaps</span>
+                                <strong>{summary.places_with_gaps}</strong>
+                                <small>{gapsPercentage}% of total</small>
+                            </div>
+                        </div>
+
+                        <section className="data-coverage-section">
+                            <h5>Data confidence</h5>
+                            <div className="data-coverage-distribution" aria-label="Data confidence distribution">
+                                {DATA_CONFIDENCE_LEVELS.map(level => {
+                                    const count = summary.confidence_distribution[level];
+                                    const presentation = DATA_CONFIDENCE_PRESENTATION[level];
+                                    return (
+                                        <span
+                                            key={level}
+                                            className={presentation.className}
+                                            style={{ flex: count, display: count > 0 ? undefined : 'none' }}
+                                            title={`${count} ${presentation.label.toLowerCase()}-confidence places`}
+                                        />
+                                    );
+                                })}
+                            </div>
+                            <div className="data-coverage-key">
+                                {DATA_CONFIDENCE_LEVELS.map(level => {
+                                    const presentation = DATA_CONFIDENCE_PRESENTATION[level];
+                                    return (
+                                        <span key={level}>
+                                            <i className={presentation.className} />
+                                            {presentation.label} {summary.confidence_distribution[level]}
+                                        </span>
+                                    );
+                                })}
+                            </div>
+                        </section>
+
+                        <section className="data-coverage-section">
+                            <h5>Primary internet access</h5>
+                            <div className="data-coverage-access">
+                                <div><strong>{satellitePercent === null ? '—' : `${satellitePercent}%`}</strong><span>Satellite</span></div>
+                                <div><strong>{satellitePercent === null ? '—' : `${100 - satellitePercent}%`}</strong><span>Wired or other</span></div>
+                            </div>
+                        </section>
+
+                        {(isExpanded || !onToggle) && (
+                            <section className="data-coverage-section">
+                                <h5>Most common gap types</h5>
+                                <div className="data-coverage-gaps">
+                                    {Object.entries(summary.gap_breakdown)
+                                        .filter(([, data]) => data.count > 0)
+                                        .sort(([, a], [, b]) => b.count - a.count)
+                                        .slice(0, 5)
+                                        .map(([gapType, data]) => {
+                                            const info = getDataGapPresentation(gapType);
+                                            return (
+                                                <div key={gapType}>
+                                                    <span>{info.label}</span>
+                                                    <strong className={`is-${info.severity}`}>
+                                                        {data.count} ({data.percentage}%)
+                                                    </strong>
+                                                </div>
+                                            );
+                                        })}
+                                </div>
+                            </section>
+                        )}
+
+                        {onToggle && (
+                            <Button size="small" variant="ghost" onClick={onToggle}>
+                                {isExpanded ? 'Show less detail' : 'Show more detail'}
+                            </Button>
+                        )}
+
+                        <div className="data-coverage-source">Source: FCC Broadband Availability</div>
+                    </>
+                )}
             </div>
         </div>
     );
-
-    if (loading) {
-        return renderShell(
-            <>
-                <div style={{ padding: '24px 24px 8px 24px', fontSize: '16px', fontWeight: '500', color: '#181d26' }}>
-                    <span>Data Coverage Layer</span>
-                </div>
-                <div style={{ padding: '8px 24px 24px 24px', fontSize: '12px', color: '#41454d' }}>
-                    Loading...
-                </div>
-            </>
-        );
-    }
-
-    if (error || !summary) {
-        return renderShell(
-            <>
-                <div style={{ padding: '24px 24px 8px 24px', fontSize: '16px', fontWeight: '500', color: '#181d26' }}>
-                    <span>Data Coverage Layer</span>
-                </div>
-                <div style={{ padding: '8px 24px 24px 24px', fontSize: '12px', color: '#dc2626' }}>
-                    {error || 'No data available'}
-                </div>
-            </>
-        );
-    }
-
-    const gapsPercentage = Math.round((summary.places_with_gaps / summary.total_places) * 100);
-    const satellitePercent = Math.round((summary.primary_access.SATELLITE / summary.total_places) * 100);
-
-    return renderShell(
-        <>
-            {/* Header */}
-            <div
-                style={{
-                    padding: '24px 24px 8px 24px',
-                    fontSize: '16px',
-                    fontWeight: '500',
-                    color: '#181d26',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    cursor: onToggle ? 'pointer' : 'default'
-                }}
-                onClick={onToggle}
-            >
-                <span>Data Coverage Layer</span>
-                {onToggle && (
-                    <span style={{ fontSize: '10px', marginLeft: '8px', color: '#9297a0' }}>
-                        {isExpanded ? '▼' : '▶'}
-                    </span>
-                )}
-            </div>
-
-            {/* Quick Stats */}
-            <div style={{ padding: '8px 24px 16px 24px' }}>
-                <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: '1fr 1fr',
-                    gap: '16px'
-                }}>
-                    <div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginBottom: '4px' }}>Total Places</div>
-                        <div style={{ fontWeight: '400', fontSize: '24px', color: '#181d26', letterSpacing: '-0.02em' }}>
-                            {summary.total_places}
-                        </div>
-                    </div>
-                    <div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginBottom: '4px' }}>With Data Gaps</div>
-                        <div style={{ fontWeight: '400', fontSize: '24px', color: '#aa2d00', letterSpacing: '-0.02em' }}>
-                            {summary.places_with_gaps} <span style={{ fontSize: '13px', fontWeight: '400', color: '#aa2d00' }}>({gapsPercentage}%)</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            {/* Confidence Distribution */}
-            <div style={{ padding: '16px 24px' }}>
-                <div style={{ fontSize: '12px', color: '#181d26', marginBottom: '12px', fontWeight: '500' }}>
-                    Data Confidence
-                </div>
-                <div style={{ display: 'flex', gap: '2px', height: '8px', borderRadius: '4px', overflow: 'hidden' }}>
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.HIGH,
-                            backgroundColor: '#006400',
-                            minWidth: summary.confidence_distribution.HIGH > 0 ? '4px' : '0'
-                        }}
-                    />
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.MEDIUM,
-                            backgroundColor: '#f4d35e',
-                            minWidth: summary.confidence_distribution.MEDIUM > 0 ? '4px' : '0'
-                        }}
-                    />
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.LOW,
-                            backgroundColor: '#aa2d00',
-                            minWidth: summary.confidence_distribution.LOW > 0 ? '4px' : '0'
-                        }}
-                    />
-                </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '10px', fontSize: '11px', color: '#41454d' }}>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#006400' }} />
-                        High
-                    </span>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#f4d35e' }} />
-                        Med
-                    </span>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#aa2d00' }} />
-                        Low
-                    </span>
-                </div>
-            </div>
-
-            {/* Primary Access Type */}
-            <div style={{ padding: '16px 24px' }}>
-                <div style={{ fontSize: '12px', color: '#181d26', marginBottom: '12px', fontWeight: '500' }}>
-                    Primary Internet Access
-                </div>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                    <div style={{
-                        flex: 1,
-                        padding: '12px',
-                        borderRadius: '6px',
-                        backgroundColor: '#f8fafc',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center'
-                    }}>
-                        <div style={{ fontWeight: '400', color: '#181d26', fontSize: '18px' }}>{satellitePercent}%</div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginTop: '4px' }}>Satellite</div>
-                    </div>
-                    <div style={{
-                        flex: 1,
-                        padding: '12px',
-                        borderRadius: '6px',
-                        backgroundColor: '#f8fafc',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center'
-                    }}>
-                        <div style={{ fontWeight: '400', color: '#181d26', fontSize: '18px' }}>{100 - satellitePercent}%</div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginTop: '4px' }}>Wired</div>
-                    </div>
-                </div>
-            </div>
-
-            {/* Expanded: Gap Breakdown */}
-            {(isExpanded || !onToggle) && (
-                <div style={{ padding: '10px 12px' }}>
-                    <div style={{ fontSize: '11px', color: '#6b7280', marginBottom: '6px', fontWeight: '600' }}>
-                        Data Gap Types
-                    </div>
-                    {Object.entries(summary.gap_breakdown)
-                        .filter(([_, data]) => data.count > 0)
-                        .sort(([_, a], [__, b]) => b.count - a.count)
-                        .slice(0, 5)
-                        .map(([gapType, data]) => {
-                            const info = getDataGapInfo(gapType);
-                            return (
-                                <div key={gapType} style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    padding: '4px 0',
-                                    fontSize: '11px',
-                                    borderBottom: '1px solid #f3f4f6'
-                                }}>
-                                    <span>{info.label}</span>
-                                    <span style={{
-                                        color: info.severity === 'error' ? '#dc2626' :
-                                            info.severity === 'warning' ? '#f97316' : '#6b7280',
-                                        fontWeight: '500'
-                                    }}>
-                                        {data.count} ({data.percentage}%)
-                                    </span>
-                                </div>
-                            );
-                        })}
-                </div>
-            )}
-
-            {/* Footer Note */}
-            <div style={{
-                padding: '16px 24px 24px 24px',
-                fontSize: '11px',
-                color: '#9297a0'
-            }}>
-                Data source: FCC Broadband Availability
-            </div>
-        </>
-    );
 }
-
-// Airtable Styles (Flat Canvas, Hairline Border)
-const panelStyle: React.CSSProperties = {
-    minWidth: '240px',
-    maxWidth: '280px',
-    background: '#ffffff',
-    borderRadius: '10px',
-    border: '1px solid #dddddd',
-    fontSize: '13px',
-    overflow: 'hidden',
-    fontFamily: 'inherit'
-};

--- a/frontend/src/components/Legend.css
+++ b/frontend/src/components/Legend.css
@@ -1,216 +1,174 @@
-.legend-hover-shell {
-    position: absolute;
-    right: 20px;
-    bottom: 80px;
-    z-index: 1000;
+.legend-popover {
+  position: absolute;
+  right: var(--spacing-4);
+  bottom: var(--spacing-6);
+  z-index: var(--z-overlay);
 }
 
-.legend-hover-shell-left {
-    right: auto;
-    left: 20px;
+.legend-popover--left {
+  right: auto;
+  left: var(--spacing-4);
 }
 
 .legend-trigger {
-    border: 1px solid rgba(148, 163, 184, 0.75);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.94);
-    color: #1e293b;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.16);
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 800;
-    cursor: help;
+  box-shadow: var(--shadow-md);
 }
 
 .legend-panel {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 10px);
-    width: min(320px, calc(100vw - 32px));
-    max-height: min(70vh, 620px);
-    overflow: auto;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-    transition: opacity 0.16s ease, transform 0.16s ease;
-    background: rgba(255, 255, 255, 0.94);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    padding: 16px 18px;
-    border-radius: 12px;
-    border: 1px solid rgba(203, 213, 225, 0.9);
-    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.18);
-    font-size: 12px;
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + var(--spacing-2));
+  width: min(320px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-text);
+  font-size: var(--font-xs);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.legend-hover-shell-left .legend-panel {
-    right: auto;
-    left: 0;
+.legend-panel[hidden] {
+  display: none;
 }
 
-.legend-hover-shell:hover .legend-panel,
-.legend-hover-shell:focus-within .legend-panel {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    transform: translateY(0);
+.legend-popover--left .legend-panel {
+  right: auto;
+  left: 0;
 }
 
 .legend-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 12px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-2);
 }
 
 .legend-header h4 {
-    margin: 0;
-    color: #0f172a;
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0;
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  font-weight: 700;
 }
 
 .legend-header span {
-    color: #64748b;
-    font-size: 10px;
-    font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 600;
 }
 
 .legend-section {
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid #e5e7eb;
-    display: grid;
-    gap: 8px;
+  display: grid;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-3);
 }
 
 .legend-section-title {
-    color: #334155;
-    font-weight: 800;
-    margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-weight: 700;
 }
 
 .legend-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    margin-bottom: 8px;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .legend-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    margin-top: 3px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  margin-top: 3px;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xs);
 }
 
 .legend-row-label {
-    color: #1e293b;
-    font-weight: 600;
+  color: var(--color-text);
+  font-weight: 600;
 }
 
 .legend-row-note,
 .legend-copy {
-    color: #64748b;
-    font-size: 11px;
-    line-height: 1.4;
-}
-
-.legend-copy {
-    color: #475569;
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+  line-height: 1.4;
 }
 
 .legend-tier-list {
-    display: grid;
-    gap: 6px;
-    color: #475569;
-    font-size: 11px;
-    line-height: 1.4;
+  display: grid;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.4;
 }
 
 .legend-tier-list strong {
-    color: #1e293b;
-}
-
-.legend-chip-row {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-}
-
-.legend-chip {
-    border-radius: 999px;
-    padding: 3px 7px;
-    font-size: 10px;
-    font-weight: 800;
-}
-
-.legend-chip.high {
-    background: #dcfce7;
-    color: #166534;
-}
-
-.legend-chip.low {
-    background: #fef3c7;
-    color: #92400e;
-}
-
-.legend-chip.missing {
-    background: #fee2e2;
-    color: #b91c1c;
+  color: var(--color-text);
 }
 
 .legend-footer-row {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid #e5e7eb;
-    color: #64748b;
-    display: flex;
-    justify-content: space-between;
-    font-size: 10px;
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
 }
 
 .legend-footer-row strong {
-    color: #334155;
+  color: var(--color-text-secondary);
 }
 
 .legend-scale {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid #e5e7eb;
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
 }
 
 .legend-gradient {
-    height: 6px;
-    border-radius: 3px;
-    margin-bottom: 4px;
+  height: 6px;
+  margin-bottom: var(--spacing-1);
+  border-radius: var(--radius-full);
 }
 
 .legend-scale-labels {
-    display: flex;
-    justify-content: space-between;
-    color: #94a3b8;
-    font-size: 9px;
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
 }
 
 @media (max-width: 900px) {
-    .legend-hover-shell {
-        right: 12px;
-        bottom: 14px;
-    }
+  .legend-popover {
+    right: var(--spacing-3);
+    bottom: calc(46vh + var(--spacing-5));
+  }
 
-    .legend-hover-shell-left {
-        right: auto;
-        left: 12px;
-    }
+  .legend-popover--left {
+    right: auto;
+    left: var(--spacing-3);
+  }
 
-    .legend-panel {
-        max-height: 52vh;
-    }
+  .legend-panel {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 700px) {
+  .legend-panel {
+    max-height: max(140px, calc(54dvh - 214px));
+  }
 }

--- a/frontend/src/components/Legend.test.tsx
+++ b/frontend/src/components/Legend.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import Legend from './Legend';
 
@@ -25,5 +25,21 @@ describe('Legend', () => {
 
         expect(screen.getByLabelText(/Healthcare Desert Score: A 0-100 need score/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/CAT Tier: Community Access Tier summarizes/i)).toBeInTheDocument();
+    });
+
+    it('opens on click and closes with Escape', () => {
+        render(<Legend />);
+
+        const trigger = screen.getByRole('button', { name: 'Open discovery legend' });
+        const panel = document.querySelector('[role="region"][aria-label="Discovery legend"]') as HTMLElement;
+        expect(panel).not.toBeVisible();
+
+        fireEvent.click(trigger);
+        expect(panel).toBeVisible();
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(panel).not.toBeVisible();
+        expect(trigger).toHaveFocus();
     });
 });

--- a/frontend/src/components/Legend.tsx
+++ b/frontend/src/components/Legend.tsx
@@ -1,6 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { getNeedColor, getNeedLabel } from '../api/catApi';
+import { useEffect, useId, useRef, useState } from 'react';
+import {
+    CAT_TIERS,
+    CAT_TIER_PRESENTATION,
+    getDesertScorePresentation,
+} from '../domain/metrics';
 import MetricTooltip from './MetricTooltip';
+import Button from './ui/Button';
+import IconButton from './ui/IconButton';
 import './Legend.css';
 
 interface LegendProps {
@@ -8,26 +14,71 @@ interface LegendProps {
     position?: 'bottom-right' | 'bottom-left';
 }
 
-const getNeedCapability = (score: number): string => {
-    if (score >= 75) return 'Severe lack of nearby healthcare facilities';
-    if (score >= 50) return 'Limited access to clinics or hospitals';
-    if (score >= 25) return 'Adequate access with some travel distance';
-    return 'Good access to nearby healthcare facilities';
-};
-
 export default function Legend({ totalRegions, position = 'bottom-right' }: LegendProps) {
     const needLevels = [87, 62, 37, 12];
+    const [open, setOpen] = useState(false);
+    const shellRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelId = useId();
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!shellRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            setOpen(false);
+            triggerRef.current?.focus();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [open]);
 
     return (
-        <div className={`legend-hover-shell ${position === 'bottom-left' ? 'legend-hover-shell-left' : ''}`}>
-            <button type="button" className="legend-trigger" aria-label="Show discovery legend">
+        <div
+            ref={shellRef}
+            className={`legend-popover ${position === 'bottom-left' ? 'legend-popover--left' : ''}`}
+        >
+            <Button
+                ref={triggerRef}
+                size="small"
+                className="legend-trigger"
+                aria-label={open ? 'Close discovery legend' : 'Open discovery legend'}
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => setOpen(value => !value)}
+            >
                 Legend
-            </button>
+            </Button>
 
-            <div className="legend-panel">
+            <div
+                id={panelId}
+                className="legend-panel"
+                role="region"
+                aria-label="Discovery legend"
+                hidden={!open}
+            >
                 <div className="legend-header">
-                    <h4>Discovery Legend</h4>
-                    <span>Plain-language guide</span>
+                    <div>
+                        <h4>Discovery Legend</h4>
+                        <span>Plain-language guide</span>
+                    </div>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        aria-label="Close discovery legend"
+                        onClick={() => {
+                            setOpen(false);
+                            triggerRef.current?.focus();
+                        }}
+                    />
                 </div>
 
                 <div className="legend-section-title">
@@ -37,19 +88,22 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                     </MetricTooltip>
                 </div>
 
-                {needLevels.map(score => (
-                    <div key={score} className="legend-row">
-                        <span
-                            className="legend-dot"
-                            style={{ backgroundColor: getNeedColor(score) }}
-                            aria-hidden="true"
-                        />
-                        <div>
-                            <div className="legend-row-label">{getNeedLabel(score)}</div>
-                            <div className="legend-row-note">{getNeedCapability(score)}</div>
+                {needLevels.map(score => {
+                    const presentation = getDesertScorePresentation(score);
+                    return (
+                        <div key={score} className="legend-row">
+                            <span
+                                className="legend-dot"
+                                style={{ backgroundColor: presentation.color }}
+                                aria-hidden="true"
+                            />
+                            <div>
+                                <div className="legend-row-label">{presentation.label}</div>
+                                <div className="legend-row-note">{presentation.description}</div>
+                            </div>
                         </div>
-                    </div>
-                ))}
+                    );
+                })}
 
                 <div className="legend-section">
                     <div className="legend-section-title">
@@ -59,10 +113,11 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                         </MetricTooltip>
                     </div>
                     <div className="legend-tier-list">
-                        <div><strong>Tier 1:</strong> strongest access; road-connected or easier service reach.</div>
-                        <div><strong>Tier 2:</strong> moderate access; some travel or logistics constraints.</div>
-                        <div><strong>Tier 3:</strong> limited access; remote travel makes care harder to reach.</div>
-                        <div><strong>Tier 4:</strong> most isolated; highest transport and service-access barriers.</div>
+                        {CAT_TIERS.map(tier => (
+                            <div key={tier}>
+                                <strong>Tier {tier}:</strong> {CAT_TIER_PRESENTATION[tier].shortDescription}
+                            </div>
+                        ))}
                     </div>
                 </div>
 
@@ -77,7 +132,7 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                     <div
                         className="legend-gradient"
                         style={{
-                            background: `linear-gradient(to right, ${getNeedColor(12)}, ${getNeedColor(37)}, ${getNeedColor(62)}, ${getNeedColor(87)})`,
+                            background: `linear-gradient(to right, ${needLevels.slice().reverse().map(score => getDesertScorePresentation(score).color).join(', ')})`,
                         }}
                     />
                     <div className="legend-scale-labels">

--- a/frontend/src/components/sidebar/FilterControls.tsx
+++ b/frontend/src/components/sidebar/FilterControls.tsx
@@ -1,3 +1,5 @@
+import { BASE_TELEHEALTH_STATUSES, getTelehealthStatusLabel } from '../../domain/statusPresentation';
+import { CAT_TIERS, DESERT_SCORE_FILTER_OPTIONS } from '../../domain/metrics';
 import { DataGapFilter, SidebarFilters } from './sidebarUtils';
 
 interface FilterControlsProps {
@@ -7,10 +9,10 @@ interface FilterControlsProps {
 
 const STATUS_OPTIONS = [
     { value: '', label: 'All statuses' },
-    { value: 'TELEHEALTH_READY', label: 'Ready' },
-    { value: 'COMMUNITY_ANCHOR', label: 'Anchor' },
-    { value: 'CRITICAL_GAP', label: 'Critical' },
-    { value: 'DATA_UNAVAILABLE', label: 'Unknown' },
+    ...BASE_TELEHEALTH_STATUSES.map(value => ({
+        value,
+        label: getTelehealthStatusLabel(value),
+    })),
 ];
 
 export default function FilterControls({ filters, onChange }: FilterControlsProps) {
@@ -20,13 +22,13 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 CAT tier
                 <select
                     value={filters.tier}
-                    onChange={(event) => onChange({ ...filters, tier: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        tier: event.target.value as SidebarFilters['tier'],
+                    })}
                 >
                     <option value="">All tiers</option>
-                    <option value="1">Tier 1</option>
-                    <option value="2">Tier 2</option>
-                    <option value="3">Tier 3</option>
-                    <option value="4">Tier 4</option>
+                    {CAT_TIERS.map(tier => <option key={tier} value={tier}>Tier {tier}</option>)}
                 </select>
             </label>
 
@@ -34,7 +36,10 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 Status
                 <select
                     value={filters.status}
-                    onChange={(event) => onChange({ ...filters, status: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        status: event.target.value as SidebarFilters['status'],
+                    })}
                 >
                     {STATUS_OPTIONS.map(option => (
                         <option key={option.value} value={option.value}>{option.label}</option>
@@ -46,13 +51,14 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 Desert score
                 <select
                     value={filters.desert}
-                    onChange={(event) => onChange({ ...filters, desert: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        desert: event.target.value as SidebarFilters['desert'],
+                    })}
                 >
-                    <option value="">All scores</option>
-                    <option value="70-plus">70+ severe need</option>
-                    <option value="50-plus">50+ high need</option>
-                    <option value="below-50">Below 50</option>
-                    <option value="unknown">Unknown score</option>
+                    {DESERT_SCORE_FILTER_OPTIONS.map(option => (
+                        <option key={option.value || 'all'} value={option.value}>{option.label}</option>
+                    ))}
                 </select>
             </label>
 

--- a/frontend/src/components/sidebar/QuickFilterChips.tsx
+++ b/frontend/src/components/sidebar/QuickFilterChips.tsx
@@ -1,0 +1,73 @@
+import type { SidebarFilters } from './sidebarUtils';
+
+interface QuickFilterChipsProps {
+    filters: SidebarFilters;
+    onChange: (filters: SidebarFilters) => void;
+}
+
+interface QuickFilter {
+    id: string;
+    label: string;
+    isActive: (filters: SidebarFilters) => boolean;
+    toggle: (filters: SidebarFilters) => SidebarFilters;
+}
+
+const QUICK_FILTERS: QuickFilter[] = [
+    {
+        id: 'critical',
+        label: 'Critical gaps',
+        isActive: filters => filters.status === 'CRITICAL_GAP',
+        toggle: filters => ({
+            ...filters,
+            status: filters.status === 'CRITICAL_GAP' ? '' : 'CRITICAL_GAP',
+        }),
+    },
+    {
+        id: 'desert',
+        label: 'High desert score',
+        isActive: filters => filters.desert === '75-plus',
+        toggle: filters => ({
+            ...filters,
+            desert: filters.desert === '75-plus' ? '' : '75-plus',
+        }),
+    },
+    {
+        id: 'incomplete',
+        label: 'Data incomplete',
+        isActive: filters => filters.dataGap === 'missing',
+        toggle: filters => ({
+            ...filters,
+            dataGap: filters.dataGap === 'missing' ? 'all' : 'missing',
+        }),
+    },
+    {
+        id: 'ready',
+        label: 'Telehealth ready',
+        isActive: filters => filters.status === 'TELEHEALTH_READY',
+        toggle: filters => ({
+            ...filters,
+            status: filters.status === 'TELEHEALTH_READY' ? '' : 'TELEHEALTH_READY',
+        }),
+    },
+];
+
+export default function QuickFilterChips({ filters, onChange }: QuickFilterChipsProps) {
+    return (
+        <div className="sidebar-quick-filters" aria-label="Quick filters">
+            {QUICK_FILTERS.map(filter => {
+                const active = filter.isActive(filters);
+                return (
+                    <button
+                        key={filter.id}
+                        type="button"
+                        className={`sidebar-filter-chip${active ? ' is-active' : ''}`}
+                        aria-pressed={active}
+                        onClick={() => onChange(filter.toggle(filters))}
+                    >
+                        {filter.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/sidebar/RegionCard.tsx
+++ b/frontend/src/components/sidebar/RegionCard.tsx
@@ -1,5 +1,12 @@
 import { RegionSummary } from '../../api/catApi';
-import { formatMissing, formatStatus, statusClassName } from './sidebarUtils';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
+import { getRegionSeverityClassName } from '../../domain/metrics';
+import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
+import {
+    formatMissing,
+    formatStatus,
+} from './sidebarUtils';
 
 interface RegionCardProps {
     region: RegionSummary;
@@ -28,7 +35,7 @@ export default function RegionCard({
 
     return (
         <article
-            className={`region-card ${selected ? 'selected' : ''}`}
+            className={`region-card ${getRegionSeverityClassName(region)} ${selected ? 'selected' : ''}`}
             data-testid="sidebar-result"
             data-region-code={region.region_code}
         >
@@ -41,30 +48,45 @@ export default function RegionCard({
                     <strong>{region.name}</strong>
                     <small>{region.region_code}</small>
                 </span>
-                <span className={`status-badge ${statusClassName(region.telehealth_status)}`}>
-                    {formatStatus(region.telehealth_status)}
-                </span>
+                <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)}>
+                    {getTelehealthStatusLabel(region.telehealth_status)}
+                </StatusBadge>
             </button>
 
             {showCatDetails && (
-                <div className="region-card-meta">
-                    <span>CAT {formatMissing(region.cat_tier)}</span>
-                    <span>Desert {desertScore}</span>
-                    <span>Confidence {formatStatus(region.data_confidence)}</span>
-                    <span>{region.has_data_gap ? 'Data incomplete' : 'Data complete'}</span>
+                <div className="region-card-metrics">
+                    <span className="region-card-metric" aria-label={`Desert score ${desertScore}`}>
+                        <small>Desert</small>
+                        <strong>{desertScore}</strong>
+                    </span>
+                    <span className="region-card-metric">
+                        <small>CAT tier</small>
+                        <strong>{formatMissing(region.cat_tier)}</strong>
+                    </span>
+                    <span
+                        className={`region-card-data-state${region.has_data_gap ? ' is-incomplete' : ''}`}
+                        aria-label={`${region.has_data_gap ? 'Data incomplete' : 'Data complete'}. ${formatStatus(region.data_confidence)} confidence`}
+                    >
+                        <i aria-hidden="true" />
+                        <span>
+                            {region.has_data_gap ? 'Incomplete' : 'Complete'}
+                            <small>{formatStatus(region.data_confidence)} confidence</small>
+                        </span>
+                    </span>
                 </div>
             )}
 
             {showPin && (
-                <button
-                    type="button"
+                <Button
+                    variant={pinned ? 'primary' : 'ghost'}
+                    size="small"
                     className={`pin-button ${pinned ? 'pinned' : ''}`}
                     aria-label={`${pinned ? 'Unpin' : 'Pin'} ${region.name}`}
                     disabled={!pinned && pinDisabled}
                     onClick={() => onTogglePin(region.region_code)}
                 >
                     {pinned ? 'Pinned' : 'Pin'}
-                </button>
+                </Button>
             )}
         </article>
     );

--- a/frontend/src/components/sidebar/SearchBar.tsx
+++ b/frontend/src/components/sidebar/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { KeyboardEvent, useMemo, useState } from 'react';
+import { KeyboardEvent, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { useRegionSearch } from '../../hooks/useRegionSearch';
-import { formatStatus, statusClassName } from './sidebarUtils';
+import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
+import StatusBadge from '../ui/StatusBadge';
 
 interface SearchBarProps {
     value: string;
@@ -11,9 +12,21 @@ interface SearchBarProps {
 
 export default function SearchBar({ value, onChange, onSelectRegion }: SearchBarProps) {
     const [isOpen, setIsOpen] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const listboxId = useId();
     const searchParams = useMemo(() => ({ q: value }), [value]);
     const { results } = useRegionSearch(searchParams);
     const dropdownResults = value.trim() ? results.slice(0, 8) : [];
+    const listboxOpen = isOpen && dropdownResults.length > 0;
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false);
+        };
+        document.addEventListener('pointerdown', handlePointerDown);
+        return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, [isOpen]);
 
     function selectRegion(region: RegionSummary) {
         onSelectRegion(region.region_code);
@@ -31,9 +44,13 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
     }
 
     return (
-        <div className="sidebar-search">
+        <div className="sidebar-search" ref={rootRef}>
             <input
+                role="combobox"
                 aria-label="Search communities"
+                aria-autocomplete="list"
+                aria-expanded={listboxOpen}
+                aria-controls={listboxId}
                 data-testid="community-search"
                 value={value}
                 onChange={(event) => {
@@ -45,13 +62,15 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
                 placeholder="Search communities"
                 className="sidebar-search-input"
             />
-            {isOpen && dropdownResults.length > 0 && (
-                <div className="sidebar-autocomplete" role="listbox">
+            {listboxOpen && (
+                <div className="sidebar-autocomplete" role="listbox" id={listboxId} aria-label="Community suggestions">
                     {dropdownResults.map(region => (
                         <button
                             key={region.region_code}
                             className="sidebar-autocomplete-row"
                             data-testid="sidebar-search-result"
+                            role="option"
+                            aria-selected="false"
                             onClick={() => selectRegion(region)}
                             type="button"
                         >
@@ -59,9 +78,9 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
                                 <strong>{region.name}</strong>
                                 <small>CAT {region.cat_tier ?? 'Unknown'}</small>
                             </span>
-                            <span className={`status-badge ${statusClassName(region.telehealth_status)}`}>
-                                {formatStatus(region.telehealth_status)}
-                            </span>
+                            <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)}>
+                                {getTelehealthStatusLabel(region.telehealth_status)}
+                            </StatusBadge>
                         </button>
                     ))}
                 </div>

--- a/frontend/src/components/sidebar/SelectedRegionPanel.test.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RegionSummary } from '../../api/catApi';
+import SelectedRegionPanel from './SelectedRegionPanel';
+
+vi.mock('../../hooks/useResearchProfile', () => ({
+    useResearchProfile: () => ({
+        profile: null,
+        loading: false,
+        error: null,
+    }),
+}));
+
+const region: RegionSummary = {
+    id: 1,
+    region_code: 'AK-BETHEL',
+    name: 'Bethel',
+    lat: 60.7922,
+    lon: -161.7558,
+    cat_tier: 3,
+    telehealth_status: 'COMMUNITY_ANCHOR',
+    desert_score: 55,
+    affordability_status: 'unaffordable',
+    data_confidence: 'medium',
+    has_data_gap: true,
+    region: 'Yukon-Kuskokwim',
+};
+
+function renderPanel(activeLayer: 'cat' | 'affordability') {
+    render(
+        <SelectedRegionPanel
+            region={region}
+            season="year_round"
+            activeLayer={activeLayer}
+            pinned={false}
+            pinDisabled={false}
+            onTogglePin={vi.fn()}
+        />,
+    );
+}
+
+describe('SelectedRegionPanel layer details', () => {
+    it('shows CAT-first details on the CAT layer', () => {
+        renderPanel('cat');
+
+        expect(screen.getByRole('heading', { name: 'CAT access' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Transport evidence' })).toBeInTheDocument();
+        expect(screen.getByText(/CAT details/)).toBeInTheDocument();
+        expect(screen.getByTestId('cat-region-summary')).toBeInTheDocument();
+        expect(screen.queryByTestId('affordability-region-summary')).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Affordability' })).not.toBeInTheDocument();
+        expect(screen.queryByText('Cost burden')).not.toBeInTheDocument();
+    });
+
+    it('shows affordability details on the affordability layer', () => {
+        renderPanel('affordability');
+
+        expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Connectivity' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Affordability' })).toBeInTheDocument();
+        expect(screen.getAllByText('Cost burden')).toHaveLength(2);
+        expect(screen.getByText(/Affordability details/)).toBeInTheDocument();
+        expect(screen.getByTestId('affordability-region-summary')).toBeInTheDocument();
+        expect(screen.queryByTestId('cat-region-summary')).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'CAT access' })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/sidebar/SelectedRegionPanel.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.tsx
@@ -1,17 +1,30 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { RegionSummary, Season } from '../../api/catApi';
+import type { BaseMapLayer } from '../../domain/mapMode';
 import type { ScenarioRegion } from '../../types/scenario';
 import { useResearchProfile } from '../../hooks/useResearchProfile';
 import { exportResearchProfileReport } from '../../utils/reportExport';
-import { formatMissing, formatStatus, statusClassName, telehealthNeedLabel } from './sidebarUtils';
+import {
+    getTelehealthStatusClassName,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+} from '../../domain/statusPresentation';
+import {
+    formatMissing,
+    formatStatus,
+    telehealthNeedLabel,
+} from './sidebarUtils';
 import { DATA_UNAVAILABLE, formatResearchValue } from '../../utils/formatResearchValue';
 import { ScenarioSidebarCard } from '../scenario/ScenarioLayer';
 import MetricTooltip from '../MetricTooltip';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
 
 interface SelectedRegionPanelProps {
     region: RegionSummary | null;
     season: Season;
     focusKey?: number;
+    activeLayer?: BaseMapLayer;
     pinned: boolean;
     pinDisabled: boolean;
     onTogglePin: (regionCode: string) => void;
@@ -22,6 +35,7 @@ export default function SelectedRegionPanel({
     region,
     season,
     focusKey = 0,
+    activeLayer = 'cat',
     pinned,
     pinDisabled,
     onTogglePin,
@@ -30,6 +44,7 @@ export default function SelectedRegionPanel({
     const { profile, loading, error } = useResearchProfile(region?.region_code ?? null, season);
     const panelRef = useRef<HTMLElement | null>(null);
     const [highlight, setHighlight] = useState(false);
+    const [actionStatus, setActionStatus] = useState<{ message: string; error: boolean } | null>(null);
 
     useEffect(() => {
         if (!region || focusKey === 0) return;
@@ -40,20 +55,135 @@ export default function SelectedRegionPanel({
     }, [focusKey, region]);
 
     if (!region) {
-        return null;
+        return (
+            <section className="selected-region-panel selected-region-empty">
+                <strong>Select a community</strong>
+                <span>Choose a result to inspect access, connectivity, and data quality.</span>
+            </section>
+        );
     }
 
     const handleDownloadReport = async () => {
         if (!profile) return;
-        await exportResearchProfileReport(
-            profile,
-            document.querySelector<HTMLElement>('.leaflet-container'),
-        );
+        try {
+            await exportResearchProfileReport(
+                profile,
+                document.querySelector<HTMLElement>('.leaflet-container'),
+            );
+            setActionStatus({ message: 'Report download started.', error: false });
+        } catch {
+            setActionStatus({ message: 'Report could not be generated.', error: true });
+        }
     };
 
     const handleCopyShareLink = async () => {
-        await navigator.clipboard?.writeText(window.location.href);
+        try {
+            if (!navigator.clipboard) throw new Error('Clipboard unavailable');
+            await navigator.clipboard.writeText(window.location.href);
+            setActionStatus({ message: 'Share link copied.', error: false });
+        } catch {
+            setActionStatus({ message: 'Share link could not be copied.', error: true });
+        }
     };
+
+    const profileFallback = loading
+        ? 'Loading…'
+        : error
+            ? 'Details unavailable'
+            : DATA_UNAVAILABLE;
+    const catDetailSections = (
+        <>
+            <DetailSection title="CAT access">
+                <DetailRow
+                    label={<>CAT tier<MetricTooltip term="CAT Tier">Transport access category. Higher tiers indicate more limited or fragile access.</MetricTooltip></>}
+                    value={formatMissing(region.cat_tier)}
+                />
+                <DetailRow
+                    label={<>Healthcare desert score<MetricTooltip term="Healthcare Desert Score">Higher scores mean greater need for telehealth due to healthcare access barriers.</MetricTooltip></>}
+                    value={formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}
+                />
+                <DetailRow
+                    label={<>Telehealth need<MetricTooltip term="Telehealth Need">Interprets healthcare desert score: below 25 adequate, 25-49 moderate, 50-74 high, and 75-100 critical.</MetricTooltip></>}
+                    value={telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}
+                />
+                <DetailRow label="Region" value={formatMissing(region.region)} />
+                <DetailRow label="Season" value={profile?.telehealth.season_note ?? formatStatus(season)} />
+            </DetailSection>
+
+            <DetailSection title="Transport evidence">
+                <DetailRow
+                    label={<>Telehealth status<MetricTooltip term="Telehealth Status">Combines affordability and clinic access into a practical access label.</MetricTooltip></>}
+                    value={<span className={`status-text ${getTelehealthStatusClassName(region.telehealth_status)}`}>{getTelehealthStatusLabel(region.telehealth_status)}</span>}
+                />
+                <DetailRow label="Nearest care" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_name) : profileFallback} />
+                <DetailRow label="Facility distance" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Data confidence">
+                <DetailRow
+                    label={<>Confidence<MetricTooltip term="Data Confidence">Confidence describes whether supporting coverage data is strong, weak, or missing.</MetricTooltip></>}
+                    value={formatStatus(region.data_confidence)}
+                />
+                <DetailRow
+                    label={<>Coverage<MetricTooltip term="Data Incomplete">Some required coverage, speed, affordability, or access evidence is missing.</MetricTooltip></>}
+                    value={region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}
+                />
+            </DetailSection>
+        </>
+    );
+    const telehealthDetailSections = (
+        <>
+            <DetailSection title="Access">
+                <DetailRow
+                    label={<>CAT tier<MetricTooltip term="CAT Tier">Transport access category. Higher tiers indicate more limited or fragile access.</MetricTooltip></>}
+                    value={formatMissing(region.cat_tier)}
+                />
+                <DetailRow
+                    label={<>Telehealth<MetricTooltip term="Telehealth Status">Combines affordability and clinic access into a practical access label.</MetricTooltip></>}
+                    value={<span className={`status-text ${getTelehealthStatusClassName(region.telehealth_status)}`}>{getTelehealthStatusLabel(region.telehealth_status)}</span>}
+                />
+                <DetailRow
+                    label={<>Telehealth need<MetricTooltip term="Telehealth Need">Interprets healthcare desert score: below 25 adequate, 25-49 moderate, 50-74 high, and 75-100 critical.</MetricTooltip></>}
+                    value={telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}
+                />
+                <DetailRow label="Region" value={formatMissing(region.region)} />
+            </DetailSection>
+
+            <DetailSection title="Connectivity">
+                <DetailRow label="Download speed" value={profile ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 }) : profileFallback} />
+                <DetailRow label="Upload speed" value={profile ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 }) : profileFallback} />
+                <DetailRow label="Latency" value={profile ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Affordability">
+                <DetailRow
+                    label={<>Status<MetricTooltip term="Affordability Burden">Whether monthly internet cost is affordable relative to income data.</MetricTooltip></>}
+                    value={formatStatus(profile?.affordability.status ?? region.affordability_status)}
+                />
+                <DetailRow label="Cost burden" value={profile ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Healthcare">
+                <DetailRow
+                    label={<>Desert score<MetricTooltip term="Healthcare Desert Score">Higher scores mean greater need for telehealth due to healthcare access barriers.</MetricTooltip></>}
+                    value={formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}
+                />
+                <DetailRow label="Nearest care" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_name) : profileFallback} />
+                <DetailRow label="Facility distance" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Data confidence">
+                <DetailRow
+                    label={<>Confidence<MetricTooltip term="Data Confidence">Confidence describes whether supporting coverage data is strong, weak, or missing.</MetricTooltip></>}
+                    value={formatStatus(region.data_confidence)}
+                />
+                <DetailRow
+                    label={<>Coverage<MetricTooltip term="Data Incomplete">Some required coverage, speed, affordability, or access evidence is missing.</MetricTooltip></>}
+                    value={region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}
+                />
+            </DetailSection>
+        </>
+    );
 
     return (
         <section
@@ -63,155 +193,101 @@ export default function SelectedRegionPanel({
             <div className="selected-region-header">
                 <div>
                     <h2>{region.name}</h2>
-                    <small>{region.region_code}</small>
+                    <small>{region.region_code} · {activeLayer === 'cat' ? 'CAT details' : activeLayer === 'affordability' ? 'Affordability details' : 'Gap Hunter details'}</small>
                 </div>
-                <button
-                    type="button"
-                    className={`pin-button ${pinned ? 'pinned' : ''}`}
+                <Button
+                    variant={pinned ? 'primary' : 'secondary'}
+                    size="small"
+                    className="selected-region-pin"
                     aria-label={`${pinned ? 'Unpin' : 'Pin'} ${region.name}`}
                     disabled={!pinned && pinDisabled}
                     onClick={() => onTogglePin(region.region_code)}
                 >
                     {pinned ? 'Pinned' : 'Pin'}
-                </button>
+                </Button>
             </div>
 
+            {activeLayer !== 'affordability' ? (
+                <div className="selected-region-summary" data-testid="cat-region-summary">
+                    <StatusBadge tone="neutral" showDot>
+                        CAT tier {formatMissing(region.cat_tier)}
+                    </StatusBadge>
+                    <span><small>Desert score</small><strong>{formatResearchValue(region.desert_score, { digits: 1 })}</strong></span>
+                    <span><small>Region</small><strong>{formatMissing(region.region)}</strong></span>
+                </div>
+            ) : (
+                <div className="selected-region-summary" data-testid="affordability-region-summary">
+                    <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)} showDot>
+                        {getTelehealthStatusLabel(region.telehealth_status)}
+                    </StatusBadge>
+                    <span><small>Affordability</small><strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong></span>
+                    <span><small>Cost burden</small><strong>{profile ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) : profileFallback}</strong></span>
+                </div>
+            )}
+
             <div className="selected-region-actions">
-                <button
-                    type="button"
-                    className="sidebar-action-button"
+                <Button
+                    variant="primary"
+                    size="small"
                     data-testid="download-report"
                     disabled={loading || !profile}
                     onClick={handleDownloadReport}
                     aria-label={`Download report for ${region.name}`}
                 >
                     Download Report
-                </button>
-                <button
-                    type="button"
-                    className="sidebar-action-button"
+                </Button>
+                <Button
+                    variant="secondary"
+                    size="small"
                     data-testid="copy-share-link"
                     onClick={handleCopyShareLink}
                     aria-label={`Copy share link for ${region.name}`}
                 >
                     Copy Share Link
-                </button>
+                </Button>
             </div>
 
-            {error && <div className="selected-region-note error">{error}</div>}
+            {actionStatus && (
+                <div
+                    className={`selected-region-action-status${actionStatus.error ? ' is-error' : ''}`}
+                    role={actionStatus.error ? 'alert' : 'status'}
+                >
+                    {actionStatus.message}
+                </div>
+            )}
+
+            {loading && <div className="selected-region-note" role="status">Loading community details…</div>}
+            {error && <div className="selected-region-note error" role="alert">Community details unavailable: {error}</div>}
             {profile?.region?.has_data_gap && (
-                <div className="selected-region-note">
+                <div className="selected-region-note" role="status">
                     {profile.region?.data_confidence ?? DATA_UNAVAILABLE} confidence · {profile.region?.missing_fields?.length ?? 0} data gaps
                 </div>
             )}
 
-            <div className="selected-detail-grid">
-                <span>
-                    CAT tier
-                    <MetricTooltip term="CAT Tier">
-                        Transport access category. Higher tiers indicate more limited or fragile access.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatMissing(region.cat_tier)}</strong>
-
-                <span>
-                    Telehealth
-                    <MetricTooltip term="Telehealth Status">
-                        Combines affordability and clinic access into a practical access label.
-                    </MetricTooltip>
-                </span>
-                <strong className={`status-text ${statusClassName(region.telehealth_status)}`}>
-                    {formatStatus(region.telehealth_status)}
-                </strong>
-
-                <span>
-                    Desert score
-                    <MetricTooltip term="Healthcare Desert Score">
-                        Higher scores mean greater need for telehealth due to healthcare access barriers.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}</strong>
-
-                <span>
-                    Telehealth need
-                    <MetricTooltip term="Telehealth Need">
-                        Interprets healthcare desert score: 0-30 low, 31-60 moderate, 61-80 high, and 81-100 critical.
-                    </MetricTooltip>
-                </span>
-                <strong>{telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}</strong>
-
-                <span>
-                    Affordability
-                    <MetricTooltip term="Affordability Burden">
-                        Whether monthly internet cost is affordable relative to income data.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong>
-
-                <span>
-                    Data confidence
-                    <MetricTooltip term="Data Confidence">
-                        Confidence describes whether supporting coverage data is strong, weak, or missing.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatStatus(region.data_confidence)}</strong>
-
-                <span>
-                    Data gap
-                    <MetricTooltip term="Data Incomplete">
-                        Some required coverage, speed, affordability, or access evidence is missing.
-                    </MetricTooltip>
-                </span>
-                <strong>{region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}</strong>
-
-                <span>Region</span>
-                <strong>{formatMissing(region.region)}</strong>
-
-                <span>Download speed</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Upload speed</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Latency</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Cost burden</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Nearest care</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.healthcare.nearest_facility_name)
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Facility distance</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
+            <div className="selected-region-detail-sections">
+                {activeLayer === 'affordability' ? telehealthDetailSections : catDetailSections}
             </div>
 
             {/* Scenario Sidebar Card */}
             <ScenarioSidebarCard region={scenarioRegion} />
         </section>
+    );
+}
+
+function DetailSection({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <section className="selected-detail-section">
+            <h3>{title}</h3>
+            <div className="selected-detail-grid">{children}</div>
+        </section>
+    );
+}
+
+function DetailRow({ label, value }: { label: ReactNode; value: ReactNode }) {
+    return (
+        <>
+            <span>{label}</span>
+            <strong>{value}</strong>
+        </>
     );
 }

--- a/frontend/src/components/sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/sidebar/Sidebar.test.tsx
@@ -132,8 +132,27 @@ describe('Sidebar discovery', () => {
         expect(screen.getByText('Eareckson')).toBeInTheDocument();
         expect(screen.getByText('Missing Data')).toBeInTheDocument();
         expect(screen.getAllByText('Data incomplete').length).toBeGreaterThan(0);
-        expect(screen.getAllByText('Confidence Missing').length).toBeGreaterThan(0);
-        expect(screen.getByText('Desert Unknown')).toBeInTheDocument();
+        expect(screen.getAllByLabelText(/Data incomplete\. Missing confidence/i).length).toBeGreaterThan(0);
+        expect(screen.getByLabelText('Desert score Unknown')).toBeInTheDocument();
+    });
+
+    it('keeps quick filters synchronized with the existing filter controls', () => {
+        renderSidebar();
+
+        const critical = screen.getByRole('button', { name: 'Critical gaps' });
+        fireEvent.click(critical);
+
+        expect(critical).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByLabelText(/^Status$/i)).toHaveValue('CRITICAL_GAP');
+        expect(resultCodes()).toEqual(['AK-EARECKSON']);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Data incomplete' }));
+        expect(screen.getByLabelText(/^Data gaps$/i)).toHaveValue('missing');
+        expect(resultCodes()).toEqual(['AK-EARECKSON']);
+
+        fireEvent.click(critical);
+        expect(screen.getByLabelText(/^Status$/i)).toHaveValue('');
+        expect(resultCodes()).toEqual(['AK-BETHEL', 'AK-EARECKSON', 'AK-MISSING']);
     });
 
     it('filters by CAT tier', async () => {
@@ -167,7 +186,7 @@ describe('Sidebar discovery', () => {
     it('filters by healthcare desert score', async () => {
         renderSidebar();
 
-        fireEvent.change(screen.getByLabelText(/Desert score/i), { target: { value: '70-plus' } });
+        fireEvent.change(screen.getByLabelText(/^Desert score$/i), { target: { value: '75-plus' } });
 
         expect(screen.getByText('Eareckson')).toBeInTheDocument();
         expect(screen.queryByText('Bethel')).not.toBeInTheDocument();

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,12 +1,22 @@
-import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { Season } from '../../api/catApi';
+import type { BaseMapLayer } from '../../domain/mapMode';
 import type { ScenarioRegion } from '../../types/scenario';
 import FilterControls from './FilterControls';
 import RegionList from './RegionList';
 import SearchBar from './SearchBar';
 import SelectedRegionPanel from './SelectedRegionPanel';
 import SortControls from './SortControls';
+import QuickFilterChips from './QuickFilterChips';
+import Button from '../ui/Button';
 import {
     filterRegions,
     RegionSortMode,
@@ -22,7 +32,7 @@ interface SidebarProps {
     selectedRegionCode: string | null;
     detailsFocusKey?: number;
     season?: Season;
-    activeLayer?: 'cat' | 'affordability' | 'gap';
+    activeLayer?: BaseMapLayer;
     pinnedRegionCodes?: string[];
     maxPinnedRegions?: number;
     scenarioRegion?: ScenarioRegion;
@@ -61,6 +71,7 @@ export default function Sidebar({
     const [query, setQuery] = useState('');
     const [filters, setFilters] = useState<SidebarFilters>(DEFAULT_FILTERS);
     const [sortMode, setSortMode] = useState<RegionSortMode>('name');
+    const [filtersOpen, setFiltersOpen] = useState(false);
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(360);
     const activePinnedRegionCodes = pinnedRegionCodes ?? [];
@@ -68,6 +79,9 @@ export default function Sidebar({
     const activeTogglePin = onTogglePin ?? (() => {});
     const activeIsPinned = isPinned ?? (() => false);
     const showCatTools = activeLayer === 'cat';
+    const activeFilterCount = [filters.tier, filters.status, filters.desert]
+        .filter(Boolean).length + (filters.dataGap === 'all' ? 0 : 1);
+    const hasActiveControls = Boolean(query) || activeFilterCount > 0 || sortMode !== 'name';
 
     const selectedRegion = useMemo(
         () => regions.find(region => region.region_code === selectedRegionCode) ?? null,
@@ -118,6 +132,21 @@ export default function Sidebar({
         document.addEventListener('mouseup', handleUp);
     }, [sidebarWidth]);
 
+    const resizeWithKeyboard = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+        event.preventDefault();
+        if (event.key === 'Home') {
+            setSidebarWidth(MIN_SIDEBAR_WIDTH);
+            return;
+        }
+        if (event.key === 'End') {
+            setSidebarWidth(MAX_SIDEBAR_WIDTH);
+            return;
+        }
+        const delta = event.key === 'ArrowRight' ? 16 : -16;
+        setSidebarWidth(width => Math.min(Math.max(width + delta, MIN_SIDEBAR_WIDTH), MAX_SIDEBAR_WIDTH));
+    }, []);
+
     if (isCollapsed) {
         return (
             <aside
@@ -125,14 +154,13 @@ export default function Sidebar({
                 style={{ width: 56, minWidth: 56 }}
                 aria-label="Collapsed community sidebar"
             >
-                <button
-                    type="button"
-                    className="sidebar-collapse-button"
+                <Button
+                    size="small"
                     onClick={() => setIsCollapsed(false)}
                     aria-label="Expand community sidebar"
                 >
                     Open
-                </button>
+                </Button>
                 <div className="sidebar-collapsed-label">Communities</div>
             </aside>
         );
@@ -149,22 +177,14 @@ export default function Sidebar({
                     <p>{loading ? 'Loading...' : `${visibleRegions.length} of ${regions.length}`}</p>
                 </div>
                 <div className="sidebar-header-actions">
-                    <button
-                        type="button"
-                        className="sidebar-action-button"
-                        onClick={resetSidebarControls}
-                        aria-label="Reset sidebar filters"
-                    >
-                        Reset
-                    </button>
-                    <button
-                        type="button"
-                        className="sidebar-collapse-button"
+                    <Button
+                        variant="ghost"
+                        size="small"
                         onClick={() => setIsCollapsed(true)}
                         aria-label="Collapse community sidebar"
                     >
                         Hide
-                    </button>
+                    </Button>
                 </div>
             </header>
 
@@ -176,8 +196,40 @@ export default function Sidebar({
 
             {showCatTools && (
                 <>
-                    <FilterControls filters={filters} onChange={setFilters} />
-                    <SortControls value={sortMode} onChange={setSortMode} />
+                    <QuickFilterChips filters={filters} onChange={setFilters} />
+                    <section className="sidebar-control-panel" aria-label="Community controls">
+                        <div className="sidebar-control-panel__header">
+                            <button
+                                type="button"
+                                className="sidebar-control-panel__toggle"
+                                aria-expanded={filtersOpen}
+                                aria-controls="sidebar-filter-controls"
+                                onClick={() => setFiltersOpen(value => !value)}
+                            >
+                                Filters &amp; sort
+                                {activeFilterCount > 0 && (
+                                    <span>{activeFilterCount} active</span>
+                                )}
+                            </button>
+                            <Button
+                                variant="ghost"
+                                size="small"
+                                onClick={resetSidebarControls}
+                                disabled={!hasActiveControls}
+                                aria-label="Reset sidebar filters"
+                            >
+                                Reset
+                            </Button>
+                        </div>
+                        <div
+                            id="sidebar-filter-controls"
+                            className="sidebar-control-panel__body"
+                            hidden={!filtersOpen}
+                        >
+                            <FilterControls filters={filters} onChange={setFilters} />
+                            <SortControls value={sortMode} onChange={setSortMode} />
+                        </div>
+                    </section>
                 </>
             )}
 
@@ -205,6 +257,7 @@ export default function Sidebar({
                 region={selectedRegion}
                 season={season}
                 focusKey={detailsFocusKey}
+                activeLayer={activeLayer}
                 pinned={selectedRegion ? activeIsPinned(selectedRegion.region_code) : false}
                 pinDisabled={activePinnedRegionCodes.length >= activeMaxPinnedRegions}
                 onTogglePin={activeTogglePin}
@@ -231,9 +284,15 @@ export default function Sidebar({
             <div
                 className="sidebar-resize-handle"
                 role="separator"
+                tabIndex={0}
                 aria-orientation="vertical"
                 aria-label="Resize community sidebar"
+                aria-valuemin={MIN_SIDEBAR_WIDTH}
+                aria-valuemax={MAX_SIDEBAR_WIDTH}
+                aria-valuenow={sidebarWidth}
+                aria-valuetext={`${sidebarWidth} pixels`}
                 onMouseDown={startResize}
+                onKeyDown={resizeWithKeyboard}
             />
         </aside>
     );

--- a/frontend/src/components/sidebar/sidebarUtils.ts
+++ b/frontend/src/components/sidebar/sidebarUtils.ts
@@ -1,12 +1,18 @@
-import { RegionSummary } from '../../api/catApi';
+import type { RegionSummary, TelehealthStatusName } from '../../api/catApi';
+import {
+    getDesertScorePresentation,
+    matchesDesertScoreFilter,
+    type CatTier,
+    type DesertScoreFilter,
+} from '../../domain/metrics';
 
 export type RegionSortMode = 'name' | 'tier' | 'desert';
 export type DataGapFilter = 'all' | 'missing' | 'complete';
 
 export interface SidebarFilters {
-    tier: string;
-    status: string;
-    desert: string;
+    tier: '' | `${CatTier}`;
+    status: '' | TelehealthStatusName;
+    desert: DesertScoreFilter;
     dataGap: DataGapFilter;
 }
 
@@ -28,22 +34,11 @@ export function formatStatus(status: string | null | undefined, fallback = 'Unkn
         .join(' ');
 }
 
-export function statusClassName(status: string | null | undefined) {
-    const normalized = (status || '').toLowerCase();
-    if (normalized.includes('ready')) return 'status-ready';
-    if (normalized.includes('anchor')) return 'status-anchor';
-    if (normalized.includes('critical')) return 'status-critical';
-    return 'status-unknown';
-}
-
 export function telehealthNeedLabel(score: number | null | undefined): string {
     if (score === null || score === undefined || !Number.isFinite(score)) {
         return 'Data unavailable';
     }
-    if (score <= 30) return `Low Need (${score.toFixed(1)})`;
-    if (score <= 60) return `Moderate Need (${score.toFixed(1)})`;
-    if (score <= 80) return `High Need (${score.toFixed(1)})`;
-    return `Critical Need (${score.toFixed(1)})`;
+    return `${getDesertScorePresentation(score).label} (${score.toFixed(1)})`;
 }
 
 export function sortRegions(regions: RegionSummary[], sortMode: RegionSortMode) {
@@ -85,19 +80,7 @@ export function filterRegions(
             return false;
         }
 
-        if (filters.desert === '70-plus' && (region.desert_score ?? -1) < 70) {
-            return false;
-        }
-
-        if (filters.desert === '50-plus' && (region.desert_score ?? -1) < 50) {
-            return false;
-        }
-
-        if (filters.desert === 'below-50' && (region.desert_score === null || region.desert_score === undefined || region.desert_score >= 50)) {
-            return false;
-        }
-
-        if (filters.desert === 'unknown' && region.desert_score !== null && region.desert_score !== undefined) {
+        if (!matchesDesertScoreFilter(region.desert_score, filters.desert)) {
             return false;
         }
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'small' | 'default';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    leadingIcon?: ReactNode;
+    trailingIcon?: ReactNode;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
+    variant = 'secondary',
+    size = 'default',
+    leadingIcon,
+    trailingIcon,
+    className = '',
+    children,
+    type = 'button',
+    ...props
+}, ref) {
+    const classes = ['ui-button', `ui-button--${variant}`, `ui-button--${size}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button ref={ref} type={type} className={classes} {...props}>
+            {leadingIcon && <span className="ui-button__icon" aria-hidden="true">{leadingIcon}</span>}
+            <span className="ui-button__label">{children}</span>
+            {trailingIcon && <span className="ui-button__icon" aria-hidden="true">{trailingIcon}</span>}
+        </button>
+    );
+});
+
+export default Button;

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import type { ButtonSize, ButtonVariant } from './Button';
+import './ui.css';
+
+export interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
+    'aria-label': string;
+    icon: ReactNode;
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+}
+
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
+    'aria-label': ariaLabel,
+    icon,
+    variant = 'ghost',
+    size = 'default',
+    className = '',
+    type = 'button',
+    ...props
+}, ref) {
+    const classes = ['ui-icon-button', `ui-button--${variant}`, `ui-icon-button--${size}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button
+            ref={ref}
+            type={type}
+            className={classes}
+            aria-label={ariaLabel}
+            {...props}
+        >
+            <span className="ui-icon-button__icon" aria-hidden="true">{icon}</span>
+        </button>
+    );
+});
+
+export default IconButton;

--- a/frontend/src/components/ui/MetricCard.tsx
+++ b/frontend/src/components/ui/MetricCard.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type MetricTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+
+export interface MetricCardProps extends HTMLAttributes<HTMLElement> {
+    label: string;
+    value: ReactNode;
+    supportingText?: ReactNode;
+    tone?: MetricTone;
+}
+
+const MetricCard = forwardRef<HTMLElement, MetricCardProps>(function MetricCard({
+    label,
+    value,
+    supportingText,
+    tone = 'neutral',
+    className = '',
+    ...props
+}, ref) {
+    const classes = ['ui-metric-card', `ui-metric-card--${tone}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <article ref={ref} className={classes} {...props}>
+            <span className="ui-metric-card__label">{label}</span>
+            <strong className="ui-metric-card__value">{value}</strong>
+            {supportingText && (
+                <span className="ui-metric-card__supporting-text">{supportingText}</span>
+            )}
+        </article>
+    );
+});
+
+export default MetricCard;

--- a/frontend/src/components/ui/Panel.tsx
+++ b/frontend/src/components/ui/Panel.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import './ui.css';
+
+export type PanelPadding = 'none' | 'small' | 'default';
+
+export interface PanelProps extends HTMLAttributes<HTMLDivElement> {
+    padding?: PanelPadding;
+    elevated?: boolean;
+}
+
+const Panel = forwardRef<HTMLDivElement, PanelProps>(function Panel({
+    padding = 'default',
+    elevated = false,
+    className = '',
+    ...props
+}, ref) {
+    const classes = [
+        'ui-panel',
+        `ui-panel--padding-${padding}`,
+        elevated ? 'ui-panel--elevated' : '',
+        className,
+    ].filter(Boolean).join(' ');
+
+    return <div ref={ref} className={classes} {...props} />;
+});
+
+export default Panel;

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type StatusTone = 'neutral' | 'ready' | 'anchor' | 'limited' | 'critical' | 'info';
+
+export interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+    children: ReactNode;
+    tone?: StatusTone;
+    showDot?: boolean;
+}
+
+const StatusBadge = forwardRef<HTMLSpanElement, StatusBadgeProps>(function StatusBadge({
+    children,
+    tone = 'neutral',
+    showDot = false,
+    className = '',
+    ...props
+}, ref) {
+    const classes = ['ui-status-badge', `ui-status-badge--${tone}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <span ref={ref} className={classes} {...props}>
+            {showDot && <span className="ui-status-badge__dot" aria-hidden="true" />}
+            {children}
+        </span>
+    );
+});
+
+export default StatusBadge;

--- a/frontend/src/components/ui/ui.css
+++ b/frontend/src/components/ui/ui.css
@@ -1,0 +1,263 @@
+.ui-button,
+.ui-icon-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow: var(--shadow-xs);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.ui-button:hover:not(:disabled),
+.ui-icon-button:hover:not(:disabled) {
+  box-shadow: var(--shadow-sm);
+}
+
+.ui-button:focus-visible,
+.ui-icon-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring), var(--shadow-xs);
+}
+
+.ui-button:disabled,
+.ui-icon-button:disabled {
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.ui-button--primary {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+}
+
+.ui-button--primary:hover:not(:disabled) {
+  border-color: var(--color-primary-hover);
+  background: var(--color-primary-hover);
+}
+
+.ui-button--primary:active:not(:disabled) {
+  border-color: var(--color-primary-active);
+  background: var(--color-primary-active);
+}
+
+.ui-button--secondary {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.ui-button--secondary:hover:not(:disabled) {
+  border-color: #94a3b8;
+  background: var(--color-surface-subtle);
+}
+
+.ui-button--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  box-shadow: none;
+}
+
+.ui-button--ghost:hover:not(:disabled) {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+.ui-button--danger {
+  border-color: var(--color-danger);
+  background: var(--color-danger);
+  color: var(--color-text-inverse);
+}
+
+.ui-button--danger:hover:not(:disabled) {
+  border-color: var(--color-danger-hover);
+  background: var(--color-danger-hover);
+}
+
+.ui-button {
+  gap: var(--spacing-2);
+  min-width: max-content;
+}
+
+.ui-button--small {
+  min-height: var(--control-height-sm);
+  padding: 0 var(--spacing-3);
+  font-size: var(--font-xs);
+}
+
+.ui-button--default {
+  min-height: var(--control-height);
+  padding: 0 var(--spacing-4);
+  font-size: var(--font-sm);
+}
+
+.ui-button__icon,
+.ui-icon-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+}
+
+.ui-button__icon > svg,
+.ui-icon-button__icon > svg {
+  width: 100%;
+  height: 100%;
+  stroke-width: 2;
+}
+
+.ui-icon-button {
+  padding: 0;
+}
+
+.ui-icon-button--small {
+  width: var(--control-icon-size-sm);
+  height: var(--control-icon-size-sm);
+  font-size: var(--font-sm);
+}
+
+.ui-icon-button--default {
+  width: var(--control-icon-size);
+  height: var(--control-icon-size);
+  font-size: var(--font-base);
+}
+
+.ui-panel {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-xs);
+}
+
+.ui-panel--padding-none {
+  padding: 0;
+}
+
+.ui-panel--padding-small {
+  padding: var(--spacing-3);
+}
+
+.ui-panel--padding-default {
+  padding: var(--spacing-4);
+}
+
+.ui-panel--elevated {
+  box-shadow: var(--shadow-md);
+}
+
+.ui-metric-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  border: 1px solid var(--color-border);
+  border-top: 3px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-xs);
+}
+
+.ui-metric-card--success {
+  border-top-color: var(--color-status-ready);
+}
+
+.ui-metric-card--warning {
+  border-top-color: var(--color-status-anchor);
+}
+
+.ui-metric-card--danger {
+  border-top-color: var(--color-status-gap);
+}
+
+.ui-metric-card--info {
+  border-top-color: var(--color-status-info);
+}
+
+.ui-metric-card__label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.ui-metric-card__value {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+}
+
+.ui-metric-card__supporting-text {
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+}
+
+.ui-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  width: fit-content;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-status-unknown-subtle);
+  color: var(--color-status-unknown);
+  padding: 0.1875rem var(--spacing-2);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.ui-status-badge--ready {
+  border-color: #bbf7d0;
+  background: var(--color-status-ready-subtle);
+  color: var(--color-status-ready);
+}
+
+.ui-status-badge--anchor {
+  border-color: #fde68a;
+  background: var(--color-status-anchor-subtle);
+  color: var(--color-status-anchor);
+}
+
+.ui-status-badge--limited {
+  border-color: #ddd6fe;
+  background: var(--color-status-limited-subtle);
+  color: var(--color-status-limited);
+}
+
+.ui-status-badge--critical {
+  border-color: #fecaca;
+  background: var(--color-status-gap-subtle);
+  color: var(--color-status-gap);
+}
+
+.ui-status-badge--info {
+  border-color: #bae6fd;
+  background: var(--color-status-info-subtle);
+  color: var(--color-status-info);
+}
+
+.ui-status-badge__dot {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: var(--radius-full);
+  background: currentColor;
+}

--- a/frontend/src/domain/domainPresentation.test.ts
+++ b/frontend/src/domain/domainPresentation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DESERT_SCORE_THRESHOLDS,
+    getDataGapPresentation,
+    getDesertScorePresentation,
+    matchesDesertScoreFilter,
+} from './metrics';
+import {
+    getTelehealthStatusColor,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+} from './statusPresentation';
+
+describe('desert score presentation', () => {
+    it.each([
+        [0, 'adequate', 'Adequate Need'],
+        [DESERT_SCORE_THRESHOLDS.moderate - 0.1, 'adequate', 'Adequate Need'],
+        [DESERT_SCORE_THRESHOLDS.moderate, 'moderate', 'Moderate Need'],
+        [DESERT_SCORE_THRESHOLDS.high, 'high', 'High Need'],
+        [DESERT_SCORE_THRESHOLDS.critical, 'critical', 'Critical Need'],
+        [100, 'critical', 'Critical Need'],
+    ])('classifies %s as %s', (score, level, label) => {
+        expect(getDesertScorePresentation(score)).toMatchObject({ level, label });
+    });
+
+    it('uses the same thresholds for sidebar score filters', () => {
+        expect(matchesDesertScoreFilter(75, '75-plus')).toBe(true);
+        expect(matchesDesertScoreFilter(74.9, '75-plus')).toBe(false);
+        expect(matchesDesertScoreFilter(50, '50-plus')).toBe(true);
+        expect(matchesDesertScoreFilter(49.9, 'below-50')).toBe(true);
+        expect(matchesDesertScoreFilter(null, 'unknown')).toBe(true);
+    });
+});
+
+describe('status presentation', () => {
+    it('provides one label, color, and tone for each shared status', () => {
+        expect(getTelehealthStatusLabel('COMMUNITY_ANCHOR')).toBe('Community Anchor');
+        expect(getTelehealthStatusColor('CRITICAL_GAP')).toBe('#ef4444');
+        expect(getTelehealthStatusColor('COMMUNITY_ANCHOR', 'scenario')).toBe('#f97316');
+        expect(getTelehealthStatusTone('LIMITED_TELEHEALTH')).toBe('limited');
+    });
+
+    it('names satellite dependency as connectivity, not affordability', () => {
+        expect(getDataGapPresentation('SATELLITE_DEPENDENT').label).toBe('Satellite-dependent access');
+    });
+});

--- a/frontend/src/domain/mapMode.ts
+++ b/frontend/src/domain/mapMode.ts
@@ -1,0 +1,27 @@
+export type BaseMapLayer = 'cat' | 'gap' | 'affordability';
+
+export type MapMode =
+    | { type: 'cat' }
+    | { type: 'gapHunter' }
+    | { type: 'telehealthAccess' }
+    | { type: 'scenario' };
+
+export const CAT_MAP_MODE: MapMode = { type: 'cat' };
+
+export function mapModeFromLayer(layer: BaseMapLayer): MapMode {
+    switch (layer) {
+        case 'gap': return { type: 'gapHunter' };
+        case 'affordability': return { type: 'telehealthAccess' };
+        case 'cat': return CAT_MAP_MODE;
+    }
+}
+
+export function baseLayerForMapMode(mode: MapMode): BaseMapLayer {
+    switch (mode.type) {
+        case 'gapHunter': return 'gap';
+        case 'telehealthAccess': return 'affordability';
+        case 'cat':
+        case 'scenario':
+            return 'cat';
+    }
+}

--- a/frontend/src/domain/metrics.ts
+++ b/frontend/src/domain/metrics.ts
@@ -1,0 +1,171 @@
+import type { StatusTone } from '../components/ui/StatusBadge';
+import type { TelehealthStatusName } from './statusPresentation';
+
+export type CatTier = 1 | 2 | 3 | 4;
+
+interface CatTierPresentation {
+    label: string;
+    shortDescription: string;
+    color: string;
+    tone: StatusTone;
+}
+
+export const CAT_TIER_PRESENTATION: Record<CatTier, CatTierPresentation> = {
+    1: {
+        label: 'Full Multimodal Access',
+        shortDescription: 'strongest access; road-connected or easier service reach.',
+        color: '#22c55e',
+        tone: 'ready',
+    },
+    2: {
+        label: 'Dual Mode Access',
+        shortDescription: 'moderate access; some travel or logistics constraints.',
+        color: '#eab308',
+        tone: 'info',
+    },
+    3: {
+        label: 'Limited Access',
+        shortDescription: 'limited access; remote travel makes care harder to reach.',
+        color: '#f97316',
+        tone: 'anchor',
+    },
+    4: {
+        label: 'Extreme/No Direct Access',
+        shortDescription: 'most isolated; highest transport and service-access barriers.',
+        color: '#ef4444',
+        tone: 'critical',
+    },
+};
+
+export const CAT_TIERS = [1, 2, 3, 4] as const;
+
+export interface DesertScorePresentation {
+    level: 'adequate' | 'moderate' | 'high' | 'critical';
+    label: string;
+    color: string;
+    tone: StatusTone;
+    description: string;
+}
+
+export const DESERT_SCORE_THRESHOLDS = {
+    moderate: 25,
+    high: 50,
+    critical: 75,
+} as const;
+
+const REGION_CARD_SEVERITY_THRESHOLDS = {
+    warning: 60,
+    critical: 80,
+} as const;
+
+export function getDesertScorePresentation(score: number): DesertScorePresentation {
+    if (score >= DESERT_SCORE_THRESHOLDS.critical) {
+        return {
+            level: 'critical',
+            label: 'Critical Need',
+            color: '#f43f5e',
+            tone: 'critical',
+            description: 'Severe lack of nearby healthcare facilities',
+        };
+    }
+    if (score >= DESERT_SCORE_THRESHOLDS.high) {
+        return {
+            level: 'high',
+            label: 'High Need',
+            color: '#fb923c',
+            tone: 'anchor',
+            description: 'Limited access to clinics or hospitals',
+        };
+    }
+    if (score >= DESERT_SCORE_THRESHOLDS.moderate) {
+        return {
+            level: 'moderate',
+            label: 'Moderate Need',
+            color: '#fbbf24',
+            tone: 'info',
+            description: 'Adequate access with some travel distance',
+        };
+    }
+    return {
+        level: 'adequate',
+        label: 'Adequate Need',
+        color: '#34d399',
+        tone: 'ready',
+        description: 'Good access to nearby healthcare facilities',
+    };
+}
+
+export type DesertScoreFilter = '' | '75-plus' | '50-plus' | 'below-50' | 'unknown';
+
+export const DESERT_SCORE_FILTER_OPTIONS: Array<{ value: DesertScoreFilter; label: string }> = [
+    { value: '', label: 'All scores' },
+    { value: '75-plus', label: `${DESERT_SCORE_THRESHOLDS.critical}+ critical need` },
+    { value: '50-plus', label: `${DESERT_SCORE_THRESHOLDS.high}+ high need` },
+    { value: 'below-50', label: `Below ${DESERT_SCORE_THRESHOLDS.high}` },
+    { value: 'unknown', label: 'Unknown score' },
+];
+
+export function matchesDesertScoreFilter(
+    score: number | null | undefined,
+    filter: DesertScoreFilter,
+): boolean {
+    if (!filter) return true;
+    if (filter === 'unknown') return score === null || score === undefined;
+    if (score === null || score === undefined) return false;
+    if (filter === '75-plus') return score >= DESERT_SCORE_THRESHOLDS.critical;
+    if (filter === '50-plus') return score >= DESERT_SCORE_THRESHOLDS.high;
+    return score < DESERT_SCORE_THRESHOLDS.high;
+}
+
+export function getRegionSeverityClassName(region: {
+    telehealth_status: TelehealthStatusName;
+    desert_score: number | null;
+}): string {
+    const status: TelehealthStatusName = region.telehealth_status;
+    const score = region.desert_score ?? -1;
+    // These existing card-emphasis cutoffs are intentionally distinct from the
+    // canonical 25/50/75 desert-score meaning bands above.
+    if (status === 'CRITICAL_GAP' || score >= REGION_CARD_SEVERITY_THRESHOLDS.critical) return 'severity-critical';
+    if (status === 'COMMUNITY_ANCHOR' || score >= REGION_CARD_SEVERITY_THRESHOLDS.warning) return 'severity-warning';
+    if (status === 'TELEHEALTH_READY') return 'severity-ready';
+    return 'severity-unknown';
+}
+
+export type DataGapSeverity = 'warning' | 'error' | 'info';
+
+export type DataConfidenceLevel = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export const DATA_CONFIDENCE_PRESENTATION: Record<DataConfidenceLevel, {
+    label: string;
+    className: string;
+}> = {
+    HIGH: { label: 'High', className: 'is-high' },
+    MEDIUM: { label: 'Medium', className: 'is-medium' },
+    LOW: { label: 'Low', className: 'is-low' },
+};
+
+export const DATA_CONFIDENCE_LEVELS: DataConfidenceLevel[] = ['HIGH', 'MEDIUM', 'LOW'];
+
+export function getDataGapPresentation(gap: string): { label: string; severity: DataGapSeverity } {
+    switch (gap) {
+        case 'SATELLITE_DEPENDENT':
+            return { label: 'Satellite-dependent access', severity: 'warning' };
+        case 'LOW_TERRESTRIAL':
+            return { label: 'Low wired coverage', severity: 'warning' };
+        case 'LOW_CONFIDENCE':
+            return { label: 'Low data confidence', severity: 'info' };
+        case 'INTERNET_DESERT':
+            return { label: 'No internet coverage', severity: 'error' };
+        case 'MISSING_WIRED_DATA':
+            return { label: 'Missing wired data', severity: 'info' };
+        case 'MISSING_SATELLITE_DATA':
+            return { label: 'Missing satellite data', severity: 'info' };
+        default:
+            return { label: gap, severity: 'info' };
+    }
+}
+
+export const SATELLITE_PRIMARY_METRIC = {
+    label: 'Satellite-primary places',
+    description: 'This is a connectivity access type, not a measure of affordability.',
+} as const;

--- a/frontend/src/domain/statusPresentation.ts
+++ b/frontend/src/domain/statusPresentation.ts
@@ -1,0 +1,101 @@
+import type { StatusTone } from '../components/ui/StatusBadge';
+
+export type TelehealthStatusName =
+    | 'TELEHEALTH_READY'
+    | 'COMMUNITY_ANCHOR'
+    | 'CRITICAL_GAP'
+    | 'DATA_UNAVAILABLE';
+
+export type ScenarioTelehealthStatusName = TelehealthStatusName | 'LIMITED_TELEHEALTH';
+
+interface TelehealthStatusPresentation {
+    label: string;
+    color: string;
+    scenarioColor?: string;
+    tone: StatusTone;
+    className: string;
+    description: string;
+}
+
+export const TELEHEALTH_STATUS_PRESENTATION: Record<ScenarioTelehealthStatusName, TelehealthStatusPresentation> = {
+    TELEHEALTH_READY: {
+        label: 'Telehealth Ready',
+        color: '#22c55e',
+        tone: 'ready',
+        className: 'status-ready',
+        description: 'Affordable home access',
+    },
+    COMMUNITY_ANCHOR: {
+        label: 'Community Anchor',
+        color: '#f59e0b',
+        scenarioColor: '#f97316',
+        tone: 'anchor',
+        className: 'status-anchor',
+        description: 'Nearby clinic safety net',
+    },
+    LIMITED_TELEHEALTH: {
+        label: 'Limited Telehealth',
+        color: '#eab308',
+        tone: 'limited',
+        className: 'status-limited',
+        description: 'Some access requirements are not met',
+    },
+    CRITICAL_GAP: {
+        label: 'Critical Gap',
+        color: '#ef4444',
+        tone: 'critical',
+        className: 'status-critical',
+        description: 'Unaffordable access and no nearby clinic',
+    },
+    DATA_UNAVAILABLE: {
+        label: 'Data Unavailable',
+        color: '#6b7280',
+        tone: 'neutral',
+        className: 'status-unknown',
+        description: 'Required classification data is missing',
+    },
+};
+
+export const BASE_TELEHEALTH_STATUSES: TelehealthStatusName[] = [
+    'TELEHEALTH_READY',
+    'COMMUNITY_ANCHOR',
+    'CRITICAL_GAP',
+    'DATA_UNAVAILABLE',
+];
+
+export const SCENARIO_TELEHEALTH_STATUSES: ScenarioTelehealthStatusName[] = [
+    'TELEHEALTH_READY',
+    'COMMUNITY_ANCHOR',
+    'LIMITED_TELEHEALTH',
+    'CRITICAL_GAP',
+    'DATA_UNAVAILABLE',
+];
+
+export function isScenarioTelehealthStatus(value: unknown): value is ScenarioTelehealthStatusName {
+    return typeof value === 'string'
+        && SCENARIO_TELEHEALTH_STATUSES.includes(value as ScenarioTelehealthStatusName);
+}
+
+export function getTelehealthStatusPresentation(status: ScenarioTelehealthStatusName) {
+    return TELEHEALTH_STATUS_PRESENTATION[status];
+}
+
+export function getTelehealthStatusLabel(status: ScenarioTelehealthStatusName): string {
+    return getTelehealthStatusPresentation(status).label;
+}
+
+export function getTelehealthStatusColor(
+    status: ScenarioTelehealthStatusName,
+    context: 'baseline' | 'scenario' = 'baseline',
+): string {
+    const presentation = getTelehealthStatusPresentation(status);
+    return context === 'scenario' ? presentation.scenarioColor ?? presentation.color : presentation.color;
+}
+
+export function getTelehealthStatusTone(status: ScenarioTelehealthStatusName): StatusTone {
+    return getTelehealthStatusPresentation(status).tone;
+}
+
+export function getTelehealthStatusClassName(status: ScenarioTelehealthStatusName): string {
+    return getTelehealthStatusPresentation(status).className;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,206 @@
+/* TENeT shared design tokens
+ *
+ * The semantic tokens are the preferred API for new UI. The aliases near the
+ * end of :root keep existing screens working while they are migrated.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Neutral surfaces */
+  --color-canvas: #f4f7fa;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f8fafc;
+  --color-surface-muted: #eef2f6;
+  --color-surface-overlay: rgba(255, 255, 255, 0.94);
+
+  /* Text */
+  --color-text: #172033;
+  --color-text-secondary: #536176;
+  --color-text-muted: #64748b;
+  --color-text-inverse: #ffffff;
+  --color-text-link: #1d4ed8;
+
+  /* Borders */
+  --color-border: #d8e0e8;
+  --color-border-strong: #b8c4d0;
+  --color-border-subtle: #e8edf2;
+
+  /* Brand and interaction */
+  --color-primary: #1d4ed8;
+  --color-primary-hover: #1e40af;
+  --color-primary-active: #1e3a8a;
+  --color-primary-subtle: #eff6ff;
+  --color-danger: #b42318;
+  --color-danger-hover: #912018;
+  --color-danger-subtle: #fef3f2;
+
+  /* Operational status colors */
+  --color-status-ready: #15803d;
+  --color-status-ready-subtle: #f0fdf4;
+  --color-status-anchor: #b45309;
+  --color-status-anchor-subtle: #fffbeb;
+  --color-status-gap: #b42318;
+  --color-status-gap-subtle: #fef3f2;
+  --color-status-limited: #6d28d9;
+  --color-status-limited-subtle: #f5f3ff;
+  --color-status-info: #0369a1;
+  --color-status-info-subtle: #f0f9ff;
+  --color-status-unknown: #64748b;
+  --color-status-unknown-subtle: #f1f5f9;
+
+  /* Typography */
+  --font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-xs: 0.75rem;
+  --font-sm: 0.875rem;
+  --font-base: 1rem;
+  --font-lg: 1.125rem;
+  --font-xl: 1.25rem;
+  --font-2xl: 1.5rem;
+
+  /* Spacing (4px base) */
+  --spacing-0: 0;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
+
+  /* Shape */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Elevation */
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.05);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 6px 18px rgba(15, 23, 42, 0.1);
+  --shadow-lg: 0 16px 36px rgba(15, 23, 42, 0.14);
+
+  /* Controls and motion */
+  --control-height-sm: 2rem;
+  --control-height: 2.5rem;
+  --control-height-lg: 2.75rem;
+  --control-icon-size-sm: 2rem;
+  --control-icon-size: 2.5rem;
+  --focus-ring-color: rgba(37, 99, 235, 0.28);
+  --focus-ring: 0 0 0 3px var(--focus-ring-color);
+  --transition-fast: 150ms ease;
+
+  /* Layer order — matches actual overlay stacking across the app */
+  --z-map-controls: 1000;
+  --z-overlay: 1100;
+  --z-toast: 1150;
+  --z-sidebar: 1200;
+  --z-popover: 1500;
+  --z-tooltip: 2500;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  overflow: hidden;
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+p {
+  color: var(--color-text-secondary);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  background: none;
+}
+
+button:not(:disabled) {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+:where(button, input, select, textarea, a):focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: #dbeafe;
+  color: var(--color-text);
+}
+
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-full);
+  background: #c1cad4;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #98a6b6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
-
+import './index.css'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -1,7 +1,8 @@
 /**
  * Scenario Analysis types
  */
-import { Season, TelehealthStatusName } from '../api/catApi';
+import { Season } from '../api/catApi';
+import type { ScenarioTelehealthStatusName } from '../domain/statusPresentation';
 
 /** Scenario lifecycle states */
 export type ScenarioMode = 'off' | 'calculating' | 'active';
@@ -24,8 +25,8 @@ export interface ScenarioRegion {
     name: string;
     lat: number | null;
     lon: number | null;
-    baseline_status: string;
-    scenario_status: string;
+    baseline_status: ScenarioTelehealthStatusName;
+    scenario_status: ScenarioTelehealthStatusName;
     status_delta: StatusDelta;
     baseline_need_score: number;
     scenario_need_score: number;
@@ -75,7 +76,7 @@ export interface ScenarioPreset {
 export const SCENARIO_PRESETS: ScenarioPreset[] = [
     {
         id: 'fcc',
-        label: 'FCC Standard',
+        label: 'Baseline (25/3 Mbps)',
         thresholds: {
             min_download_mbps: 25,
             min_upload_mbps: 3,
@@ -108,22 +109,21 @@ export const BASELINE_THRESHOLDS: ScenarioThresholds = {
     affordability_burden_pct: 2,
 };
 
-/** Status color helper */
-export function getScenarioStatusColor(status: string): string {
-    switch (status) {
-        case 'TELEHEALTH_READY': return '#22c55e';
-        case 'LIMITED_TELEHEALTH': return '#eab308';
-        case 'COMMUNITY_ANCHOR': return '#f97316';
-        case 'CRITICAL_GAP': return '#ef4444';
-        case 'DATA_UNAVAILABLE': return '#6b7280';
-        default: return '#6b7280';
-    }
-}
-
 export function getScenarioDeltaColor(delta: StatusDelta): string {
     switch (delta) {
         case 'improved': return '#22c55e';
         case 'worsened': return '#ef4444';
         case 'unchanged': return '#94a3b8';
+    }
+}
+
+export function getScenarioStatusColor(status: ScenarioTelehealthStatusName | string): string {
+    switch (status) {
+        case 'TELEHEALTH_READY': return '#22c55e';
+        case 'COMMUNITY_ANCHOR': return '#f97316';
+        case 'LIMITED_TELEHEALTH': return '#eab308';
+        case 'CRITICAL_GAP': return '#ef4444';
+        case 'DATA_UNAVAILABLE': return '#6b7280';
+        default: return '#94a3b8';
     }
 }


### PR DESCRIPTION
## Description

Centralize frontend domain semantics and metric presentation.

This PR makes CAT, telehealth, desert score, confidence, and affordability-related labels more trustworthy by moving shared labels, tones, thresholds, and helpers into a small domain/presentation layer.

## Scope

- Centralize shared CAT tier, healthcare desert score, telehealth status, and data confidence presentation helpers.
- Replace duplicated semantics in legend, data coverage, sidebar filters/cards/details, and related tests.
- Fix CAT vs affordability selected-region details so each layer shows the correct detail view.
- Preserve backend APIs and avoid broad UI redesign.

## Validation

Validated on the final stacked branch:

- `npm run typecheck` passed
- `npm run test` passed: 14 files, 45 tests
- `npm run build` passed with the existing Vite large chunk warning


