### PR TITLE
Centralize App map mode and URL state

### DIFF
--- a/frontend/ENGINEERING.md
+++ b/frontend/ENGINEERING.md
@@ -1,0 +1,27 @@
+# Frontend engineering boundaries
+
+Keep frontend changes small, behavior-preserving, and easy to review.
+
+## Ownership boundaries
+
+- `src/api` owns HTTP calls and the frontend contracts for backend responses. Components should not call endpoints directly.
+- `src/hooks` owns reusable state, data-loading, and orchestration logic. Hooks should not own presentation.
+- `src/components/ui` owns shared visual primitives; feature folders own feature composition and feature-specific styling.
+- `src/types` owns shared domain types that span more than one feature. Keep local-only props and types beside their consumer.
+
+## Change rules
+
+- Maintain one shared design system in `src/components/ui`. Extend or migrate the existing primitives instead of creating a parallel set.
+- Do not present inferred, partial, modeled, or unavailable data as an observed metric. Labels and supporting text must state the source or limitation clearly enough to avoid misleading users.
+- When a shared primitive exists, use it instead of introducing raw styling for the same UI role. Dynamic values that cannot be represented by an existing class or token may remain inline.
+- Every new abstraction must replace and delete or migrate the old code in the same change. Do not layer a second path over an obsolete one.
+
+## Quality gates
+
+- `npm run typecheck` checks the strict TypeScript project without emitting files.
+- `npm run test` runs the Vitest unit and component tests once.
+- `npm run build` creates the production Vite bundle.
+- `npm run validate` runs typecheck, tests, and build in sequence.
+- End-to-end coverage is available separately through `npm run e2e` because it requires a browser and an application/API environment.
+
+ESLint and Prettier are not currently installed. No lint or format-check script is declared until those tools and an agreed configuration are added; a script that only aliases typechecking would be misleading.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TENeT - Telehealth effectiveness and Necessity Tracker</title>
+    <title>TENeT - Telehealth Effectiveness and Necessity Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,19 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TENeT - Telehealth Network Tracker</title>
+    <title>TENeT - Telehealth effectiveness and Necessity Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
-      * { box-sizing: border-box; margin: 0; padding: 0; }
-      body {
-        font-family: "Haas", "Haas Groot Disp", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background-color: #ffffff;
-        color: #181d26;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-      }
+      /* Styles moved to src/index.css */
     </style>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,9 +14,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-leaflet-cluster": "^2.1.0",
-        "supercluster": "^8.0.1",
-        "use-supercluster": "^1.2.0"
+        "react-leaflet-cluster": "^2.1.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -25,7 +23,6 @@
         "@types/leaflet": "^1.9.8",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
-        "@types/supercluster": "^7.1.3",
         "@vitejs/plugin-react": "^4.2.1",
         "jsdom": "^24.1.3",
         "typescript": "^5.2.2",
@@ -394,6 +391,380 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -1153,14 +1524,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "license": "MIT",
@@ -1899,13 +2262,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3079,10 +3435,6 @@
         "html2canvas": "^1.0.0-rc.5"
       }
     },
-    "node_modules/kdbush": {
-      "version": "4.1.0",
-      "license": "ISC"
-    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "license": "BSD-2-Clause"
@@ -3934,13 +4286,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
-    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "license": "MIT",
@@ -4084,33 +4429,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/use-deep-compare-effect": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "dequal": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13"
-      }
-    },
-    "node_modules/use-supercluster": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-deep-compare-effect": "^1.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "supercluster": ">=8"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "validate": "npm run typecheck && npm run test && npm run build",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed"
   },
@@ -19,9 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "react-leaflet-cluster": "^2.1.0",
-    "supercluster": "^8.0.1",
-    "use-supercluster": "^1.2.0"
+    "react-leaflet-cluster": "^2.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
@@ -30,7 +29,6 @@
     "@types/leaflet": "^1.9.8",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@types/supercluster": "^7.1.3",
     "@vitejs/plugin-react": "^4.2.1",
     "jsdom": "^24.1.3",
     "typescript": "^5.2.2",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,113 @@
+.tenet-app {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.map-workspace {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  height: 100vh;
+  height: 100dvh;
+}
+
+.map-state-message {
+  position: absolute;
+  z-index: var(--z-toast);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-3) var(--spacing-5);
+  box-shadow: var(--shadow-md);
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  font-weight: 600;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.map-state-message--loading {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.map-state-message--error,
+.map-state-message--notice {
+  top: 92px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.map-state-message--error {
+  border-color: #fecaca;
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+}
+
+.map-state-message--notice {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  border-color: #fde68a;
+  background: var(--color-status-anchor-subtle);
+  color: #92400e;
+}
+
+.scenario-panel-shell {
+  position: absolute;
+  top: 90px;
+  right: var(--spacing-4);
+  z-index: var(--z-overlay);
+}
+
+@media (max-width: 1200px) {
+  .scenario-panel-shell {
+    top: 158px;
+  }
+
+  .map-state-message--error,
+  .map-state-message--notice {
+    top: 160px;
+  }
+}
+
+@media (max-width: 900px) {
+  .scenario-panel-shell #scenario-panel {
+    max-height: calc(54vh - 174px) !important;
+    max-height: calc(54dvh - 174px) !important;
+  }
+
+  .map-workspace .leaflet-bottom.leaflet-right {
+    bottom: calc(46vh + 60px);
+    bottom: calc(46dvh + 60px);
+  }
+}
+
+@media (max-width: 700px) {
+  .scenario-panel-shell {
+    top: 212px;
+    right: var(--spacing-3);
+    left: 60px;
+  }
+
+  .scenario-panel-shell #scenario-panel {
+    width: 100% !important;
+    max-height: max(140px, calc(54vh - 228px)) !important;
+    max-height: max(140px, calc(54dvh - 228px)) !important;
+  }
+
+  .map-workspace .leaflet-top.leaflet-left {
+    top: 206px;
+    left: var(--spacing-3);
+  }
+
+  .map-state-message--error,
+  .map-state-message--notice {
+    top: 212px;
+    max-width: calc(100% - var(--spacing-6));
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,188 +1,87 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { MapContainer, TileLayer, useMap, useMapEvents } from 'react-leaflet';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { MapContainer, TileLayer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
-import { fetchRegions, CATRegion, RegionSummary, Season, AllTelehealthStatusResponse } from './api/catApi';
-import RegionMarker from './components/RegionMarker';
+import { fetchRegions, CATRegion, Season, AllTelehealthStatusResponse } from './api/catApi';
+import { errorMessage, isAbortError } from './api/http';
 import RegionClusters from './components/RegionClusters';
 import Legend from './components/Legend';
-import SeasonSelector from './components/SeasonSelector';
 import DataCoveragePanel from './components/DataCoveragePanel';
 import PerformanceLayer from './components/PerformanceLayer';
 import AffordabilityLayer, { AffordabilityLegend } from './components/AffordabilityLayer';
 import Sidebar from './components/sidebar/Sidebar';
 import ResearchComparisonPanel from './components/ResearchComparisonPanel';
 import ScenarioPanel from './components/scenario/ScenarioPanel';
-import ScenarioLayer, { ScenarioSidebarCard, ScenarioLegend } from './components/scenario/ScenarioLayer';
+import ScenarioLayer, { ScenarioLegend } from './components/scenario/ScenarioLayer';
 import { usePinnedRegions } from './hooks/usePinnedRegions';
 import { useRegionSummary } from './hooks/useRegionSummary';
 import { useScenarioState } from './hooks/useScenarioState';
 import { useScenarioPreview } from './hooks/useScenarioPreview';
+import Dashboard, { type InsightsMapLayer } from './components/dashboard/Dashboard';
+import IconButton from './components/ui/IconButton';
+import MapToolbar from './components/layout/MapToolbar';
+import LayerSwitcher from './components/layout/LayerSwitcher';
+import {
+  ComparisonMapController,
+  MapViewportController,
+  SelectionController,
+} from './components/map/MapControllers';
+import {
+  baseLayerForMapMode,
+  CAT_MAP_MODE,
+  mapModeFromLayer,
+  type BaseMapLayer,
+  type MapMode,
+} from './domain/mapMode';
+import {
+  ALASKA_BOUNDS,
+  parseMapUrlState,
+  type ParsedMapUrlState,
+} from './domain/mapUrlState';
+import { useMapSelection } from './hooks/useMapSelection';
+import { useMapUrlSync } from './hooks/useMapUrlSync';
+import './App.css';
 
-delete (L.Icon.Default.prototype as any)._getIconUrl;
+delete (L.Icon.Default.prototype as L.Icon.Default & { _getIconUrl?: unknown })._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
   iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
 });
 
-// Alaska-specific coordinates. This framing keeps Alaska in focus and avoids
-// opening with too much far-west Russia in the visible map area.
-const ALASKA_CENTER: [number, number] = [64.2, -152.0];
-const ALASKA_ZOOM = 4;
-const STALE_DEFAULT_CENTERS: Array<[number, number]> = [
-  [62.9752, -154.95117],
-  [62.35, -146.75],
-  [62.2, -141.8],
-  [62.2, -170.8],
-  [62.35, -136.5],
-];
-
-const ALASKA_BOUNDS: [[number, number], [number, number]] = [
-  [51.0, -179.5],
-  [72.0, -129.0]
-];
-
-type ActiveLayer = 'cat' | 'affordability' | 'gap';
-
-function parseInitialUrlState() {
-  if (typeof window === 'undefined') {
-    return {
-      region: null,
-      season: 'year_round' as Season,
-      layer: 'cat' as ActiveLayer,
-      pins: [] as string[],
-      center: ALASKA_CENTER,
-      zoom: ALASKA_ZOOM,
-    };
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  const seasonParam = params.get('season') as Season | null;
-  const layerParam = params.get('layer') as ActiveLayer | null;
-  const latParam = params.get('lat');
-  const lngParam = params.get('lng');
-  const zoomParam = params.get('zoom');
-  const lat = latParam === null ? NaN : Number(latParam);
-  const lng = lngParam === null ? NaN : Number(lngParam);
-  const zoom = zoomParam === null ? NaN : Number(zoomParam);
-  const hasSafeCenter = (
-    Number.isFinite(lat)
-    && Number.isFinite(lng)
-    && lat >= ALASKA_BOUNDS[0][0]
-    && lat <= ALASKA_BOUNDS[1][0]
-    && lng >= ALASKA_BOUNDS[0][1]
-    && lng <= ALASKA_BOUNDS[1][1]
-  );
-  const hasSafeZoom = Number.isFinite(zoom) && zoom >= 4 && zoom <= 18;
-  const hasStaleDefaultViewport = (
-    hasSafeCenter
-    && hasSafeZoom
-    && STALE_DEFAULT_CENTERS.some(([staleLat, staleLng]) => (
-      Math.abs(lat - staleLat) < 0.0001
-      && Math.abs(lng - staleLng) < 0.0001
-    ))
-    && zoom === ALASKA_ZOOM
-  );
-
-  return {
-    region: params.get('region'),
-    season: seasonParam && ['summer', 'winter', 'year_round'].includes(seasonParam)
-      ? seasonParam
-      : 'year_round',
-    layer: layerParam && ['cat', 'affordability', 'gap'].includes(layerParam)
-      ? layerParam
-      : 'cat',
-    pins: (params.get('pins') || '').split(',').map(pin => pin.trim()).filter(Boolean).slice(0, 3),
-    center: hasSafeCenter && !hasStaleDefaultViewport ? [lat, lng] as [number, number] : ALASKA_CENTER,
-    zoom: hasSafeZoom && !hasStaleDefaultViewport ? zoom : ALASKA_ZOOM,
-  };
-}
-
-interface SelectionControllerProps {
-  selectedRegionCode: string | null;
-  regionSummaries: RegionSummary[];
-  markerRefs: React.MutableRefObject<Record<string, L.Marker | L.CircleMarker>>;
-}
-
-interface MapUrlControllerProps {
-  onViewportChange: (center: [number, number], zoom: number) => void;
-}
-
-interface ComparisonMapControllerProps {
-  active: boolean;
-}
-
-function MapUrlController({ onViewportChange }: MapUrlControllerProps) {
-  const map = useMapEvents({
-    moveend: () => {
-      const center = map.getCenter();
-      onViewportChange([Number(center.lat.toFixed(5)), Number(center.lng.toFixed(5))], map.getZoom());
-    },
-    zoomend: () => {
-      const center = map.getCenter();
-      onViewportChange([Number(center.lat.toFixed(5)), Number(center.lng.toFixed(5))], map.getZoom());
-    },
-  });
-
-  return null;
-}
-
-function ComparisonMapController({ active }: ComparisonMapControllerProps) {
-  const map = useMap();
-
-  useEffect(() => {
-    if (!active) return;
-    map.closePopup();
-    map.panBy([0, 96], { animate: true, duration: 0.25 });
-  }, [active, map]);
-
-  return null;
-}
-
-function SelectionController({
-  selectedRegionCode,
-  regionSummaries,
-  markerRefs,
-}: SelectionControllerProps) {
-  const map = useMap();
-
-  useEffect(() => {
-    if (!selectedRegionCode) return;
-
-    const selected = regionSummaries.find(region => region.region_code === selectedRegionCode);
-    if (!selected || selected.lat === null || selected.lon === null) return;
-
-    map.flyTo([selected.lat, selected.lon], Math.max(map.getZoom(), 8), { duration: 1.1 });
-
-    window.setTimeout(() => {
-      markerRefs.current[selectedRegionCode]?.openPopup();
-    }, 350);
-  }, [map, markerRefs, regionSummaries, selectedRegionCode]);
-
-  return null;
-}
+type ActiveView = 'map' | 'dashboard';
 
 function App() {
-  const initialUrlState = useMemo(() => parseInitialUrlState(), []);
+  const initialUrlState = useMemo(
+    () => parseMapUrlState(typeof window === 'undefined' ? '' : window.location.search),
+    [],
+  );
+  const [activeView, setActiveView] = useState<ActiveView>('map');
   const [regions, setRegions] = useState<CATRegion[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [season, setSeason] = useState<Season>(initialUrlState.season);
-  const [performanceLayerVisible, setPerformanceLayerVisible] = useState(initialUrlState.layer === 'gap');
-  const [affordabilityLayerVisible, setAffordabilityLayerVisible] = useState(initialUrlState.layer === 'affordability');
-  const [gapModeActive, setGapModeActive] = useState(initialUrlState.layer === 'gap');
+  const [mapMode, setMapMode] = useState<MapMode>(initialUrlState.mapMode);
   const [affordabilitySummary, setAffordabilitySummary] = useState<AllTelehealthStatusResponse['summary'] | undefined>(undefined);
-  const [selectedRegionCode, setSelectedRegionCode] = useState<string | null>(initialUrlState.region);
-  const [detailsFocusKey, setDetailsFocusKey] = useState(0);
   const [visibleRegionCodes, setVisibleRegionCodes] = useState<string[] | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number]>(initialUrlState.center);
   const [mapZoom, setMapZoom] = useState(initialUrlState.zoom);
   const [urlNotice, setUrlNotice] = useState<string | null>(null);
-  const markerRefs = useRef<Record<string, L.Marker | L.CircleMarker>>({});
+  const {
+    selectedRegionCode,
+    setSelectedRegionCode,
+    detailsFocusKey,
+    markerRefs,
+    registerMarker,
+    selectRegion: handleSelectRegion,
+    viewRegionDetails: handleViewRegionDetails,
+  } = useMapSelection(initialUrlState.selectedRegionCode);
 
   // ── Scenario Mode ──────────────────────────────────────────────────
-  const scenarioState = useScenarioState(season);
+  const scenarioState = useScenarioState(season, {
+    active: initialUrlState.mapMode.type === 'scenario',
+    ...initialUrlState.scenario,
+  });
   const scenarioPreview = useScenarioPreview(
     scenarioState.mode,
     scenarioState.thresholds,
@@ -190,53 +89,20 @@ function App() {
     null,
     scenarioState.setMode,
   );
-  const scenarioActive = scenarioState.mode !== 'off';
+  const scenarioActive = mapMode.type === 'scenario';
   const {
     pinnedRegionCodes,
     isPinned,
     togglePinned,
     replacePinned,
     maxPinnedRegions,
-  } = usePinnedRegions(initialUrlState.pins);
+  } = usePinnedRegions(initialUrlState.pinnedRegionCodes);
   const {
     regions: regionSummaries,
     loading: summaryLoading,
     error: summaryError,
   } = useRegionSummary();
-
-  const registerMarker = useCallback((regionCode: string, marker: L.Marker | null) => {
-    if (marker) {
-      markerRefs.current[regionCode] = marker;
-    } else {
-      delete markerRefs.current[regionCode];
-    }
-  }, []);
-
-  const registerAffordabilityMarker = useCallback((regionCode: string, marker: L.CircleMarker | null) => {
-    if (marker) {
-      markerRefs.current[regionCode] = marker;
-    } else {
-      delete markerRefs.current[regionCode];
-    }
-  }, []);
-
-  const registerScenarioMarker = useCallback((regionCode: string, marker: L.Marker | null) => {
-    if (marker) {
-      markerRefs.current[regionCode] = marker;
-    } else {
-      delete markerRefs.current[regionCode];
-    }
-  }, []);
-
-  const handleSelectRegion = useCallback((regionCode: string) => {
-    setSelectedRegionCode(regionCode);
-  }, []);
-
-  const handleViewRegionDetails = useCallback((regionCode: string) => {
-    setSelectedRegionCode(regionCode);
-    setDetailsFocusKey(key => key + 1);
-    markerRefs.current[regionCode]?.closePopup();
-  }, []);
+  const restoreScenarioFromUrl = scenarioState.restoreFromUrl;
 
   const handleVisibleRegionsChange = useCallback((regionCodes: string[]) => {
     setVisibleRegionCodes(regionCodes);
@@ -256,11 +122,7 @@ function App() {
     if (!visibleRegionCodeSet) return regions;
     return regions.filter(region => visibleRegionCodeSet.has(region.region_code));
   }, [regions, visibleRegionCodeSet]);
-  const activeSidebarLayer = gapModeActive
-    ? 'gap'
-    : affordabilityLayerVisible
-      ? 'affordability'
-      : 'cat';
+  const activeSidebarLayer = baseLayerForMapMode(mapMode);
 
   useEffect(() => {
     if (summaryLoading || regionSummaries.length === 0) return;
@@ -291,55 +153,53 @@ function App() {
     return () => window.clearTimeout(timer);
   }, [urlNotice]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+  const restoreUrlState = useCallback((state: ParsedMapUrlState) => {
+    setSelectedRegionCode(state.selectedRegionCode);
+    setSeason(state.season);
+    setMapMode(state.mapMode);
+    replacePinned(state.pinnedRegionCodes);
+    setMapCenter(state.center);
+    setMapZoom(state.zoom);
+    restoreScenarioFromUrl({
+      active: state.mapMode.type === 'scenario',
+      ...state.scenario,
+    });
+  }, [replacePinned, restoreScenarioFromUrl, setSelectedRegionCode]);
 
-    const params = new URLSearchParams(window.location.search);
-    params.delete('region');
-    params.delete('layer');
-    params.delete('season');
-    params.delete('pins');
-    params.delete('lat');
-    params.delete('lng');
-    params.delete('zoom');
+  const serializedUrlState = useMemo(() => ({
+    selectedRegionCode,
+    season,
+    mapMode,
+    pinnedRegionCodes,
+    center: mapCenter,
+    zoom: mapZoom,
+    scenario: {
+      thresholds: scenarioState.thresholds,
+      preset: scenarioState.activePreset,
+    },
+  }), [
+    mapCenter,
+    mapMode,
+    mapZoom,
+    pinnedRegionCodes,
+    scenarioState.activePreset,
+    scenarioState.thresholds,
+    season,
+    selectedRegionCode,
+  ]);
+  useMapUrlSync(serializedUrlState, restoreUrlState);
 
-    if (selectedRegionCode) params.set('region', selectedRegionCode);
-    if (activeSidebarLayer !== 'cat') params.set('layer', activeSidebarLayer);
-    if (season !== 'year_round') params.set('season', season);
-    if (pinnedRegionCodes.length) params.set('pins', pinnedRegionCodes.join(','));
-    if (mapCenter[0] !== ALASKA_CENTER[0]) params.set('lat', mapCenter[0].toFixed(5));
-    if (mapCenter[1] !== ALASKA_CENTER[1]) params.set('lng', mapCenter[1].toFixed(5));
-    if (mapZoom !== ALASKA_ZOOM) params.set('zoom', String(mapZoom));
-
-    const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-    window.history.replaceState(null, '', nextUrl);
-  }, [activeSidebarLayer, mapCenter, mapZoom, pinnedRegionCodes, season, selectedRegionCode]);
-
-  const toggleAffordabilityLayer = () => {
-    if (!affordabilityLayerVisible) {
-      setGapModeActive(false);
-      setPerformanceLayerVisible(false);
-    }
-    setAffordabilityLayerVisible(!affordabilityLayerVisible);
-  };
-
-  const toggleGapMode = () => {
-    if (!gapModeActive) {
-      setAffordabilityLayerVisible(false);
-      setPerformanceLayerVisible(true);
-    } else {
-      setPerformanceLayerVisible(false);
-    }
-    setGapModeActive(!gapModeActive);
+  const handleLayerChange = (layer: BaseMapLayer) => {
+    if (scenarioActive) scenarioState.deactivate();
+    setMapMode(mapModeFromLayer(layer));
   };
 
   const toggleScenarioMode = () => {
-    if (scenarioState.mode === 'off') {
-      setGapModeActive(false);
-      setPerformanceLayerVisible(false);
-      setAffordabilityLayerVisible(false);
+    if (!scenarioActive) {
+      setMapMode({ type: 'scenario' });
       scenarioState.activate();
     } else {
+      setMapMode(CAT_MAP_MODE);
       scenarioState.deactivate();
     }
   };
@@ -351,32 +211,60 @@ function App() {
   }, [scenarioActive, scenarioPreview.data, selectedRegionCode]);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     async function loadData() {
       try {
         setLoading(true);
-        const data = await fetchRegions(season);
-        setRegions(data);
         setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load data');
-        console.error('Error loading regions:', err);
+        setRegions([]);
+        const data = await fetchRegions(season, undefined, controller.signal);
+        if (controller.signal.aborted) return;
+        setRegions(data);
+      } catch (caught: unknown) {
+        if (isAbortError(caught)) return;
+        setError(errorMessage(caught, 'Failed to load data'));
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     }
     loadData();
+
+    return () => {
+      controller.abort();
+    };
   }, [season]);
 
-  const getSeasonInfo = () => {
-    switch (season) {
-      case 'summer': return { label: 'Summer', note: 'All transport modes' };
-      case 'winter': return { label: 'Winter', note: 'Limited routes' };
-      case 'year_round': return { label: 'Year-Round', note: 'Average' };
-    }
+  const handleInsightsViewMap = (layer: InsightsMapLayer) => {
+    handleLayerChange(layer);
+    setActiveView('map');
   };
 
+  const handleInsightsViewRegion = (regionCode: string) => {
+    handleLayerChange('cat');
+    handleViewRegionDetails(regionCode);
+    setActiveView('map');
+  };
+
+  const closeInsights = () => {
+    setActiveView('map');
+    window.requestAnimationFrame(() => {
+      document.getElementById('insights-toolbar-button')?.focus();
+    });
+  };
+
+  if (activeView === 'dashboard') {
+    return (
+      <Dashboard
+        onClose={closeInsights}
+        onViewMap={handleInsightsViewMap}
+        onViewRegion={handleInsightsViewRegion}
+      />
+    );
+  }
+
   return (
-    <div style={{ height: '100vh', width: '100%', margin: 0, padding: 0, display: 'flex', overflow: 'hidden' }}>
+    <div className="tenet-app">
       <Sidebar
         regions={regionSummaries}
         loading={summaryLoading}
@@ -394,7 +282,7 @@ function App() {
         onVisibleRegionsChange={handleVisibleRegionsChange}
       />
 
-      <div style={{ position: 'relative', flex: 1, minWidth: 0, height: '100vh' }}>
+      <main className="map-workspace">
         <MapContainer
           center={mapCenter}
           zoom={mapZoom}
@@ -411,7 +299,7 @@ function App() {
             updateWhenZooming={false}
           />
 
-          {!gapModeActive && !affordabilityLayerVisible && !scenarioActive && (
+          {mapMode.type === 'cat' && (
             <RegionClusters
               regions={mapRegions}
               season={season}
@@ -428,318 +316,118 @@ function App() {
             markerRefs={markerRefs}
           />
 
-          <MapUrlController onViewportChange={handleViewportChange} />
+          <MapViewportController
+            center={mapCenter}
+            zoom={mapZoom}
+            onViewportChange={handleViewportChange}
+          />
 
           <ComparisonMapController active={pinnedRegionCodes.length >= 2} />
 
 
 
           <PerformanceLayer
-            visible={performanceLayerVisible}
-            onToggle={() => setPerformanceLayerVisible(false)}
-            onModeChange={setGapModeActive}
+            visible={mapMode.type === 'gapHunter'}
+            onToggle={() => setMapMode(CAT_MAP_MODE)}
           />
 
-          {!scenarioActive && (
-            <AffordabilityLayer
-              visible={affordabilityLayerVisible}
-              selectedRegionCode={selectedRegionCode}
-              onSelect={handleSelectRegion}
-              onViewDetails={handleViewRegionDetails}
-              onMarkerReady={registerAffordabilityMarker}
-              onDataLoad={setAffordabilitySummary}
-            />
-          )}
-
-          <ScenarioLayer
-            data={scenarioPreview.data}
-            active={scenarioActive && !gapModeActive}
+          <AffordabilityLayer
+            visible={mapMode.type === 'telehealthAccess'}
             selectedRegionCode={selectedRegionCode}
             onSelect={handleSelectRegion}
             onViewDetails={handleViewRegionDetails}
-            onMarkerReady={registerScenarioMarker}
+            onMarkerReady={registerMarker}
+            onDataLoad={setAffordabilitySummary}
+          />
+
+          <ScenarioLayer
+            data={scenarioPreview.data}
+            active={scenarioActive}
+            selectedRegionCode={selectedRegionCode}
+            onSelect={handleSelectRegion}
+            onViewDetails={handleViewRegionDetails}
+            onMarkerReady={registerMarker}
           />
         </MapContainer>
 
-      <ResearchComparisonPanel
-        pinnedRegionCodes={pinnedRegionCodes}
-        season={season}
-        onSelectRegion={handleSelectRegion}
-      />
+        <ResearchComparisonPanel
+          pinnedRegionCodes={pinnedRegionCodes}
+          season={season}
+          onSelectRegion={handleSelectRegion}
+        />
 
       {loading && (
-        <div style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          zIndex: 1000,
-          background: '#ffffff',
-          padding: '24px 48px',
-          borderRadius: '10px',
-          border: '1px solid #dddddd',
-          fontSize: '14px',
-          fontWeight: '500',
-          color: '#181d26'
-        }}>
+        <div className="map-state-message map-state-message--loading" role="status">
           Loading community data...
         </div>
       )}
 
       {error && (
-        <div style={{
-          position: 'absolute',
-          top: '40px',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          zIndex: 1000,
-          background: '#ffffff',
-          color: '#aa2d00',
-          padding: '12px 24px',
-          borderRadius: '6px',
-          border: '1px solid #dddddd',
-          fontSize: '14px',
-          fontWeight: '500'
-        }}>
+        <div className="map-state-message map-state-message--error" role="alert">
           {error}
         </div>
       )}
 
       {urlNotice && (
-        <div style={{
-          position: 'absolute',
-          top: '128px',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          zIndex: 1000,
-          background: 'rgba(255, 251, 235, 0.96)',
-          color: '#92400e',
-          padding: '10px 18px',
-          borderRadius: '8px',
-          fontSize: '13px',
-          fontWeight: '600',
-          border: '1px solid #f59e0b',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '12px'
-        }}>
+        <div className="map-state-message map-state-message--notice" role="status">
           <span>{urlNotice}</span>
-          <button
-            type="button"
+          <IconButton
             aria-label="Dismiss notice"
+            icon="×"
+            size="small"
             onClick={() => setUrlNotice(null)}
-            style={{
-              appearance: 'none',
-              border: 0,
-              background: 'transparent',
-              color: '#92400e',
-              cursor: 'pointer',
-              fontSize: '16px',
-              fontWeight: 700,
-              lineHeight: 1,
-              padding: 0
-            }}
-          >
-            ×
-          </button>
+            style={{ color: 'inherit' }}
+          />
         </div>
       )}
 
-      {!loading && !scenarioActive && (
-        <div style={{
-          position: 'absolute',
-          top: '20px',
-          left: '60px',
-          zIndex: 1000,
-          display: 'flex',
-          gap: '10px'
-        }}>
-          {/* Airtable Secondary Button Style */}
-          <button
-            onClick={toggleGapMode}
-            type="button"
-            aria-label="Open Gap Hunter layer"
-            style={{
-              backgroundColor: '#ffffff',
-              color: '#181d26',
-              border: '1px solid #dddddd',
-              borderRadius: '12px',
-              padding: '10px 16px',
-              fontSize: '14px',
-              fontWeight: '500',
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-              transition: 'all 0.15s ease'
-            }}
-          >
-            Gap Hunter
-          </button>
+      <MapToolbar
+        season={season}
+        scenarioActive={scenarioActive}
+        scenarioDisabled={loading}
+        onSeasonChange={setSeason}
+        onOpenInsights={() => setActiveView('dashboard')}
+        onToggleScenario={toggleScenarioMode}
+      />
 
-          <button
-            onClick={toggleAffordabilityLayer}
-            type="button"
-            aria-label="Open affordability layer"
-            style={{
-              backgroundColor: '#ffffff',
-              color: '#181d26',
-              border: '1px solid #dddddd',
-              borderRadius: '12px',
-              padding: '10px 16px',
-              fontSize: '14px',
-              fontWeight: '500',
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-              transition: 'all 0.15s ease'
-            }}
-          >
-            Affordability
-          </button>
-        </div>
+      {!loading && (
+        <LayerSwitcher
+          activeLayer={activeSidebarLayer}
+          scenarioActive={scenarioActive}
+          onChange={handleLayerChange}
+        />
       )}
 
-      {/* RIGHT SIDE: Title + Season Dropdown */}
-      <div style={{
-        position: 'absolute',
-        top: '20px',
-        right: '20px',
-        zIndex: 1001,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-end',
-        gap: '12px'
-      }}>
-        {/* Title Card with Dropdown (Airtable flat card style) */}
-        <div style={{
-          background: '#ffffff',
-          padding: '12px 16px',
-          borderRadius: '10px',
-          border: '1px solid #dddddd',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '16px'
-        }}>
-          <div>
-            <div style={{
-              fontSize: '16px',
-              fontWeight: '500',
-              color: '#181d26',
-              letterSpacing: '0'
-            }}>
-              TENeT
-            </div>
-            <div style={{
-              fontSize: '12px',
-              color: '#41454d'
-            }}>
-              Telehealth Network Tracker
-            </div>
-          </div>
-          <div style={{
-            width: '1px',
-            height: '32px',
-            backgroundColor: '#dddddd',
-            margin: '0 4px'
-          }}></div>
-          <div>
-            <SeasonSelector season={season} onChange={setSeason} />
-          </div>
-        </div>
-
-        {/* Scenario Mode Toggle */}
-        {!loading && (
-          <button
-            onClick={toggleScenarioMode}
-            id="scenario-toggle-button"
-            data-testid="scenario-button"
-            type="button"
-            aria-label={scenarioActive ? 'Exit scenario mode' : 'Open what-if scenario mode'}
-            style={{
-              background: scenarioActive
-                ? 'linear-gradient(135deg, #6D28D9 0%, #5B21B6 100%)'
-                : 'rgba(255, 255, 255, 0.92)',
-              backdropFilter: 'blur(12px)',
-              WebkitBackdropFilter: 'blur(12px)',
-              color: scenarioActive ? 'white' : '#6D28D9',
-              border: scenarioActive ? 'none' : '1px solid rgba(124, 58, 237, 0.25)',
-              borderRadius: '10px',
-              padding: '10px 18px',
-              fontSize: '13px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              boxShadow: scenarioActive
-                ? '0 4px 16px rgba(124, 58, 237, 0.35)'
-                : '0 4px 16px rgba(31, 38, 135, 0.1)',
-              transition: 'all 0.2s',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              alignSelf: 'flex-end',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-1px)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-            }}
-          >
-            <span style={{ fontSize: '14px' }}>🔬</span>
-            {scenarioActive ? '✕ Exit Scenarios' : 'What-If Scenarios'}
-          </button>
-        )}
-
-        {/* Scenario Panel */}
-        {scenarioActive && (
+      {scenarioActive && (
+        <div className="scenario-panel-shell">
           <ScenarioPanel
             scenario={scenarioState}
             preview={scenarioPreview}
-            gapModeActive={gapModeActive}
+            onClose={toggleScenarioMode}
           />
-        )}
-
-        {/* Close Affordability button */}
-        {affordabilityLayerVisible && (
-          <button
-            onClick={() => setAffordabilityLayerVisible(false)}
-            type="button"
-            aria-label="Close affordability layer"
-            style={{
-              background: 'rgba(55, 65, 81, 0.9)',
-              backdropFilter: 'blur(10px)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              padding: '10px 16px',
-              fontSize: '13px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
-            }}
-          >
-            ✕ Close Affordability
-          </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* BOTTOM LEFT: Data Coverage Panel */}
-      {!loading && !gapModeActive && !affordabilityLayerVisible && !scenarioActive && (
-        <DataCoveragePanel totalRegions={regions.length} />
+      {!loading && mapMode.type === 'cat' && (
+        <DataCoveragePanel />
       )}
 
       {/* BOTTOM RIGHT: Legend Panel */}
-      {!loading && !gapModeActive && !affordabilityLayerVisible && !scenarioActive && (
+      {!loading && mapMode.type === 'cat' && (
         <Legend totalRegions={regions.length} />
       )}
 
       {/* Affordability Legend */}
-      {!loading && affordabilityLayerVisible && !scenarioActive && (
+      {!loading && mapMode.type === 'telehealthAccess' && (
         <AffordabilityLegend summary={affordabilitySummary} />
       )}
 
       {/* Scenario Legend */}
-      {!loading && scenarioActive && !gapModeActive && (
+      {!loading && scenarioActive && (
         <ScenarioLegend />
       )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -43,7 +43,7 @@ export interface RegionSummary {
     lat: number | null;
     lon: number | null;
     cat_tier: number | null;
-    telehealth_status: TelehealthStatusName | string;
+    telehealth_status: TelehealthStatusName;
     desert_score: number | null;
     affordability_status: AffordabilityStatusName | string;
     data_confidence: 'high' | 'medium' | 'low' | 'missing' | 'unknown' | string;
@@ -354,8 +354,8 @@ export async function fetchBroadbandCoverage(filters?: {
 /**
  * Fetch data gaps summary for dashboard display
  */
-export async function fetchDataGapsSummary(): Promise<DataGapsSummary> {
-    const response = await fetch(`${API_BASE}/data-gaps`);
+export async function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
+    const response = await fetch(`${API_BASE}/data-gaps`, { signal });
     if (!response.ok) {
         throw new Error(`Failed to fetch data gaps: ${response.statusText}`);
     }

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -2,6 +2,13 @@
  * API client for CAT (Community Access Tier) data
  */
 
+import { CAT_TIER_PRESENTATION, getDesertScorePresentation, type CatTier } from '../domain/metrics';
+import type { TelehealthStatusName } from '../domain/statusPresentation';
+import type { Feature, FeatureCollection, MultiPolygon } from 'geojson';
+import { ApiError, fetchJson, withQuery } from './http';
+
+export type { TelehealthStatusName } from '../domain/statusPresentation';
+
 export const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
 
 // Season type for user-selected seasonal scenario
@@ -13,7 +20,7 @@ export type PerformanceFilterType = 'combined' | 'affordability' | 'latency';
 export interface CATRegion {
     region_code: string;
     region_name: string;
-    tier_level: number;
+    tier_level: CatTier;
     description: string;
     centroid_lat: number | null;
     centroid_lon: number | null;
@@ -28,13 +35,18 @@ export interface RegionsResponse {
     total: number;
 }
 
-export type TelehealthStatusName =
-    | 'TELEHEALTH_READY'
-    | 'COMMUNITY_ANCHOR'
-    | 'CRITICAL_GAP'
-    | 'DATA_UNAVAILABLE';
+export interface BoundaryProperties {
+    CommunityName: string;
+    EconomicRegion: string;
+    FIPS: string;
+    Census_Area: 'Y' | null;
+}
+
+export type BoundaryFeature = Feature<MultiPolygon, BoundaryProperties>;
+export type BoundaryCollection = FeatureCollection<MultiPolygon, BoundaryProperties>;
 
 export type AffordabilityStatusName = 'affordable' | 'unaffordable' | 'unknown';
+export type RegionDataConfidence = 'high' | 'medium' | 'low' | 'missing' | 'unknown';
 
 export interface RegionSummary {
     id: number;
@@ -42,11 +54,11 @@ export interface RegionSummary {
     name: string;
     lat: number | null;
     lon: number | null;
-    cat_tier: number | null;
+    cat_tier: CatTier | null;
     telehealth_status: TelehealthStatusName;
     desert_score: number | null;
-    affordability_status: AffordabilityStatusName | string;
-    data_confidence: 'high' | 'medium' | 'low' | 'missing' | 'unknown' | string;
+    affordability_status: AffordabilityStatusName;
+    data_confidence: RegionDataConfidence;
     has_data_gap: boolean;
     region: string | null;
 }
@@ -59,8 +71,8 @@ export interface RegionSummaryResponse {
 export interface RegionSearchParams {
     q?: string;
     name?: string;
-    tier?: number | string | null;
-    status?: string | null;
+    tier?: CatTier | `${CatTier}` | null;
+    status?: TelehealthStatusName | null;
     desert_min?: number | string | null;
     desert_max?: number | string | null;
     data_gap?: boolean | string | null;
@@ -93,7 +105,7 @@ export interface SeasonScenario {
 export interface TelehealthPriorityResponse {
     region_code: string;
     region_name: string;
-    cat_tier: number;
+    cat_tier: CatTier;
     necessity_score: number;
     connectivity_score: number;
     combined_priority: number;
@@ -125,65 +137,55 @@ export interface TelehealthPriorityResponse {
 /**
  * Fetch all CAT regions with optional season adjustment
  */
-export async function fetchRegions(season: Season = 'year_round', tier?: number): Promise<CATRegion[]> {
-    let url = `${API_BASE}/regions?season=${season}`;
-    if (tier) {
-        url += `&tier=${tier}`;
-    }
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch regions: ${response.statusText}`);
-    }
-
-    const data: RegionsResponse = await response.json();
+export async function fetchRegions(
+    season: Season = 'year_round',
+    tier?: number,
+    signal?: AbortSignal,
+): Promise<CATRegion[]> {
+    const data = await fetchJson<RegionsResponse>(
+        withQuery(`${API_BASE}/regions`, { season, tier: tier || undefined }),
+        { signal },
+        'Failed to fetch regions',
+    );
     return data.regions;
+}
+
+export function fetchBoundaries(signal?: AbortSignal): Promise<BoundaryCollection> {
+    return fetchJson(`${API_BASE}/boundaries`, { signal }, 'Failed to load boundaries');
 }
 
 /**
  * Fetch lightweight community summaries for sidebar navigation.
  */
-export async function fetchRegionSummary(): Promise<RegionSummary[]> {
-    const response = await fetch(`${API_BASE}/regions/summary`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch region summary: ${response.statusText}`);
-    }
-
-    const data: RegionSummaryResponse = await response.json();
+export async function fetchRegionSummary(signal?: AbortSignal): Promise<RegionSummary[]> {
+    const data = await fetchJson<RegionSummaryResponse>(
+        `${API_BASE}/regions/summary`,
+        { signal },
+        'Failed to fetch region summary',
+    );
     return data.regions;
 }
 
 /**
  * Search lightweight community summaries for sidebar discovery.
  */
-export async function searchRegions(params: RegionSearchParams = {}): Promise<RegionSummary[]> {
-    const query = new URLSearchParams();
-
-    Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null && value !== '') {
-            query.append(key, String(value));
-        }
-    });
-
-    const suffix = query.toString() ? `?${query.toString()}` : '';
-    const response = await fetch(`${API_BASE}/regions/search${suffix}`);
-    if (!response.ok) {
-        throw new Error(`Failed to search regions: ${response.statusText}`);
-    }
-
-    const data: RegionSearchResponse = await response.json();
+export async function searchRegions(
+    params: RegionSearchParams = {},
+    signal?: AbortSignal,
+): Promise<RegionSummary[]> {
+    const data = await fetchJson<RegionSearchResponse>(
+        withQuery(`${API_BASE}/regions/search`, params),
+        { signal },
+        'Failed to search regions',
+    );
     return data.regions;
 }
 
 /**
  * Fetch database statistics
  */
-export async function fetchStatistics(): Promise<StatisticsResponse> {
-    const response = await fetch(`${API_BASE}/statistics`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch statistics: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchStatistics(signal?: AbortSignal): Promise<StatisticsResponse> {
+    return fetchJson(`${API_BASE}/statistics`, { signal }, 'Failed to fetch statistics');
 }
 
 /**
@@ -191,75 +193,14 @@ export async function fetchStatistics(): Promise<StatisticsResponse> {
  */
 export async function fetchTelehealthPriority(
     regionCode: string,
-    season: Season = 'year_round'
+    season: Season = 'year_round',
+    signal?: AbortSignal,
 ): Promise<TelehealthPriorityResponse> {
-    const url = `${API_BASE}/telehealth-priority/${regionCode}?season=${season}`;
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch telehealth priority: ${response.statusText}`);
-    }
-
-    return response.json();
-}
-
-/**
- * Get tier color based on CAT tier level
- */
-export function getTierColor(tier: number): string {
-    switch (tier) {
-        case 1: return '#22c55e'; // Green - Full access
-        case 2: return '#eab308'; // Yellow - Dual mode
-        case 3: return '#f97316'; // Orange - Limited
-        case 4: return '#ef4444'; // Red - Extreme
-        default: return '#6b7280'; // Gray - Unknown
-    }
-}
-
-/**
- * Get map color based on Telehealth Necessity Score (0-100)
- */
-export function getNeedColor(score: number): string {
-    if (score >= 75) return '#f43f5e';      // Vibrant Rose (Professional Critical)
-    if (score >= 50) return '#fb923c';      // Warm Orange (High)
-    if (score >= 25) return '#fbbf24';      // Rich Amber (Moderate)
-    return '#34d399';                       // Fresh Emerald (Adequate)
-}
-
-/**
- * Get label based on Telehealth Necessity Score (0-100)
- */
-export function getNeedLabel(score: number): string {
-    if (score >= 75) return 'Critical Need';
-    if (score >= 50) return 'High Need';
-    if (score >= 25) return 'Moderate Need';
-    return 'Adequate Need';
-}
-
-/**
- * Get tier label based on CAT tier level
- */
-export function getTierLabel(tier: number): string {
-    switch (tier) {
-        case 1: return 'Full Multimodal Access';
-        case 2: return 'Dual Mode Access';
-        case 3: return 'Limited Access';
-        case 4: return 'Extreme/No Direct Access';
-        default: return 'Unknown';
-    }
-}
-
-/**
- * Get priority color for telehealth classification
- */
-export function getPriorityColor(priority: string): string {
-    switch (priority) {
-        case 'HIGH': return '#22c55e';      // Green
-        case 'CRITICAL': return '#ef4444';   // Red
-        case 'MODERATE': return '#f97316';   // Orange
-        case 'LOW': return '#3b82f6';        // Blue
-        default: return '#6b7280';           // Gray
-    }
+    return fetchJson(
+        withQuery(`${API_BASE}/telehealth-priority/${encodeURIComponent(regionCode)}`, { season }),
+        { signal },
+        'Failed to fetch telehealth priority',
+    );
 }
 
 // =============================================================================
@@ -331,69 +272,40 @@ export async function fetchBroadbandCoverage(filters?: {
     telehealth_viable?: string;
     primary_access?: string;
     has_gaps?: boolean;
-}): Promise<BroadbandResponse> {
-    let url = `${API_BASE}/broadband`;
-    const params = new URLSearchParams();
-
-    if (filters?.confidence) params.append('confidence', filters.confidence);
-    if (filters?.telehealth_viable) params.append('telehealth_viable', filters.telehealth_viable);
-    if (filters?.primary_access) params.append('primary_access', filters.primary_access);
-    if (filters?.has_gaps) params.append('has_gaps', 'true');
-
-    if (params.toString()) {
-        url += `?${params.toString()}`;
-    }
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch broadband data: ${response.statusText}`);
-    }
-    return response.json();
+}, signal?: AbortSignal): Promise<BroadbandResponse> {
+    return fetchJson(
+        withQuery(`${API_BASE}/broadband`, {
+            confidence: filters?.confidence,
+            telehealth_viable: filters?.telehealth_viable,
+            primary_access: filters?.primary_access,
+            has_gaps: filters?.has_gaps ? true : undefined,
+        }),
+        { signal },
+        'Failed to fetch broadband data',
+    );
 }
 
 /**
  * Fetch data gaps summary for dashboard display
  */
-export async function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
-    const response = await fetch(`${API_BASE}/data-gaps`, { signal });
-    if (!response.ok) {
-        throw new Error(`Failed to fetch data gaps: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
+    return fetchJson(`${API_BASE}/data-gaps`, { signal }, 'Failed to fetch data gaps');
 }
 
-/**
- * Get confidence color for data quality visualization
- */
-export function getConfidenceColor(confidence: string): string {
-    switch (confidence) {
-        case 'HIGH': return '#22c55e';    // Green
-        case 'MEDIUM': return '#eab308';   // Yellow
-        case 'LOW': return '#ef4444';      // Red
-        default: return '#6b7280';         // Gray
-    }
+export function getNeedColor(score: number | null | undefined): string {
+    return getDesertScorePresentation(score ?? 0).color;
 }
 
-/**
- * Get icon/label for data gap types
- */
-export function getDataGapInfo(gap: string): { icon: string; label: string; severity: 'warning' | 'error' | 'info' } {
-    switch (gap) {
-        case 'SATELLITE_DEPENDENT':
-            return { icon: '', label: 'Satellite Only', severity: 'warning' };
-        case 'LOW_TERRESTRIAL':
-            return { icon: '📶', label: 'Low Wired Coverage', severity: 'warning' };
-        case 'LOW_CONFIDENCE':
-            return { icon: '❓', label: 'Low Data Confidence', severity: 'info' };
-        case 'INTERNET_DESERT':
-            return { icon: '🚫', label: 'No Internet Coverage', severity: 'error' };
-        case 'MISSING_WIRED_DATA':
-            return { icon: '📊', label: 'Missing Wired Data', severity: 'info' };
-        case 'MISSING_SATELLITE_DATA':
-            return { icon: '📊', label: 'Missing Satellite Data', severity: 'info' };
-        default:
-            return { icon: '', label: gap, severity: 'info' };
+export function getNeedLabel(score: number | null | undefined): string {
+    if (score === null || score === undefined) return 'Unknown Need';
+    return getDesertScorePresentation(score).label;
+}
+
+export function getTierColor(tier: CatTier | number | null | undefined): string {
+    if (tier === 1 || tier === 2 || tier === 3 || tier === 4) {
+        return CAT_TIER_PRESENTATION[tier].color;
     }
+    return '#94a3b8';
 }
 
 // =============================================================================
@@ -450,41 +362,23 @@ export interface HealthcareSummary {
 /**
  * Fetch healthcare facilities near a specific region
  */
-export async function fetchHealthcareByRegion(regionCode: string, limit = 10): Promise<HealthcareByRegion> {
-    const response = await fetch(`${API_BASE}/healthcare/by-region/${regionCode}?limit=${limit}`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch healthcare data: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchHealthcareByRegion(
+    regionCode: string,
+    limit = 10,
+    signal?: AbortSignal,
+): Promise<HealthcareByRegion> {
+    return fetchJson(
+        withQuery(`${API_BASE}/healthcare/by-region/${encodeURIComponent(regionCode)}`, { limit }),
+        { signal },
+        'Failed to fetch healthcare data',
+    );
 }
 
 /**
  * Fetch healthcare summary statistics
  */
-export async function fetchHealthcareSummary(): Promise<HealthcareSummary> {
-    const response = await fetch(`${API_BASE}/healthcare/summary`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch healthcare summary: ${response.statusText}`);
-    }
-    return response.json();
-}
-
-/**
- * Get facility type icon and color
- */
-export function getFacilityTypeInfo(type: string): { icon: string; color: string; label: string } {
-    switch (type) {
-        case 'hospital':
-            return { icon: '🏥', color: '#dc2626', label: 'Hospital' };
-        case 'clinic':
-            return { icon: '🩺', color: '#2563eb', label: 'Clinic' };
-        case 'pharmacy':
-            return { icon: '💊', color: '#16a34a', label: 'Pharmacy' };
-        case 'health_center':
-            return { icon: '🏨', color: '#7c3aed', label: 'Health Center' };
-        default:
-            return { icon: '🏥', color: '#6b7280', label: type };
-    }
+export function fetchHealthcareSummary(signal?: AbortSignal): Promise<HealthcareSummary> {
+    return fetchJson(`${API_BASE}/healthcare/summary`, { signal }, 'Failed to fetch healthcare summary');
 }
 
 // =============================================================================
@@ -606,74 +500,46 @@ export interface PerformanceSummary {
 export async function fetchPerformance(
     year?: number,
     quarter?: number,
-    minTests: number = 1
+    minTests: number = 1,
+    signal?: AbortSignal,
 ): Promise<PerformanceResponse> {
-    let url = `${API_BASE}/performance?min_tests=${minTests}`;
-    if (year) url += `&year=${year}`;
-    if (quarter) url += `&quarter=${quarter}`;
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch performance: ${response.statusText}`);
-    }
-    return response.json();
+    return fetchJson(
+        withQuery(`${API_BASE}/performance`, {
+            min_tests: minTests,
+            year: year || undefined,
+            quarter: quarter || undefined,
+        }),
+        { signal },
+        'Failed to fetch performance',
+    );
 }
 
 /**
  * Fetch service gaps (FCC claims vs Ookla measured)
  */
-export async function fetchServiceGaps(): Promise<ServiceGapsResponse> {
-    const response = await fetch(`${API_BASE}/performance/gaps`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch service gaps: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchServiceGaps(signal?: AbortSignal): Promise<ServiceGapsResponse> {
+    return fetchJson(`${API_BASE}/performance/gaps`, { signal }, 'Failed to fetch service gaps');
 }
 
 /**
  * Fetch performance for a specific region
  */
-export async function fetchRegionPerformance(regionCode: string): Promise<RegionPerformance> {
-    const response = await fetch(`${API_BASE}/performance/by-region/${regionCode}`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch region performance: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchRegionPerformance(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<RegionPerformance> {
+    return fetchJson(
+        `${API_BASE}/performance/by-region/${encodeURIComponent(regionCode)}`,
+        { signal },
+        'Failed to fetch region performance',
+    );
 }
 
 /**
  * Fetch performance summary
  */
-export async function fetchPerformanceSummary(): Promise<PerformanceSummary> {
-    const response = await fetch(`${API_BASE}/performance/summary`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch performance summary: ${response.statusText}`);
-    }
-    return response.json();
-}
-
-/**
- * Get speed color for visualization
- */
-export function getSpeedColor(speedMbps: number | null): string {
-    if (speedMbps === null) return '#6b7280';  // Gray - no data
-    if (speedMbps >= 50) return '#22c55e';     // Green - excellent
-    if (speedMbps >= 25) return '#84cc16';     // Lime - good
-    if (speedMbps >= 10) return '#eab308';     // Yellow - moderate
-    if (speedMbps >= 5) return '#f97316';      // Orange - poor
-    return '#ef4444';                           // Red - critical
-}
-
-/**
- * Get speed label
- */
-export function getSpeedLabel(speedMbps: number | null): string {
-    if (speedMbps === null) return 'No Data';
-    if (speedMbps >= 50) return 'Excellent';
-    if (speedMbps >= 25) return 'Good';
-    if (speedMbps >= 10) return 'Moderate';
-    if (speedMbps >= 5) return 'Poor';
-    return 'Critical';
+export function fetchPerformanceSummary(signal?: AbortSignal): Promise<PerformanceSummary> {
+    return fetchJson(`${API_BASE}/performance/summary`, { signal }, 'Failed to fetch performance summary');
 }
 
 // ============================================================================
@@ -706,12 +572,12 @@ export interface TopGapsResponse {
 /**
  * Fetch top priority gaps with location names
  */
-export async function fetchTopGaps(limit: number = 10): Promise<TopGapsResponse> {
-    const response = await fetch(`${API_BASE}/performance/top-gaps?limit=${limit}`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch top gaps: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchTopGaps(limit: number = 10, signal?: AbortSignal): Promise<TopGapsResponse> {
+    return fetchJson(
+        withQuery(`${API_BASE}/performance/top-gaps`, { limit }),
+        { signal },
+        'Failed to fetch top gaps',
+    );
 }
 
 export interface LocationInfo {
@@ -725,12 +591,23 @@ export interface LocationInfo {
 /**
  * Fetch location name for given coordinates (reverse geocoding)
  */
-export async function fetchLocationName(lat: number, lon: number): Promise<LocationInfo> {
-    const response = await fetch(`${API_BASE}/performance/location?lat=${lat}&lon=${lon}`);
-    if (!response.ok) {
-        return { name: 'Unknown', region: '', country: '', lat, lon };
+export async function fetchLocationName(
+    lat: number,
+    lon: number,
+    signal?: AbortSignal,
+): Promise<LocationInfo> {
+    try {
+        return await fetchJson(
+            withQuery(`${API_BASE}/performance/location`, { lat, lon }),
+            { signal },
+            'Failed to fetch location name',
+        );
+    } catch (error: unknown) {
+        if (error instanceof ApiError && error.status > 0) {
+            return { name: 'Unknown', region: '', country: '', lat, lon };
+        }
+        throw error;
     }
-    return response.json();
 }
 
 // =============================================================================
@@ -802,15 +679,17 @@ export interface CombinedAccessResponse {
  */
 export async function fetchAffordability(
     monthlyCost: number = 120,
-    threshold: number = 2.0
+    threshold: number = 2.0,
+    signal?: AbortSignal,
 ): Promise<AffordabilityResponse> {
-    const response = await fetch(
-        `${API_BASE}/performance/affordability?monthly_cost=${monthlyCost}&threshold=${threshold}`
+    return fetchJson(
+        withQuery(`${API_BASE}/performance/affordability`, {
+            monthly_cost: monthlyCost,
+            threshold,
+        }),
+        { signal },
+        'Failed to fetch affordability data',
     );
-    if (!response.ok) {
-        throw new Error(`Failed to fetch affordability data: ${response.statusText}`);
-    }
-    return response.json();
 }
 
 /**
@@ -818,14 +697,15 @@ export async function fetchAffordability(
  * Shows TRUE_ACCESS, COVERAGE_NO_ACCESS, and INFRASTRUCTURE_GAP zones
  * @param monthlyCost - Internet cost per month (default: $120)
  */
-export async function fetchCombinedAccess(monthlyCost: number = 120): Promise<CombinedAccessResponse> {
-    const response = await fetch(
-        `${API_BASE}/performance/affordability/combined?monthly_cost=${monthlyCost}`
+export function fetchCombinedAccess(
+    monthlyCost: number = 120,
+    signal?: AbortSignal,
+): Promise<CombinedAccessResponse> {
+    return fetchJson(
+        withQuery(`${API_BASE}/performance/affordability/combined`, { monthly_cost: monthlyCost }),
+        { signal },
+        'Failed to fetch combined access data',
     );
-    if (!response.ok) {
-        throw new Error(`Failed to fetch combined access data: ${response.statusText}`);
-    }
-    return response.json();
 }
 
 // =============================================================================
@@ -869,23 +749,29 @@ export interface SafetyNetClassification {
 /**
  * Fetch affordability analysis for a specific region
  */
-export async function fetchRegionAffordability(regionCode: string): Promise<RegionAffordability> {
-    const response = await fetch(`${API_BASE}/regions/${regionCode}/affordability`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch region affordability: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchRegionAffordability(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<RegionAffordability> {
+    return fetchJson(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/affordability`,
+        { signal },
+        'Failed to fetch region affordability',
+    );
 }
 
 /**
  * Fetch safety net classification for a specific region
  */
-export async function fetchRegionSafetyNet(regionCode: string): Promise<SafetyNetClassification> {
-    const response = await fetch(`${API_BASE}/regions/${regionCode}/safety-net`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch safety net classification: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchRegionSafetyNet(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<SafetyNetClassification> {
+    return fetchJson(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/safety-net`,
+        { signal },
+        'Failed to fetch safety net classification',
+    );
 }
 
 // =============================================================================
@@ -895,7 +781,7 @@ export async function fetchRegionSafetyNet(regionCode: string): Promise<SafetyNe
 export interface TelehealthStatus {
     region_code: string;
     region_name: string;
-    status: 'TELEHEALTH_READY' | 'COMMUNITY_ANCHOR' | 'CRITICAL_GAP' | 'DATA_UNAVAILABLE';
+    status: TelehealthStatusName;
     color: string;
     label: string;
     description: string;
@@ -917,29 +803,15 @@ export interface TelehealthStatus {
  * Fetch composite telehealth status for a region
  * Combines affordability + clinic proximity into a single classification
  */
-export async function fetchTelehealthStatus(regionCode: string): Promise<TelehealthStatus> {
-    const response = await fetch(`${API_BASE}/regions/${regionCode}/telehealth-status`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch telehealth status: ${response.statusText}`);
-    }
-    return response.json();
-}
-
-/**
- * Get the color to use for a region marker based on telehealth status
- */
-export function getTelehealthStatusColor(status: TelehealthStatus['status']): string {
-    switch (status) {
-        case 'TELEHEALTH_READY':
-            return '#22c55e';  // Green
-        case 'COMMUNITY_ANCHOR':
-            return '#f59e0b';  // Amber
-        case 'CRITICAL_GAP':
-            return '#ef4444';  // Red
-        case 'DATA_UNAVAILABLE':
-        default:
-            return '#6b7280';  // Gray
-    }
+export function fetchTelehealthStatus(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<TelehealthStatus> {
+    return fetchJson(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/telehealth-status`,
+        { signal },
+        'Failed to fetch telehealth status',
+    );
 }
 
 // Bulk telehealth status for all regions
@@ -948,7 +820,7 @@ export interface RegionTelehealthStatus {
     region_name: string;
     lat: number;
     lon: number;
-    status: 'TELEHEALTH_READY' | 'COMMUNITY_ANCHOR' | 'CRITICAL_GAP' | 'DATA_UNAVAILABLE';
+    status: TelehealthStatusName;
     color: string;
     internet_cost: number | null;
     isp_name: string;
@@ -975,10 +847,10 @@ export interface AllTelehealthStatusResponse {
 /**
  * Fetch telehealth status for ALL regions (used by Affordability Layer)
  */
-export async function fetchAllTelehealthStatus(): Promise<AllTelehealthStatusResponse> {
-    const response = await fetch(`${API_BASE}/telehealth-status/all`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch all telehealth status: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchAllTelehealthStatus(signal?: AbortSignal): Promise<AllTelehealthStatusResponse> {
+    return fetchJson(
+        `${API_BASE}/telehealth-status/all`,
+        { signal },
+        'Failed to fetch all telehealth status',
+    );
 }

--- a/frontend/src/api/http.test.ts
+++ b/frontend/src/api/http.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, fetchJson, isAbortError, withQuery } from './http';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('fetchJson', () => {
+    it('returns typed JSON and forwards the abort signal', async () => {
+        const controller = new AbortController();
+        const fetchMock = vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ count: 3 }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchJson<{ count: number }>('/api/example', {
+            signal: controller.signal,
+        })).resolves.toEqual({ count: 3 });
+        expect(fetchMock).toHaveBeenCalledWith('/api/example', { signal: controller.signal });
+    });
+
+    it('throws an ApiError with response metadata and backend detail', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ error: 'Not available for this period' }),
+            { status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'application/json' } },
+        )));
+
+        const request = fetchJson('/api/example', {}, 'Could not load example');
+        await expect(request).rejects.toMatchObject({
+            name: 'ApiError',
+            status: 404,
+            statusText: 'Not Found',
+            message: 'Could not load example: Not available for this period',
+        } satisfies Partial<ApiError>);
+    });
+
+    it('normalizes network failures but preserves abort errors', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new TypeError('offline')));
+        await expect(fetchJson('/api/example')).rejects.toMatchObject({
+            name: 'ApiError',
+            status: 0,
+            message: 'This data source is currently unavailable: network request failed',
+        });
+
+        const abortError = new DOMException('Cancelled', 'AbortError');
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(abortError));
+        await expect(fetchJson('/api/example')).rejects.toBe(abortError);
+    });
+});
+
+describe('HTTP helpers', () => {
+    it('builds queries without empty values', () => {
+        expect(withQuery('/api/example', {
+            season: 'winter',
+            limit: 0,
+            optional: null,
+        })).toBe('/api/example?season=winter&limit=0');
+    });
+
+    it('recognizes abort errors without treating ordinary failures as cancellation', () => {
+        expect(isAbortError(new DOMException('Cancelled', 'AbortError'))).toBe(true);
+        expect(isAbortError(new Error('Network unavailable'))).toBe(false);
+    });
+});

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,119 @@
+export type QueryValue = string | number | boolean | null | undefined;
+
+export class ApiError extends Error {
+    readonly status: number;
+    readonly statusText: string;
+    readonly url: string;
+    readonly body: unknown;
+
+    constructor({
+        message,
+        status,
+        statusText,
+        url,
+        body,
+        cause,
+    }: {
+        message: string;
+        status: number;
+        statusText: string;
+        url: string;
+        body?: unknown;
+        cause?: unknown;
+    }) {
+        super(message);
+        if (cause !== undefined) {
+            (this as Error & { cause?: unknown }).cause = cause;
+        }
+        this.name = 'ApiError';
+        this.status = status;
+        this.statusText = statusText;
+        this.url = url;
+        this.body = body;
+    }
+}
+
+function responseErrorDetail(body: unknown): string | null {
+    if (!body || typeof body !== 'object') return null;
+    const candidate = body as { error?: unknown; message?: unknown };
+    if (typeof candidate.error === 'string' && candidate.error.trim()) return candidate.error;
+    if (typeof candidate.message === 'string' && candidate.message.trim()) return candidate.message;
+    return null;
+}
+
+async function readErrorBody(response: Response): Promise<unknown> {
+    const contentType = response.headers.get('content-type') ?? '';
+    try {
+        return contentType.includes('application/json')
+            ? await response.json()
+            : await response.text();
+    } catch {
+        return null;
+    }
+}
+
+export async function fetchJson<T>(
+    url: string,
+    init: RequestInit = {},
+    errorMessage = 'This data source is currently unavailable',
+): Promise<T> {
+    let response: Response;
+    try {
+        response = await fetch(url, init);
+    } catch (cause: unknown) {
+        if (isAbortError(cause)) throw cause;
+        throw new ApiError({
+            message: `${errorMessage}: network request failed`,
+            status: 0,
+            statusText: '',
+            url,
+            cause,
+        });
+    }
+
+    if (!response.ok) {
+        const body = await readErrorBody(response);
+        const detail = responseErrorDetail(body) || response.statusText;
+        throw new ApiError({
+            message: detail ? `${errorMessage}: ${detail}` : errorMessage,
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url || url,
+            body,
+        });
+    }
+
+    try {
+        return await response.json() as T;
+    } catch (cause: unknown) {
+        throw new ApiError({
+            message: `${errorMessage}: invalid JSON response`,
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url || url,
+            cause,
+        });
+    }
+}
+
+export function withQuery<T extends object>(url: string, params: T): string {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]: [string, QueryValue]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            query.set(key, String(value));
+        }
+    });
+    const suffix = query.toString();
+    return suffix ? `${url}?${suffix}` : url;
+}
+
+export function isAbortError(error: unknown): boolean {
+    return error instanceof DOMException
+        ? error.name === 'AbortError'
+        : error instanceof Error && error.name === 'AbortError';
+}
+
+export function errorMessage(error: unknown, fallback = 'This data source is currently unavailable.'): string {
+    if (error instanceof Error && error.message.trim()) return error.message;
+    return fallback;
+}

--- a/frontend/src/api/researchApi.ts
+++ b/frontend/src/api/researchApi.ts
@@ -1,35 +1,30 @@
 import { Season, API_BASE } from './catApi';
 import { ResearchProfile, ResearchProfilesResponse } from '../types/research';
+import { fetchJson, withQuery } from './http';
 
 export async function fetchResearchProfile(
     regionCode: string,
     season: Season = 'year_round',
+    signal?: AbortSignal,
 ): Promise<ResearchProfile> {
-    const params = new URLSearchParams({ season });
-    const response = await fetch(
-        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/research-profile?${params.toString()}`,
+    return fetchJson<ResearchProfile>(
+        withQuery(`${API_BASE}/regions/${encodeURIComponent(regionCode)}/research-profile`, { season }),
+        { signal },
+        'Failed to fetch research profile',
     );
-
-    if (!response.ok) {
-        throw new Error(response.status === 404 ? 'Community not found' : 'Failed to fetch research profile');
-    }
-
-    return response.json();
 }
 
 export async function fetchResearchProfiles(
     regionCodes: string[],
     season: Season = 'year_round',
+    signal?: AbortSignal,
 ): Promise<ResearchProfilesResponse> {
-    const params = new URLSearchParams({
-        codes: regionCodes.slice(0, 3).join(','),
-        season,
-    });
-    const response = await fetch(`${API_BASE}/regions/research-profiles?${params.toString()}`);
-
-    if (!response.ok) {
-        throw new Error('Failed to fetch comparison profiles');
-    }
-
-    return response.json();
+    return fetchJson<ResearchProfilesResponse>(
+        withQuery(`${API_BASE}/regions/research-profiles`, {
+            codes: regionCodes.slice(0, 3).join(','),
+            season,
+        }),
+        { signal },
+        'Failed to fetch comparison profiles',
+    );
 }

--- a/frontend/src/api/scenarioApi.ts
+++ b/frontend/src/api/scenarioApi.ts
@@ -5,6 +5,7 @@
 import type { Season } from './catApi';
 import { API_BASE } from './catApi';
 import type { ScenarioPreviewResponse, ScenarioThresholds } from '../types/scenario';
+import { fetchJson } from './http';
 
 export interface ScenarioPreviewRequest {
     mode: 'preview';
@@ -22,17 +23,10 @@ export async function fetchScenarioPreview(
     request: ScenarioPreviewRequest,
     signal?: AbortSignal,
 ): Promise<ScenarioPreviewResponse> {
-    const response = await fetch(`${API_BASE}/scenarios/preview`, {
+    return fetchJson<ScenarioPreviewResponse>(`${API_BASE}/scenarios/preview`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),
         signal,
-    });
-
-    if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({}));
-        throw new Error(errorBody.error || `Scenario preview failed: ${response.statusText}`);
-    }
-
-    return response.json();
+    }, 'Scenario preview failed');
 }

--- a/frontend/src/components/DataCoveragePanel.css
+++ b/frontend/src/components/DataCoveragePanel.css
@@ -1,49 +1,233 @@
-.data-coverage-hover {
-    position: absolute;
-    left: 20px;
-    bottom: 80px;
-    z-index: 1000;
+.data-coverage-popover {
+  position: absolute;
+  bottom: var(--spacing-6);
+  left: var(--spacing-4);
+  z-index: var(--z-overlay);
 }
 
 .data-coverage-trigger {
-    border: 1px solid rgba(148, 163, 184, 0.75);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.94);
-    color: #1e293b;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.16);
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 800;
-    cursor: help;
+  box-shadow: var(--shadow-md);
 }
 
 .data-coverage-panel {
-    position: absolute;
-    left: 0;
-    bottom: calc(100% + 10px);
-    width: min(280px, calc(100vw - 32px));
-    max-height: min(70vh, 620px);
-    overflow: auto;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-    transition: opacity 0.16s ease, transform 0.16s ease;
+  position: absolute;
+  bottom: calc(100% + var(--spacing-2));
+  left: 0;
+  width: min(300px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-text);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.data-coverage-hover:hover .data-coverage-panel,
-.data-coverage-hover:focus-within .data-coverage-panel {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
+.data-coverage-panel[hidden] {
+  display: none;
+}
+
+.data-coverage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-2);
+}
+
+.data-coverage-header h4 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.data-coverage-header span,
+.data-coverage-source {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-state {
+  padding: var(--spacing-5) 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  text-align: center;
+}
+
+.data-coverage-state--error {
+  color: var(--color-danger);
+}
+
+.data-coverage-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+}
+
+.data-coverage-stats > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-3);
+}
+
+.data-coverage-stats span,
+.data-coverage-stats small {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-stats strong {
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+}
+
+.data-coverage-stat--alert strong,
+.data-coverage-stat--alert small {
+  color: var(--color-danger);
+}
+
+.data-coverage-section {
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-3);
+}
+
+.data-coverage-section h5 {
+  margin-bottom: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.data-coverage-distribution {
+  display: flex;
+  gap: 2px;
+  height: 8px;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-muted);
+}
+
+.data-coverage-distribution span {
+  min-width: 3px;
+}
+
+.data-coverage-distribution .is-high,
+.data-coverage-key .is-high {
+  background: var(--color-status-ready);
+}
+
+.data-coverage-distribution .is-medium,
+.data-coverage-key .is-medium {
+  background: #d97706;
+}
+
+.data-coverage-distribution .is-low,
+.data-coverage-key .is-low {
+  background: var(--color-status-gap);
+}
+
+.data-coverage-key {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-key span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.data-coverage-key i {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.data-coverage-access {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+}
+
+.data-coverage-access div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-2);
+}
+
+.data-coverage-access strong {
+  color: var(--color-text);
+  font-size: var(--font-base);
+}
+
+.data-coverage-access span {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-gaps {
+  display: grid;
+  gap: var(--spacing-1);
+}
+
+.data-coverage-gaps > div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-1);
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+}
+
+.data-coverage-gaps strong {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.data-coverage-gaps strong.is-error {
+  color: var(--color-danger);
+}
+
+.data-coverage-gaps strong.is-warning {
+  color: var(--color-status-anchor);
+}
+
+.data-coverage-source {
+  margin-top: var(--spacing-3);
 }
 
 @media (max-width: 900px) {
-    .data-coverage-hover {
-        left: 12px;
-        bottom: 14px;
-    }
+  .data-coverage-popover {
+    bottom: calc(46vh + var(--spacing-5));
+    left: var(--spacing-3);
+  }
 
-    .data-coverage-panel {
-        max-height: 52vh;
-    }
+  .data-coverage-panel {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 700px) {
+  .data-coverage-panel {
+    max-height: max(140px, calc(54dvh - 214px));
+  }
 }

--- a/frontend/src/components/DataCoveragePanel.tsx
+++ b/frontend/src/components/DataCoveragePanel.tsx
@@ -1,10 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import {
-    DataGapsSummary,
+    type DataGapsSummary,
     fetchDataGapsSummary,
-    getConfidenceColor,
-    getDataGapInfo
 } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+import {
+    DATA_CONFIDENCE_LEVELS,
+    DATA_CONFIDENCE_PRESENTATION,
+    getDataGapPresentation,
+} from '../domain/metrics';
+import Button from './ui/Button';
+import IconButton from './ui/IconButton';
 import './DataCoveragePanel.css';
 
 interface DataCoveragePanelProps {
@@ -13,250 +19,197 @@ interface DataCoveragePanelProps {
     totalRegions?: number;
 }
 
-/**
- * Panel showing data coverage and data gaps summary
- * Supports the 'data coverage/confidence' layer visualization
- */
-export default function DataCoveragePanel({ isExpanded = false, onToggle, totalRegions }: DataCoveragePanelProps) {
+export default function DataCoveragePanel({
+    isExpanded = false,
+    onToggle,
+}: DataCoveragePanelProps) {
     const [summary, setSummary] = useState<DataGapsSummary | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [open, setOpen] = useState(false);
+    const shellRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelId = useId();
 
     useEffect(() => {
+        const controller = new AbortController();
         async function loadData() {
             try {
                 setLoading(true);
-                const data = await fetchDataGapsSummary();
+                const data = await fetchDataGapsSummary(controller.signal);
                 setSummary(data);
                 setError(null);
-            } catch (err) {
-                setError(err instanceof Error ? err.message : 'Failed to load data gaps');
-                console.error('Error loading data gaps:', err);
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to load data gaps'));
+                }
             } finally {
-                setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             }
         }
         loadData();
+        return () => controller.abort();
     }, []);
 
-    const renderShell = (content: React.ReactNode) => (
-        <div className="data-coverage-hover">
-            <button type="button" className="data-coverage-trigger" aria-label="Show data coverage layer legend">
-                Data
-            </button>
-            <div className="data-coverage-panel" style={panelStyle}>
-                {content}
+    useEffect(() => {
+        if (!open) return;
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!shellRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            setOpen(false);
+            triggerRef.current?.focus();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [open]);
+
+    const close = () => {
+        setOpen(false);
+        triggerRef.current?.focus();
+    };
+
+    const totalPlaces = summary?.total_places ?? 0;
+    const gapsPercentage = summary && summary.total_places > 0
+        ? Math.round((summary.places_with_gaps / summary.total_places) * 100)
+        : 0;
+    const satellitePercent = summary && summary.total_places > 0
+        ? Math.round(((summary.primary_access.SATELLITE ?? 0) / summary.total_places) * 100)
+        : null;
+
+    return (
+        <div ref={shellRef} className="data-coverage-popover">
+            <Button
+                ref={triggerRef}
+                size="small"
+                className="data-coverage-trigger"
+                aria-label={open ? 'Close data coverage summary' : 'Open data coverage summary'}
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => setOpen(value => !value)}
+            >
+                Data coverage
+            </Button>
+
+            <div
+                id={panelId}
+                className="data-coverage-panel"
+                role="region"
+                aria-label="Data coverage summary"
+                hidden={!open}
+            >
+                <div className="data-coverage-header">
+                    <div>
+                        <h4>Data Coverage</h4>
+                        <span>Availability and confidence</span>
+                    </div>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        aria-label="Close data coverage summary"
+                        onClick={close}
+                    />
+                </div>
+
+                {loading && <div className="data-coverage-state" role="status">Loading coverage data…</div>}
+
+                {!loading && (error || !summary) && (
+                    <div className="data-coverage-state data-coverage-state--error" role="alert">
+                        {error || 'No data available'}
+                    </div>
+                )}
+
+                {!loading && summary && (
+                    <>
+                        <div className="data-coverage-stats">
+                            <div>
+                                <span>Broadband places</span>
+                                <strong>{totalPlaces}</strong>
+                            </div>
+                            <div className="data-coverage-stat--alert">
+                                <span>With data gaps</span>
+                                <strong>{summary.places_with_gaps}</strong>
+                                <small>{gapsPercentage}% of total</small>
+                            </div>
+                        </div>
+
+                        <section className="data-coverage-section">
+                            <h5>Data confidence</h5>
+                            <div className="data-coverage-distribution" aria-label="Data confidence distribution">
+                                {DATA_CONFIDENCE_LEVELS.map(level => {
+                                    const count = summary.confidence_distribution[level];
+                                    const presentation = DATA_CONFIDENCE_PRESENTATION[level];
+                                    return (
+                                        <span
+                                            key={level}
+                                            className={presentation.className}
+                                            style={{ flex: count, display: count > 0 ? undefined : 'none' }}
+                                            title={`${count} ${presentation.label.toLowerCase()}-confidence places`}
+                                        />
+                                    );
+                                })}
+                            </div>
+                            <div className="data-coverage-key">
+                                {DATA_CONFIDENCE_LEVELS.map(level => {
+                                    const presentation = DATA_CONFIDENCE_PRESENTATION[level];
+                                    return (
+                                        <span key={level}>
+                                            <i className={presentation.className} />
+                                            {presentation.label} {summary.confidence_distribution[level]}
+                                        </span>
+                                    );
+                                })}
+                            </div>
+                        </section>
+
+                        <section className="data-coverage-section">
+                            <h5>Primary internet access</h5>
+                            <div className="data-coverage-access">
+                                <div><strong>{satellitePercent === null ? '—' : `${satellitePercent}%`}</strong><span>Satellite</span></div>
+                                <div><strong>{satellitePercent === null ? '—' : `${100 - satellitePercent}%`}</strong><span>Wired or other</span></div>
+                            </div>
+                        </section>
+
+                        {(isExpanded || !onToggle) && (
+                            <section className="data-coverage-section">
+                                <h5>Most common gap types</h5>
+                                <div className="data-coverage-gaps">
+                                    {Object.entries(summary.gap_breakdown)
+                                        .filter(([, data]) => data.count > 0)
+                                        .sort(([, a], [, b]) => b.count - a.count)
+                                        .slice(0, 5)
+                                        .map(([gapType, data]) => {
+                                            const info = getDataGapPresentation(gapType);
+                                            return (
+                                                <div key={gapType}>
+                                                    <span>{info.label}</span>
+                                                    <strong className={`is-${info.severity}`}>
+                                                        {data.count} ({data.percentage}%)
+                                                    </strong>
+                                                </div>
+                                            );
+                                        })}
+                                </div>
+                            </section>
+                        )}
+
+                        {onToggle && (
+                            <Button size="small" variant="ghost" onClick={onToggle}>
+                                {isExpanded ? 'Show less detail' : 'Show more detail'}
+                            </Button>
+                        )}
+
+                        <div className="data-coverage-source">Source: FCC Broadband Availability</div>
+                    </>
+                )}
             </div>
         </div>
     );
-
-    if (loading) {
-        return renderShell(
-            <>
-                <div style={{ padding: '24px 24px 8px 24px', fontSize: '16px', fontWeight: '500', color: '#181d26' }}>
-                    <span>Data Coverage Layer</span>
-                </div>
-                <div style={{ padding: '8px 24px 24px 24px', fontSize: '12px', color: '#41454d' }}>
-                    Loading...
-                </div>
-            </>
-        );
-    }
-
-    if (error || !summary) {
-        return renderShell(
-            <>
-                <div style={{ padding: '24px 24px 8px 24px', fontSize: '16px', fontWeight: '500', color: '#181d26' }}>
-                    <span>Data Coverage Layer</span>
-                </div>
-                <div style={{ padding: '8px 24px 24px 24px', fontSize: '12px', color: '#dc2626' }}>
-                    {error || 'No data available'}
-                </div>
-            </>
-        );
-    }
-
-    const gapsPercentage = Math.round((summary.places_with_gaps / summary.total_places) * 100);
-    const satellitePercent = Math.round((summary.primary_access.SATELLITE / summary.total_places) * 100);
-
-    return renderShell(
-        <>
-            {/* Header */}
-            <div
-                style={{
-                    padding: '24px 24px 8px 24px',
-                    fontSize: '16px',
-                    fontWeight: '500',
-                    color: '#181d26',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    cursor: onToggle ? 'pointer' : 'default'
-                }}
-                onClick={onToggle}
-            >
-                <span>Data Coverage Layer</span>
-                {onToggle && (
-                    <span style={{ fontSize: '10px', marginLeft: '8px', color: '#9297a0' }}>
-                        {isExpanded ? '▼' : '▶'}
-                    </span>
-                )}
-            </div>
-
-            {/* Quick Stats */}
-            <div style={{ padding: '8px 24px 16px 24px' }}>
-                <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: '1fr 1fr',
-                    gap: '16px'
-                }}>
-                    <div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginBottom: '4px' }}>Total Places</div>
-                        <div style={{ fontWeight: '400', fontSize: '24px', color: '#181d26', letterSpacing: '-0.02em' }}>
-                            {summary.total_places}
-                        </div>
-                    </div>
-                    <div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginBottom: '4px' }}>With Data Gaps</div>
-                        <div style={{ fontWeight: '400', fontSize: '24px', color: '#aa2d00', letterSpacing: '-0.02em' }}>
-                            {summary.places_with_gaps} <span style={{ fontSize: '13px', fontWeight: '400', color: '#aa2d00' }}>({gapsPercentage}%)</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            {/* Confidence Distribution */}
-            <div style={{ padding: '16px 24px' }}>
-                <div style={{ fontSize: '12px', color: '#181d26', marginBottom: '12px', fontWeight: '500' }}>
-                    Data Confidence
-                </div>
-                <div style={{ display: 'flex', gap: '2px', height: '8px', borderRadius: '4px', overflow: 'hidden' }}>
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.HIGH,
-                            backgroundColor: '#006400',
-                            minWidth: summary.confidence_distribution.HIGH > 0 ? '4px' : '0'
-                        }}
-                    />
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.MEDIUM,
-                            backgroundColor: '#f4d35e',
-                            minWidth: summary.confidence_distribution.MEDIUM > 0 ? '4px' : '0'
-                        }}
-                    />
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.LOW,
-                            backgroundColor: '#aa2d00',
-                            minWidth: summary.confidence_distribution.LOW > 0 ? '4px' : '0'
-                        }}
-                    />
-                </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '10px', fontSize: '11px', color: '#41454d' }}>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#006400' }} />
-                        High
-                    </span>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#f4d35e' }} />
-                        Med
-                    </span>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#aa2d00' }} />
-                        Low
-                    </span>
-                </div>
-            </div>
-
-            {/* Primary Access Type */}
-            <div style={{ padding: '16px 24px' }}>
-                <div style={{ fontSize: '12px', color: '#181d26', marginBottom: '12px', fontWeight: '500' }}>
-                    Primary Internet Access
-                </div>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                    <div style={{
-                        flex: 1,
-                        padding: '12px',
-                        borderRadius: '6px',
-                        backgroundColor: '#f8fafc',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center'
-                    }}>
-                        <div style={{ fontWeight: '400', color: '#181d26', fontSize: '18px' }}>{satellitePercent}%</div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginTop: '4px' }}>Satellite</div>
-                    </div>
-                    <div style={{
-                        flex: 1,
-                        padding: '12px',
-                        borderRadius: '6px',
-                        backgroundColor: '#f8fafc',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center'
-                    }}>
-                        <div style={{ fontWeight: '400', color: '#181d26', fontSize: '18px' }}>{100 - satellitePercent}%</div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginTop: '4px' }}>Wired</div>
-                    </div>
-                </div>
-            </div>
-
-            {/* Expanded: Gap Breakdown */}
-            {(isExpanded || !onToggle) && (
-                <div style={{ padding: '10px 12px' }}>
-                    <div style={{ fontSize: '11px', color: '#6b7280', marginBottom: '6px', fontWeight: '600' }}>
-                        Data Gap Types
-                    </div>
-                    {Object.entries(summary.gap_breakdown)
-                        .filter(([_, data]) => data.count > 0)
-                        .sort(([_, a], [__, b]) => b.count - a.count)
-                        .slice(0, 5)
-                        .map(([gapType, data]) => {
-                            const info = getDataGapInfo(gapType);
-                            return (
-                                <div key={gapType} style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    padding: '4px 0',
-                                    fontSize: '11px',
-                                    borderBottom: '1px solid #f3f4f6'
-                                }}>
-                                    <span>{info.label}</span>
-                                    <span style={{
-                                        color: info.severity === 'error' ? '#dc2626' :
-                                            info.severity === 'warning' ? '#f97316' : '#6b7280',
-                                        fontWeight: '500'
-                                    }}>
-                                        {data.count} ({data.percentage}%)
-                                    </span>
-                                </div>
-                            );
-                        })}
-                </div>
-            )}
-
-            {/* Footer Note */}
-            <div style={{
-                padding: '16px 24px 24px 24px',
-                fontSize: '11px',
-                color: '#9297a0'
-            }}>
-                Data source: FCC Broadband Availability
-            </div>
-        </>
-    );
 }
-
-// Airtable Styles (Flat Canvas, Hairline Border)
-const panelStyle: React.CSSProperties = {
-    minWidth: '240px',
-    maxWidth: '280px',
-    background: '#ffffff',
-    borderRadius: '10px',
-    border: '1px solid #dddddd',
-    fontSize: '13px',
-    overflow: 'hidden',
-    fontFamily: 'inherit'
-};

--- a/frontend/src/components/Legend.css
+++ b/frontend/src/components/Legend.css
@@ -1,216 +1,174 @@
-.legend-hover-shell {
-    position: absolute;
-    right: 20px;
-    bottom: 80px;
-    z-index: 1000;
+.legend-popover {
+  position: absolute;
+  right: var(--spacing-4);
+  bottom: var(--spacing-6);
+  z-index: var(--z-overlay);
 }
 
-.legend-hover-shell-left {
-    right: auto;
-    left: 20px;
+.legend-popover--left {
+  right: auto;
+  left: var(--spacing-4);
 }
 
 .legend-trigger {
-    border: 1px solid rgba(148, 163, 184, 0.75);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.94);
-    color: #1e293b;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.16);
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 800;
-    cursor: help;
+  box-shadow: var(--shadow-md);
 }
 
 .legend-panel {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 10px);
-    width: min(320px, calc(100vw - 32px));
-    max-height: min(70vh, 620px);
-    overflow: auto;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-    transition: opacity 0.16s ease, transform 0.16s ease;
-    background: rgba(255, 255, 255, 0.94);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    padding: 16px 18px;
-    border-radius: 12px;
-    border: 1px solid rgba(203, 213, 225, 0.9);
-    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.18);
-    font-size: 12px;
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + var(--spacing-2));
+  width: min(320px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-text);
+  font-size: var(--font-xs);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.legend-hover-shell-left .legend-panel {
-    right: auto;
-    left: 0;
+.legend-panel[hidden] {
+  display: none;
 }
 
-.legend-hover-shell:hover .legend-panel,
-.legend-hover-shell:focus-within .legend-panel {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    transform: translateY(0);
+.legend-popover--left .legend-panel {
+  right: auto;
+  left: 0;
 }
 
 .legend-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 12px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-2);
 }
 
 .legend-header h4 {
-    margin: 0;
-    color: #0f172a;
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0;
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  font-weight: 700;
 }
 
 .legend-header span {
-    color: #64748b;
-    font-size: 10px;
-    font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 600;
 }
 
 .legend-section {
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid #e5e7eb;
-    display: grid;
-    gap: 8px;
+  display: grid;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-3);
 }
 
 .legend-section-title {
-    color: #334155;
-    font-weight: 800;
-    margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-weight: 700;
 }
 
 .legend-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    margin-bottom: 8px;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .legend-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    margin-top: 3px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  margin-top: 3px;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xs);
 }
 
 .legend-row-label {
-    color: #1e293b;
-    font-weight: 600;
+  color: var(--color-text);
+  font-weight: 600;
 }
 
 .legend-row-note,
 .legend-copy {
-    color: #64748b;
-    font-size: 11px;
-    line-height: 1.4;
-}
-
-.legend-copy {
-    color: #475569;
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+  line-height: 1.4;
 }
 
 .legend-tier-list {
-    display: grid;
-    gap: 6px;
-    color: #475569;
-    font-size: 11px;
-    line-height: 1.4;
+  display: grid;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.4;
 }
 
 .legend-tier-list strong {
-    color: #1e293b;
-}
-
-.legend-chip-row {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-}
-
-.legend-chip {
-    border-radius: 999px;
-    padding: 3px 7px;
-    font-size: 10px;
-    font-weight: 800;
-}
-
-.legend-chip.high {
-    background: #dcfce7;
-    color: #166534;
-}
-
-.legend-chip.low {
-    background: #fef3c7;
-    color: #92400e;
-}
-
-.legend-chip.missing {
-    background: #fee2e2;
-    color: #b91c1c;
+  color: var(--color-text);
 }
 
 .legend-footer-row {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid #e5e7eb;
-    color: #64748b;
-    display: flex;
-    justify-content: space-between;
-    font-size: 10px;
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
 }
 
 .legend-footer-row strong {
-    color: #334155;
+  color: var(--color-text-secondary);
 }
 
 .legend-scale {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid #e5e7eb;
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
 }
 
 .legend-gradient {
-    height: 6px;
-    border-radius: 3px;
-    margin-bottom: 4px;
+  height: 6px;
+  margin-bottom: var(--spacing-1);
+  border-radius: var(--radius-full);
 }
 
 .legend-scale-labels {
-    display: flex;
-    justify-content: space-between;
-    color: #94a3b8;
-    font-size: 9px;
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
 }
 
 @media (max-width: 900px) {
-    .legend-hover-shell {
-        right: 12px;
-        bottom: 14px;
-    }
+  .legend-popover {
+    right: var(--spacing-3);
+    bottom: calc(46vh + var(--spacing-5));
+  }
 
-    .legend-hover-shell-left {
-        right: auto;
-        left: 12px;
-    }
+  .legend-popover--left {
+    right: auto;
+    left: var(--spacing-3);
+  }
 
-    .legend-panel {
-        max-height: 52vh;
-    }
+  .legend-panel {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 700px) {
+  .legend-panel {
+    max-height: max(140px, calc(54dvh - 214px));
+  }
 }

--- a/frontend/src/components/Legend.test.tsx
+++ b/frontend/src/components/Legend.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import Legend from './Legend';
 
@@ -25,5 +25,21 @@ describe('Legend', () => {
 
         expect(screen.getByLabelText(/Healthcare Desert Score: A 0-100 need score/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/CAT Tier: Community Access Tier summarizes/i)).toBeInTheDocument();
+    });
+
+    it('opens on click and closes with Escape', () => {
+        render(<Legend />);
+
+        const trigger = screen.getByRole('button', { name: 'Open discovery legend' });
+        const panel = document.querySelector('[role="region"][aria-label="Discovery legend"]') as HTMLElement;
+        expect(panel).not.toBeVisible();
+
+        fireEvent.click(trigger);
+        expect(panel).toBeVisible();
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(panel).not.toBeVisible();
+        expect(trigger).toHaveFocus();
     });
 });

--- a/frontend/src/components/Legend.tsx
+++ b/frontend/src/components/Legend.tsx
@@ -1,6 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { getNeedColor, getNeedLabel } from '../api/catApi';
+import { useEffect, useId, useRef, useState } from 'react';
+import {
+    CAT_TIERS,
+    CAT_TIER_PRESENTATION,
+    getDesertScorePresentation,
+} from '../domain/metrics';
 import MetricTooltip from './MetricTooltip';
+import Button from './ui/Button';
+import IconButton from './ui/IconButton';
 import './Legend.css';
 
 interface LegendProps {
@@ -8,26 +14,71 @@ interface LegendProps {
     position?: 'bottom-right' | 'bottom-left';
 }
 
-const getNeedCapability = (score: number): string => {
-    if (score >= 75) return 'Severe lack of nearby healthcare facilities';
-    if (score >= 50) return 'Limited access to clinics or hospitals';
-    if (score >= 25) return 'Adequate access with some travel distance';
-    return 'Good access to nearby healthcare facilities';
-};
-
 export default function Legend({ totalRegions, position = 'bottom-right' }: LegendProps) {
     const needLevels = [87, 62, 37, 12];
+    const [open, setOpen] = useState(false);
+    const shellRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelId = useId();
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!shellRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            setOpen(false);
+            triggerRef.current?.focus();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [open]);
 
     return (
-        <div className={`legend-hover-shell ${position === 'bottom-left' ? 'legend-hover-shell-left' : ''}`}>
-            <button type="button" className="legend-trigger" aria-label="Show discovery legend">
+        <div
+            ref={shellRef}
+            className={`legend-popover ${position === 'bottom-left' ? 'legend-popover--left' : ''}`}
+        >
+            <Button
+                ref={triggerRef}
+                size="small"
+                className="legend-trigger"
+                aria-label={open ? 'Close discovery legend' : 'Open discovery legend'}
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => setOpen(value => !value)}
+            >
                 Legend
-            </button>
+            </Button>
 
-            <div className="legend-panel">
+            <div
+                id={panelId}
+                className="legend-panel"
+                role="region"
+                aria-label="Discovery legend"
+                hidden={!open}
+            >
                 <div className="legend-header">
-                    <h4>Discovery Legend</h4>
-                    <span>Plain-language guide</span>
+                    <div>
+                        <h4>Discovery Legend</h4>
+                        <span>Plain-language guide</span>
+                    </div>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        aria-label="Close discovery legend"
+                        onClick={() => {
+                            setOpen(false);
+                            triggerRef.current?.focus();
+                        }}
+                    />
                 </div>
 
                 <div className="legend-section-title">
@@ -37,19 +88,22 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                     </MetricTooltip>
                 </div>
 
-                {needLevels.map(score => (
-                    <div key={score} className="legend-row">
-                        <span
-                            className="legend-dot"
-                            style={{ backgroundColor: getNeedColor(score) }}
-                            aria-hidden="true"
-                        />
-                        <div>
-                            <div className="legend-row-label">{getNeedLabel(score)}</div>
-                            <div className="legend-row-note">{getNeedCapability(score)}</div>
+                {needLevels.map(score => {
+                    const presentation = getDesertScorePresentation(score);
+                    return (
+                        <div key={score} className="legend-row">
+                            <span
+                                className="legend-dot"
+                                style={{ backgroundColor: presentation.color }}
+                                aria-hidden="true"
+                            />
+                            <div>
+                                <div className="legend-row-label">{presentation.label}</div>
+                                <div className="legend-row-note">{presentation.description}</div>
+                            </div>
                         </div>
-                    </div>
-                ))}
+                    );
+                })}
 
                 <div className="legend-section">
                     <div className="legend-section-title">
@@ -59,10 +113,11 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                         </MetricTooltip>
                     </div>
                     <div className="legend-tier-list">
-                        <div><strong>Tier 1:</strong> strongest access; road-connected or easier service reach.</div>
-                        <div><strong>Tier 2:</strong> moderate access; some travel or logistics constraints.</div>
-                        <div><strong>Tier 3:</strong> limited access; remote travel makes care harder to reach.</div>
-                        <div><strong>Tier 4:</strong> most isolated; highest transport and service-access barriers.</div>
+                        {CAT_TIERS.map(tier => (
+                            <div key={tier}>
+                                <strong>Tier {tier}:</strong> {CAT_TIER_PRESENTATION[tier].shortDescription}
+                            </div>
+                        ))}
                     </div>
                 </div>
 
@@ -77,7 +132,7 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                     <div
                         className="legend-gradient"
                         style={{
-                            background: `linear-gradient(to right, ${getNeedColor(12)}, ${getNeedColor(37)}, ${getNeedColor(62)}, ${getNeedColor(87)})`,
+                            background: `linear-gradient(to right, ${needLevels.slice().reverse().map(score => getDesertScorePresentation(score).color).join(', ')})`,
                         }}
                     />
                     <div className="legend-scale-labels">

--- a/frontend/src/components/SeasonSelector.css
+++ b/frontend/src/components/SeasonSelector.css
@@ -1,0 +1,33 @@
+.season-selector {
+  width: 100%;
+  min-width: 134px;
+  height: var(--control-height-sm);
+  appearance: none;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23536176' d='M3 4.5L6 7.5L9 4.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  color: var(--color-text-secondary);
+  padding: 0 32px 0 var(--spacing-3);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.season-selector:hover {
+  border-color: #94a3b8;
+}
+
+.season-selector:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
+}
+
+@media (max-width: 430px) {
+  .season-selector {
+    min-width: 0;
+  }
+}

--- a/frontend/src/components/SeasonSelector.tsx
+++ b/frontend/src/components/SeasonSelector.tsx
@@ -1,47 +1,19 @@
 import type { Season } from '../api/catApi';
+import './SeasonSelector.css';
 
 interface SeasonSelectorProps {
     season: Season;
     onChange: (season: Season) => void;
 }
 
-/**
- * Season selector dropdown for TENeT.
- * Clean dropdown design for the top-right info panel.
- */
 export default function SeasonSelector({ season, onChange }: SeasonSelectorProps) {
-    const getLabel = (s: Season): string => {
-        switch (s) {
-            case 'summer': return 'Summer';
-            case 'winter': return 'Winter';
-            case 'year_round': return 'Year-Round Average';
-        }
-    };
-
     return (
         <select
+            className="season-selector"
             aria-label="Season scenario"
             data-testid="season-selector"
             value={season}
             onChange={(e) => onChange(e.target.value as Season)}
-            style={{
-                padding: '8px 12px',
-                fontSize: '12px',
-                fontWeight: '500',
-                color: '#475569',
-                backgroundColor: 'white',
-                border: '1px solid rgba(0, 0, 0, 0.1)',
-                borderRadius: '8px',
-                cursor: 'pointer',
-                outline: 'none',
-                appearance: 'none',
-                WebkitAppearance: 'none',
-                backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23475569' d='M3 4.5L6 7.5L9 4.5'/%3E%3C/svg%3E")`,
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'right 10px center',
-                paddingRight: '32px',
-                minWidth: '140px'
-            }}
             title="Select season scenario"
         >
             <option value="summer">Summer</option>

--- a/frontend/src/components/dashboard/Dashboard.css
+++ b/frontend/src/components/dashboard/Dashboard.css
@@ -1,0 +1,534 @@
+.insights-page {
+  position: relative;
+  z-index: var(--z-overlay);
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background: var(--color-canvas);
+  color: var(--color-text);
+}
+
+.insights-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-6);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4) max(var(--spacing-6), calc((100vw - 1320px) / 2));
+  box-shadow: var(--shadow-xs);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.insights-header h1 {
+  margin: 2px 0;
+  color: var(--color-text);
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.insights-header p {
+  max-width: 720px;
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.insights-content {
+  display: grid;
+  gap: var(--spacing-5);
+  width: min(1320px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: var(--spacing-6) 0 var(--spacing-10);
+}
+
+.insights-eyebrow {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.insights-partial-notice {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  border: 1px solid #fde68a;
+  border-radius: var(--radius-md);
+  background: var(--color-status-anchor-subtle);
+  padding: var(--spacing-3) var(--spacing-4);
+  color: #78350f;
+  font-size: var(--font-xs);
+}
+
+.insights-overview {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.insights-section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.insights-section-heading h2,
+.insights-panel__header h2 {
+  margin: 2px 0 0;
+  color: var(--color-text);
+  font-size: var(--font-lg);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.insights-source-note {
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+}
+
+.insights-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--spacing-3);
+}
+
+.insights-metric-grid .ui-metric-card,
+.insights-inline-metrics .ui-metric-card {
+  min-height: 112px;
+}
+
+.insights-panel {
+  min-width: 0;
+  padding: var(--spacing-5);
+  box-shadow: var(--shadow-sm);
+}
+
+.insights-panel--critical {
+  border-top: 3px solid var(--color-status-gap);
+}
+
+.insights-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-3);
+}
+
+.insights-panel__header > div:first-child {
+  min-width: 0;
+}
+
+.insights-panel__header p {
+  max-width: 680px;
+  margin: var(--spacing-1) 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+  line-height: 1.45;
+}
+
+.insights-panel__action {
+  flex: 0 0 auto;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-4);
+  align-items: start;
+}
+
+.insights-priority-list {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--spacing-2);
+}
+
+.insights-priority-row {
+  display: flex;
+  min-width: 0;
+  min-height: 152px;
+  flex-direction: column;
+  align-items: flex-start;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-3);
+}
+
+.insights-priority-main {
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.insights-priority-main > div {
+  min-width: 0;
+}
+
+.insights-priority-main strong,
+.insights-priority-main span {
+  display: block;
+}
+
+.insights-priority-main strong {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  line-height: 1.3;
+  text-overflow: ellipsis;
+}
+
+.insights-priority-main > div > span {
+  margin-top: 2px;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.insights-priority-row p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: var(--spacing-2) 0;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.insights-priority-row > .ui-button {
+  margin-top: auto;
+  padding-inline: 0;
+}
+
+.insights-list-note {
+  grid-column: 1 / -1;
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+}
+
+.insights-inline-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-3);
+}
+
+.insights-inline-metrics--four {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.insights-inline-metrics--four .ui-metric-card {
+  min-height: 94px;
+  padding: var(--spacing-3);
+}
+
+.insights-inline-metrics--four .ui-metric-card__value {
+  font-size: var(--font-lg);
+}
+
+.insights-distribution {
+  margin-top: var(--spacing-4);
+}
+
+.insights-distribution__bar {
+  display: flex;
+  width: 100%;
+  height: 10px;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-muted);
+}
+
+.insights-distribution__bar span {
+  min-width: 2px;
+}
+
+.insights-distribution .is-excellent {
+  background: var(--color-status-ready);
+}
+
+.insights-distribution .is-good {
+  background: #65a30d;
+}
+
+.insights-distribution .is-moderate {
+  background: #ca8a04;
+}
+
+.insights-distribution .is-poor {
+  background: #ea580c;
+}
+
+.insights-distribution .is-critical {
+  background: var(--color-status-gap);
+}
+
+.insights-distribution__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2) var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.insights-distribution__legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  color: var(--color-text-secondary);
+  font-size: 0.625rem;
+  text-transform: capitalize;
+}
+
+.insights-distribution__legend i {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.insights-distribution > small,
+.insights-summary-list > small {
+  display: block;
+  margin-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.insights-summary-list {
+  display: grid;
+}
+
+.insights-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: 7px 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.insights-summary-row strong {
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.insights-summary-row.is-strong {
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-2) var(--spacing-3);
+  color: var(--color-text);
+  font-weight: 650;
+}
+
+.insights-summary-row.is-strong strong {
+  font-size: var(--font-lg);
+}
+
+.insights-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-3);
+  border: 1px solid #fde68a;
+  border-radius: var(--radius-md);
+  background: var(--color-status-anchor-subtle);
+  padding: var(--spacing-3);
+}
+
+.insights-callout > div {
+  display: flex;
+  min-width: 126px;
+  flex-direction: column;
+}
+
+.insights-callout strong {
+  color: #92400e;
+  font-size: var(--font-xl);
+  line-height: 1.2;
+}
+
+.insights-callout span {
+  color: #78350f;
+  font-size: 0.6875rem;
+  font-weight: 650;
+}
+
+.insights-callout p,
+.insights-method-note {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.45;
+}
+
+.insights-method-note {
+  margin-top: var(--spacing-3);
+  border-left: 3px solid var(--color-primary);
+  background: var(--color-primary-subtle);
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.insights-unavailable,
+.insights-empty-state {
+  display: flex;
+  min-height: 104px;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  text-align: center;
+}
+
+.insights-state-shell {
+  display: grid;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  place-items: center;
+  background: var(--color-canvas);
+  padding: var(--spacing-6);
+}
+
+.insights-state-card {
+  display: flex;
+  width: min(480px, 100%);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-8);
+  text-align: center;
+}
+
+.insights-state-card h1 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-xl);
+}
+
+.insights-state-card p {
+  margin: 0 0 var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.insights-state-card--error {
+  border-top: 3px solid var(--color-danger);
+}
+
+.insights-spinner {
+  width: 34px;
+  height: 34px;
+  border: 3px solid #dbeafe;
+  border-top-color: var(--color-primary);
+  border-radius: var(--radius-full);
+  animation: insights-spin 0.8s linear infinite;
+}
+
+@keyframes insights-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 1100px) {
+  .insights-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .insights-priority-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .insights-header {
+    padding-inline: var(--spacing-4);
+  }
+
+  .insights-content {
+    width: min(100% - 32px, 680px);
+    padding-top: var(--spacing-4);
+  }
+
+  .insights-grid,
+  .insights-priority-list {
+    grid-template-columns: 1fr;
+  }
+
+  .insights-priority-row {
+    min-height: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  .insights-header {
+    align-items: flex-start;
+    padding: var(--spacing-3);
+  }
+
+  .insights-header p {
+    display: none;
+  }
+
+  .insights-content {
+    width: calc(100% - 24px);
+  }
+
+  .insights-partial-notice,
+  .insights-section-heading,
+  .insights-panel__header,
+  .insights-callout {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .insights-section-heading {
+    gap: var(--spacing-1);
+  }
+
+  .insights-metric-grid,
+  .insights-inline-metrics,
+  .insights-inline-metrics--four {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .insights-panel {
+    padding: var(--spacing-4);
+  }
+
+  .insights-panel__action,
+  .insights-panel__action .ui-button {
+    width: 100%;
+  }
+
+  .insights-callout > div {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 390px) {
+  .insights-metric-grid,
+  .insights-inline-metrics,
+  .insights-inline-metrics--four {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/dashboard/Dashboard.test.tsx
+++ b/frontend/src/components/dashboard/Dashboard.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDashboardData, type DashboardData } from '../../hooks/useDashboardData';
+import Dashboard from './Dashboard';
+
+vi.mock('../../hooks/useDashboardData', () => ({
+    useDashboardData: vi.fn(),
+}));
+
+const dashboardData: DashboardData = {
+    statistics: {
+        total_regions: 2,
+        total_data_points: 20,
+        total_uploads: 5,
+        completed_uploads: 5,
+        total_gating_rules: 2,
+        active_gating_rules: 2,
+        total_healthcare_sites: 4,
+        hospitals: 1,
+        clinics: 2,
+    },
+    telehealthStatus: {
+        count: 2,
+        summary: {
+            telehealth_ready: 1,
+            community_anchor: 0,
+            critical_gap: 1,
+            data_unavailable: 0,
+        },
+        regions: [
+            {
+                region_code: 'AK-CRITICAL',
+                region_name: 'Critical Community',
+                lat: 60,
+                lon: -150,
+                status: 'CRITICAL_GAP',
+                color: '#b42318',
+                internet_cost: 120,
+                isp_name: 'Provider',
+                burden_pct: 3.2,
+                median_income: 40000,
+                has_nearby_clinic: false,
+                nearest_clinic_name: null,
+                nearest_clinic_km: null,
+                access_mode: 'air',
+                recommendation: 'Prioritize connectivity and supported care access.',
+            },
+        ],
+    },
+    healthcare: {
+        total_facilities: 4,
+        by_type: { hospital: 1, clinic: 2, pharmacy: 0, health_center: 1 },
+        features: { with_emergency: 1, with_specialists: 1, with_telehealth: 2 },
+        data_source: 'Test inventory',
+    },
+    performance: {
+        has_data: true,
+        period: { year: 2025, quarter: 4, label: 'Q4 2025' },
+        coverage: { total_tiles: 10, tiles_with_speed_data: 8, total_tests: 100, total_devices: 40 },
+        speeds: { avg_download_mbps: 24, max_download_mbps: 80, min_download_mbps: 2, median_download_mbps: 20 },
+        distribution: { excellent: 2, good: 2, moderate: 2, poor: 1, critical: 1 },
+        telehealth_viable_pct: 50,
+    },
+    dataGaps: {
+        total_places: 10,
+        places_with_gaps: 3,
+        gap_breakdown: {},
+        confidence_distribution: { HIGH: 6, MEDIUM: 3, LOW: 1 },
+        telehealth_viability: { YES: 5, NO: 2, UNCERTAIN: 3 },
+        primary_access: { WIRED: 7, SATELLITE: 2, LIMITED: 1 },
+    },
+    affordability: {
+        zones: [],
+        count: 10,
+        monthly_cost: 120,
+        threshold_pct: 2,
+        summary: { affordable: 6, unaffordable: 4, affordable_pct: 60 },
+    },
+};
+
+describe('Statewide Insights', () => {
+    beforeEach(() => {
+        vi.mocked(useDashboardData).mockReturnValue({
+            data: dashboardData,
+            sectionErrors: {},
+            availableSectionCount: 6,
+            hasPartialData: false,
+            loading: false,
+            error: null,
+        });
+    });
+
+    it('uses accurate affordability and satellite-dependency labels', () => {
+        render(<Dashboard onClose={vi.fn()} />);
+
+        expect(screen.getByRole('heading', { name: 'Statewide Insights' })).toBeInTheDocument();
+        expect(screen.getByText('Unaffordable analyzed zones')).toBeInTheDocument();
+        expect(screen.getByText('Satellite-primary places')).toBeInTheDocument();
+        expect(screen.getByText(/not a measure of affordability/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Open telehealth access map' })).toBeInTheDocument();
+        expect(screen.queryByText('Unaffordable Areas')).not.toBeInTheDocument();
+    });
+
+    it('routes section and community actions back to the map', () => {
+        const onViewMap = vi.fn();
+        const onViewRegion = vi.fn();
+        render(
+            <Dashboard
+                onClose={vi.fn()}
+                onViewMap={onViewMap}
+                onViewRegion={onViewRegion}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open Gap Hunter' }));
+        expect(onViewMap).toHaveBeenCalledWith('gap');
+
+        fireEvent.click(screen.getByRole('button', { name: 'View on map' }));
+        expect(onViewRegion).toHaveBeenCalledWith('AK-CRITICAL');
+    });
+});

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,388 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useDashboardData, type DashboardSection } from '../../hooks/useDashboardData';
+import Button from '../ui/Button';
+import MetricCard from '../ui/MetricCard';
+import Panel from '../ui/Panel';
+import StatusBadge from '../ui/StatusBadge';
+import { SATELLITE_PRIMARY_METRIC } from '../../domain/metrics';
+import { getTelehealthStatusLabel } from '../../domain/statusPresentation';
+import type { BaseMapLayer } from '../../domain/mapMode';
+import './Dashboard.css';
+
+export type InsightsMapLayer = BaseMapLayer;
+
+interface DashboardProps {
+    onClose: () => void;
+    onViewMap?: (layer: InsightsMapLayer) => void;
+    onViewRegion?: (regionCode: string) => void;
+}
+
+const SECTION_LABELS: Record<DashboardSection, string> = {
+    statistics: 'statewide totals',
+    telehealthStatus: 'telehealth status',
+    healthcare: 'healthcare infrastructure',
+    performance: 'network performance',
+    dataGaps: 'data quality',
+    affordability: 'affordability',
+};
+
+function displayNumber(value: number | null | undefined, digits = 0): string {
+    if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+    return value.toLocaleString(undefined, {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+    });
+}
+
+function percentage(value: number | null | undefined, digits = 0): string {
+    return value === null || value === undefined || !Number.isFinite(value)
+        ? '—'
+        : `${displayNumber(value, digits)}%`;
+}
+
+function ratioPercent(value: number | null | undefined, total: number | null | undefined): number | null {
+    if (value === null || value === undefined || !total) return null;
+    return (value / total) * 100;
+}
+
+export default function Dashboard({ onClose, onViewMap, onViewRegion }: DashboardProps) {
+    const titleRef = useRef<HTMLHeadingElement>(null);
+    const {
+        data,
+        loading,
+        error,
+        sectionErrors,
+        hasPartialData,
+        availableSectionCount,
+    } = useDashboardData();
+
+    useEffect(() => {
+        if (!loading) titleRef.current?.focus();
+    }, [loading]);
+
+    const viewMap = (layer: InsightsMapLayer = 'cat') => {
+        if (onViewMap) onViewMap(layer);
+        else onClose();
+    };
+
+    if (loading) {
+        return (
+            <div className="insights-state-shell">
+                <Panel elevated className="insights-state-card" role="status">
+                    <span className="insights-spinner" aria-hidden="true" />
+                    <h1>Preparing Statewide Insights</h1>
+                    <p>Combining telehealth, network, healthcare, and data-quality summaries.</p>
+                    <Button variant="secondary" onClick={onClose}>View map</Button>
+                </Panel>
+            </div>
+        );
+    }
+
+    if (error && availableSectionCount === 0) {
+        return (
+            <div className="insights-state-shell">
+                <Panel elevated className="insights-state-card insights-state-card--error" role="alert">
+                    <StatusBadge tone="critical">Insights unavailable</StatusBadge>
+                    <h1 ref={titleRef} tabIndex={-1}>Statewide data could not be loaded</h1>
+                    <p>{error}</p>
+                    <Button variant="primary" onClick={onClose}>Return to map</Button>
+                </Panel>
+            </div>
+        );
+    }
+
+    const { statistics, telehealthStatus, healthcare, performance, dataGaps, affordability } = data;
+    const totalCommunities = telehealthStatus?.count ?? null;
+    const criticalCount = telehealthStatus?.summary.critical_gap;
+    const readyCount = telehealthStatus?.summary.telehealth_ready;
+    const criticalRegions = telehealthStatus?.regions
+        .filter(region => region.status === 'CRITICAL_GAP')
+        .slice(0, 5) ?? [];
+    const speedDistribution = performance?.distribution;
+    const speedTileCount = speedDistribution
+        ? Object.values(speedDistribution).reduce((sum, count) => sum + count, 0)
+        : 0;
+    const unavailableSections = (Object.keys(sectionErrors) as DashboardSection[])
+        .map(section => SECTION_LABELS[section]);
+
+    return (
+        <div className="insights-page">
+            <header className="insights-header">
+                <div>
+                    <span className="insights-eyebrow">TENeT statewide view</span>
+                    <h1 ref={titleRef} tabIndex={-1}>Statewide Insights</h1>
+                    <p>Prioritize telehealth gaps, validate evidence quality, and move directly back to the map.</p>
+                </div>
+                <Button variant="primary" onClick={onClose}>View map</Button>
+            </header>
+
+            <main className="insights-content">
+                {hasPartialData && (
+                    <div className="insights-partial-notice" role="status">
+                        <StatusBadge tone="anchor">Partial data</StatusBadge>
+                        <span>
+                            Showing available statewide results. Unavailable sections: {unavailableSections.join(', ')}.
+                        </span>
+                    </div>
+                )}
+
+                <section className="insights-overview" aria-labelledby="statewide-overview-title">
+                    <div className="insights-section-heading">
+                        <div>
+                            <span className="insights-eyebrow">At a glance</span>
+                            <h2 id="statewide-overview-title">Statewide operating picture</h2>
+                        </div>
+                        <span className="insights-source-note">Counts reflect the latest available source for each section.</span>
+                    </div>
+                    <div className="insights-metric-grid">
+                        <MetricCard
+                            label="Communities classified"
+                            value={displayNumber(totalCommunities)}
+                            supportingText="Communities in the telehealth status dataset"
+                            tone="info"
+                        />
+                        <MetricCard
+                            label="Critical telehealth gaps"
+                            value={displayNumber(criticalCount)}
+                            supportingText={criticalCount === undefined
+                                ? 'Telehealth classification unavailable'
+                                : `${percentage(ratioPercent(criticalCount, totalCommunities), 1)} of classified communities`}
+                            tone="danger"
+                        />
+                        <MetricCard
+                            label="Telehealth ready"
+                            value={displayNumber(readyCount)}
+                            supportingText={readyCount === undefined
+                                ? 'Telehealth classification unavailable'
+                                : `${percentage(ratioPercent(readyCount, totalCommunities), 1)} of classified communities`}
+                            tone="success"
+                        />
+                        <MetricCard
+                            label="Broadband places with data gaps"
+                            value={displayNumber(dataGaps?.places_with_gaps)}
+                            supportingText={dataGaps
+                                ? `${percentage(ratioPercent(dataGaps.places_with_gaps, dataGaps.total_places), 1)} of ${displayNumber(dataGaps.total_places)} evaluated places`
+                                : 'Data-quality summary unavailable'}
+                            tone="warning"
+                        />
+                    </div>
+                </section>
+
+                <Panel className="insights-panel insights-panel--critical" elevated>
+                    <SectionHeading
+                        eyebrow="Action queue"
+                        title="Critical telehealth gaps"
+                        description="Communities classified with affordability constraints and insufficient nearby care support."
+                        action={<Button size="small" onClick={() => viewMap('cat')}>View CAT map</Button>}
+                    />
+
+                    {!telehealthStatus ? (
+                        <SectionUnavailable message={sectionErrors.telehealthStatus} />
+                    ) : criticalRegions.length === 0 ? (
+                        <div className="insights-empty-state">No critical-gap communities are present in the current statewide classification.</div>
+                    ) : (
+                        <div className="insights-priority-list">
+                            {criticalRegions.map(region => (
+                                <article key={region.region_code} className="insights-priority-row">
+                                    <div className="insights-priority-main">
+                                        <div>
+                                            <strong>{region.region_name}</strong>
+                                            <span>{region.region_code}</span>
+                                        </div>
+                                        <StatusBadge tone="critical">{getTelehealthStatusLabel('CRITICAL_GAP')}</StatusBadge>
+                                    </div>
+                                    <p>{region.recommendation || 'Review connectivity, affordability, and nearby clinic access on the map.'}</p>
+                                    <Button
+                                        size="small"
+                                        variant="ghost"
+                                        onClick={() => onViewRegion ? onViewRegion(region.region_code) : viewMap('cat')}
+                                    >
+                                        View on map
+                                    </Button>
+                                </article>
+                            ))}
+                            {(telehealthStatus.summary.critical_gap ?? 0) > criticalRegions.length && (
+                                <div className="insights-list-note">
+                                    Showing 5 of {displayNumber(telehealthStatus.summary.critical_gap)} critical communities.
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </Panel>
+
+                <div className="insights-grid">
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Connectivity"
+                            title="Network performance summary"
+                            description="Observed Ookla measurements indicate whether current service can support reliable telehealth."
+                            action={<Button size="small" onClick={() => viewMap('gap')}>Open Gap Hunter</Button>}
+                        />
+                        {!performance || !performance.has_data ? (
+                            <SectionUnavailable message={sectionErrors.performance || 'No measured network-performance period is available.'} />
+                        ) : (
+                            <>
+                                <div className="insights-inline-metrics">
+                                    <MetricCard
+                                        label="Average download"
+                                        value={performance.speeds.avg_download_mbps === null
+                                            ? 'Data unavailable'
+                                            : `${displayNumber(performance.speeds.avg_download_mbps, 1)} Mbps`}
+                                        supportingText={performance.period.label}
+                                        tone="info"
+                                    />
+                                    <MetricCard
+                                        label="Telehealth-viable tiles"
+                                        value={percentage(performance.telehealth_viable_pct, 1)}
+                                        supportingText={`${displayNumber(performance.coverage.tiles_with_speed_data)} tiles with speed data`}
+                                        tone="success"
+                                    />
+                                </div>
+                                <div className="insights-distribution" aria-label="Speed distribution by measured tile">
+                                    <div className="insights-distribution__bar">
+                                        {speedDistribution && Object.entries(speedDistribution).map(([level, count]) => (
+                                            <span
+                                                key={level}
+                                                className={`is-${level}`}
+                                                style={{ flexGrow: count }}
+                                                title={`${level}: ${count} tiles`}
+                                            />
+                                        ))}
+                                    </div>
+                                    <div className="insights-distribution__legend">
+                                        {speedDistribution && Object.entries(speedDistribution).map(([level, count]) => (
+                                            <span key={level}><i className={`is-${level}`} />{level} {displayNumber(count)}</span>
+                                        ))}
+                                    </div>
+                                    <small>Distribution across {displayNumber(speedTileCount)} measured tiles.</small>
+                                </div>
+                            </>
+                        )}
+                    </Panel>
+
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Care access"
+                            title="Healthcare infrastructure"
+                            description="Facility inventory helps identify where telehealth must supplement limited physical access."
+                            action={<Button size="small" onClick={() => viewMap('cat')}>View communities</Button>}
+                        />
+                        {!healthcare ? (
+                            <SectionUnavailable message={sectionErrors.healthcare} />
+                        ) : (
+                            <div className="insights-summary-list">
+                                <SummaryRow label="Total facilities" value={displayNumber(healthcare.total_facilities)} strong />
+                                <SummaryRow label="Hospitals" value={displayNumber(healthcare.by_type.hospital)} />
+                                <SummaryRow label="Clinics" value={displayNumber(healthcare.by_type.clinic)} />
+                                <SummaryRow label="Health centers" value={displayNumber(healthcare.by_type.health_center)} />
+                                <SummaryRow label="Emergency services" value={displayNumber(healthcare.features.with_emergency)} />
+                                <SummaryRow label="Telehealth-capable facilities" value={displayNumber(healthcare.features.with_telehealth)} />
+                                <small>Source: {healthcare.data_source || 'Healthcare facility inventory'}</small>
+                            </div>
+                        )}
+                    </Panel>
+
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Evidence risk"
+                            title="Data quality risks"
+                            description="Incomplete or low-confidence evidence should trigger verification before funding or service decisions."
+                        />
+                        {!dataGaps ? (
+                            <SectionUnavailable message={sectionErrors.dataGaps} />
+                        ) : (
+                            <>
+                                <div className="insights-inline-metrics insights-inline-metrics--four">
+                                    <MetricCard label="Places with gaps" value={displayNumber(dataGaps.places_with_gaps)} tone="warning" />
+                                    <MetricCard label="Low confidence" value={displayNumber(dataGaps.confidence_distribution.LOW)} tone="danger" />
+                                    <MetricCard label="Viability uncertain" value={displayNumber(dataGaps.telehealth_viability.UNCERTAIN)} tone="warning" />
+                                    <MetricCard label="Stored data points" value={displayNumber(statistics?.total_data_points)} tone="neutral" />
+                                </div>
+                                <div className="insights-callout">
+                                    <div>
+                                        <strong>{displayNumber(dataGaps.primary_access.SATELLITE)}</strong>
+                                        <span>{SATELLITE_PRIMARY_METRIC.label}</span>
+                                    </div>
+                                    <p>{SATELLITE_PRIMARY_METRIC.description}</p>
+                                </div>
+                            </>
+                        )}
+                    </Panel>
+
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Household burden"
+                            title="Affordability summary"
+                            description="Income-based burden estimates identify analyzed zones where the modeled monthly internet cost exceeds the configured threshold."
+                            action={<Button size="small" onClick={() => viewMap('affordability')}>Open telehealth access map</Button>}
+                        />
+                        {!affordability ? (
+                            <SectionUnavailable message={sectionErrors.affordability} />
+                        ) : (
+                            <>
+                                <div className="insights-inline-metrics">
+                                    <MetricCard
+                                        label="Unaffordable analyzed zones"
+                                        value={displayNumber(affordability.summary.unaffordable)}
+                                        supportingText={`of ${displayNumber(affordability.count)} analyzed ZCTAs`}
+                                        tone="danger"
+                                    />
+                                    <MetricCard
+                                        label="Affordable share"
+                                        value={percentage(affordability.summary.affordable_pct, 1)}
+                                        supportingText={`${displayNumber(affordability.summary.affordable)} analyzed zones`}
+                                        tone="success"
+                                    />
+                                </div>
+                                <div className="insights-method-note">
+                                    Modeled at {`$${displayNumber(affordability.monthly_cost)}`} per month with a {percentage(affordability.threshold_pct, 1)} income-burden threshold. Zones without usable income data may be excluded.
+                                </div>
+                            </>
+                        )}
+                    </Panel>
+                </div>
+            </main>
+        </div>
+    );
+}
+
+function SectionHeading({
+    eyebrow,
+    title,
+    description,
+    action,
+}: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    action?: ReactNode;
+}) {
+    return (
+        <div className="insights-panel__header">
+            <div>
+                <span className="insights-eyebrow">{eyebrow}</span>
+                <h2>{title}</h2>
+                <p>{description}</p>
+            </div>
+            {action && <div className="insights-panel__action">{action}</div>}
+        </div>
+    );
+}
+
+function SectionUnavailable({ message }: { message?: string }) {
+    return (
+        <div className="insights-unavailable" role="status">
+            <StatusBadge tone="neutral">Unavailable</StatusBadge>
+            <span>{message || 'This source did not return statewide data.'}</span>
+        </div>
+    );
+}
+
+function SummaryRow({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
+    return (
+        <div className={`insights-summary-row${strong ? ' is-strong' : ''}`}>
+            <span>{label}</span>
+            <strong>{value}</strong>
+        </div>
+    );
+}

--- a/frontend/src/components/layout/LayerSwitcher.css
+++ b/frontend/src/components/layout/LayerSwitcher.css
@@ -1,0 +1,96 @@
+.layer-switcher {
+  position: absolute;
+  top: var(--spacing-4);
+  left: 60px;
+  z-index: var(--z-overlay);
+  min-width: 278px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-2);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.layer-switcher__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  padding: 0 var(--spacing-1) var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.layer-switcher__header strong {
+  color: var(--color-status-limited);
+  font-size: 0.625rem;
+}
+
+.layer-switcher__options {
+  display: grid;
+  grid-template-columns: auto 1fr 1.25fr;
+  gap: 2px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+  padding: 2px;
+}
+
+.layer-switcher__option {
+  min-height: var(--control-height-sm);
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius-md) - 2px);
+  color: var(--color-text-secondary);
+  padding: 0 var(--spacing-3);
+  font-size: var(--font-xs);
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
+  transition: background-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.layer-switcher__option:hover:not(.is-active) {
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--color-text);
+}
+
+.layer-switcher__option.is-active {
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  box-shadow: var(--shadow-xs);
+}
+
+.layer-switcher__option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+@media (max-width: 1200px) {
+  .layer-switcher {
+    top: 90px;
+    right: var(--spacing-4);
+    left: auto;
+  }
+}
+
+@media (max-width: 700px) {
+  .layer-switcher {
+    top: 126px;
+    right: var(--spacing-3);
+    left: var(--spacing-3);
+    min-width: 0;
+  }
+
+  .layer-switcher__options {
+    grid-template-columns: auto 1fr 1.25fr;
+  }
+
+  .layer-switcher__option {
+    padding-inline: var(--spacing-2);
+  }
+}

--- a/frontend/src/components/layout/LayerSwitcher.tsx
+++ b/frontend/src/components/layout/LayerSwitcher.tsx
@@ -1,0 +1,48 @@
+import './LayerSwitcher.css';
+import type { BaseMapLayer } from '../../domain/mapMode';
+
+export type { BaseMapLayer } from '../../domain/mapMode';
+
+interface LayerSwitcherProps {
+    activeLayer: BaseMapLayer;
+    scenarioActive?: boolean;
+    onChange: (layer: BaseMapLayer) => void;
+}
+
+const LAYERS: Array<{ id: BaseMapLayer; label: string }> = [
+    { id: 'cat', label: 'CAT' },
+    { id: 'gap', label: 'Gap Hunter' },
+    { id: 'affordability', label: 'Affordability' },
+];
+
+export default function LayerSwitcher({
+    activeLayer,
+    scenarioActive = false,
+    onChange,
+}: LayerSwitcherProps) {
+    return (
+        <section className="layer-switcher" aria-label="Map layers">
+            <div className="layer-switcher__header">
+                <span>Layer</span>
+                {scenarioActive && <strong>Scenario active</strong>}
+            </div>
+            <div className="layer-switcher__options" role="group" aria-label="Select map layer">
+                {LAYERS.map(layer => {
+                    const active = !scenarioActive && activeLayer === layer.id;
+                    return (
+                        <button
+                            key={layer.id}
+                            type="button"
+                            className={`layer-switcher__option${active ? ' is-active' : ''}`}
+                            aria-pressed={active}
+                            aria-label={`Map layer: ${layer.label}`}
+                            onClick={() => onChange(layer.id)}
+                        >
+                            {layer.label}
+                        </button>
+                    );
+                })}
+            </div>
+        </section>
+    );
+}

--- a/frontend/src/components/layout/MapToolbar.css
+++ b/frontend/src/components/layout/MapToolbar.css
@@ -1,0 +1,117 @@
+.map-toolbar {
+  position: absolute;
+  top: var(--spacing-4);
+  right: var(--spacing-4);
+  z-index: var(--z-overlay);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  max-width: calc(100% - 390px);
+  min-height: 58px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-2) var(--spacing-3);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.map-toolbar__brand {
+  display: flex;
+  min-width: 142px;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.map-toolbar__brand strong {
+  color: var(--color-text);
+  font-size: var(--font-base);
+  letter-spacing: -0.01em;
+}
+
+.map-toolbar__brand span {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+}
+
+.map-toolbar__divider {
+  align-self: stretch;
+  width: 1px;
+  background: var(--color-border-subtle);
+}
+
+.map-toolbar__controls {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+}
+
+.map-toolbar__season {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.map-toolbar__control-label {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.map-toolbar__scenario-button.is-active {
+  border-color: var(--color-status-limited);
+  background: var(--color-status-limited);
+}
+
+.map-toolbar__scenario-button.is-active:hover:not(:disabled) {
+  border-color: #5b21b6;
+  background: #5b21b6;
+}
+
+@media (max-width: 1200px) {
+  .map-toolbar {
+    max-width: calc(100% - var(--spacing-8));
+  }
+}
+
+@media (max-width: 700px) {
+  .map-toolbar {
+    right: var(--spacing-3);
+    left: var(--spacing-3);
+    max-width: none;
+    flex-wrap: wrap;
+    gap: var(--spacing-2) var(--spacing-3);
+  }
+
+  .map-toolbar__brand {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .map-toolbar__brand span,
+  .map-toolbar__divider,
+  .map-toolbar__control-label {
+    display: none;
+  }
+
+  .map-toolbar__controls {
+    width: 100%;
+  }
+
+  .map-toolbar__season {
+    min-width: 0;
+    flex: 1;
+  }
+}
+
+@media (max-width: 430px) {
+  .map-toolbar__controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+}

--- a/frontend/src/components/layout/MapToolbar.tsx
+++ b/frontend/src/components/layout/MapToolbar.tsx
@@ -1,0 +1,65 @@
+import type { Season } from '../../api/catApi';
+import SeasonSelector from '../SeasonSelector';
+import Button from '../ui/Button';
+import './MapToolbar.css';
+
+interface MapToolbarProps {
+    season: Season;
+    scenarioActive: boolean;
+    scenarioDisabled?: boolean;
+    onSeasonChange: (season: Season) => void;
+    onOpenInsights: () => void;
+    onToggleScenario: () => void;
+}
+
+export default function MapToolbar({
+    season,
+    scenarioActive,
+    scenarioDisabled = false,
+    onSeasonChange,
+    onOpenInsights,
+    onToggleScenario,
+}: MapToolbarProps) {
+    return (
+        <header className="map-toolbar" aria-label="Map tools">
+            <div className="map-toolbar__brand">
+                <strong>TENeT</strong>
+                <span>Telehealth effectiveness and Necessity Tracker</span>
+            </div>
+
+            <div className="map-toolbar__divider" aria-hidden="true" />
+
+            <div className="map-toolbar__controls">
+                <div className="map-toolbar__season">
+                    <span className="map-toolbar__control-label">Season</span>
+                    <SeasonSelector season={season} onChange={onSeasonChange} />
+                </div>
+
+                <Button
+                    id="insights-toolbar-button"
+                    size="small"
+                    onClick={onOpenInsights}
+                    aria-label="Open Statewide Insights"
+                >
+                    Insights
+                </Button>
+
+                <Button
+                    id="scenario-toggle-button"
+                    data-testid="scenario-button"
+                    size="small"
+                    variant={scenarioActive ? 'primary' : 'secondary'}
+                    className={`map-toolbar__scenario-button${scenarioActive ? ' is-active' : ''}`}
+                    onClick={onToggleScenario}
+                    disabled={scenarioDisabled}
+                    aria-label={scenarioActive ? 'Exit scenario mode' : 'Open what-if scenario mode'}
+                    aria-pressed={scenarioActive}
+                    aria-expanded={scenarioActive}
+                    aria-controls="scenario-panel"
+                >
+                    {scenarioActive ? 'Scenario active' : 'Scenario'}
+                </Button>
+            </div>
+        </header>
+    );
+}

--- a/frontend/src/components/map/MapControllers.tsx
+++ b/frontend/src/components/map/MapControllers.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react';
+import { useMap, useMapEvents } from 'react-leaflet';
+import type { RegionSummary } from '../../api/catApi';
+import type { SelectableMapMarker } from '../../hooks/useMapSelection';
+
+interface MapViewportControllerProps {
+    center: [number, number];
+    zoom: number;
+    onViewportChange: (center: [number, number], zoom: number) => void;
+}
+
+export function MapViewportController({
+    center,
+    zoom,
+    onViewportChange,
+}: MapViewportControllerProps) {
+    const map = useMapEvents({
+        moveend: () => {
+            const nextCenter = map.getCenter();
+            onViewportChange(
+                [Number(nextCenter.lat.toFixed(5)), Number(nextCenter.lng.toFixed(5))],
+                map.getZoom(),
+            );
+        },
+        zoomend: () => {
+            const nextCenter = map.getCenter();
+            onViewportChange(
+                [Number(nextCenter.lat.toFixed(5)), Number(nextCenter.lng.toFixed(5))],
+                map.getZoom(),
+            );
+        },
+    });
+
+    useEffect(() => {
+        const current = map.getCenter();
+        if (
+            Math.abs(current.lat - center[0]) < 0.00001
+            && Math.abs(current.lng - center[1]) < 0.00001
+            && map.getZoom() === zoom
+        ) return;
+        map.setView(center, zoom, { animate: false });
+    }, [center, map, zoom]);
+
+    return null;
+}
+
+export function ComparisonMapController({ active }: { active: boolean }) {
+    const map = useMap();
+
+    useEffect(() => {
+        if (!active) return;
+        map.closePopup();
+        map.panBy([0, 96], { animate: true, duration: 0.25 });
+    }, [active, map]);
+
+    return null;
+}
+
+interface SelectionControllerProps {
+    selectedRegionCode: string | null;
+    regionSummaries: RegionSummary[];
+    markerRefs: React.MutableRefObject<Record<string, SelectableMapMarker>>;
+}
+
+export function SelectionController({
+    selectedRegionCode,
+    regionSummaries,
+    markerRefs,
+}: SelectionControllerProps) {
+    const map = useMap();
+
+    useEffect(() => {
+        if (!selectedRegionCode) return;
+        const selected = regionSummaries.find(region => region.region_code === selectedRegionCode);
+        if (!selected || selected.lat === null || selected.lon === null) return;
+
+        map.flyTo([selected.lat, selected.lon], Math.max(map.getZoom(), 8), { duration: 1.1 });
+        const timer = window.setTimeout(() => {
+            markerRefs.current[selectedRegionCode]?.openPopup();
+        }, 350);
+        return () => window.clearTimeout(timer);
+    }, [map, markerRefs, regionSummaries, selectedRegionCode]);
+
+    return null;
+}

--- a/frontend/src/components/scenario/ScenarioPanel.tsx
+++ b/frontend/src/components/scenario/ScenarioPanel.tsx
@@ -205,16 +205,19 @@ const ERROR_STYLE: React.CSSProperties = {
 interface ScenarioPanelProps {
     scenario: ScenarioState;
     preview: ScenarioPreviewState;
-    gapModeActive: boolean;
+    gapModeActive?: boolean;
+    onClose?: () => void;
 }
 
 export default function ScenarioPanel({
     scenario,
     preview,
-    gapModeActive,
+    gapModeActive = false,
+    onClose,
 }: ScenarioPanelProps) {
     const { mode, thresholds, activePreset, setThreshold, applyPreset, resetToBaseline, deactivate } = scenario;
     const { data, loading, error } = preview;
+    const closePanel = onClose ?? deactivate;
 
     if (mode === 'off') return null;
 
@@ -229,7 +232,7 @@ export default function ScenarioPanel({
                 <button
                     type="button"
                     style={CLOSE_BTN_STYLE}
-                    onClick={deactivate}
+                    onClick={closePanel}
                     aria-label="Close scenario panel"
                     title="Close scenario mode"
                 >

--- a/frontend/src/components/sidebar/FilterControls.tsx
+++ b/frontend/src/components/sidebar/FilterControls.tsx
@@ -1,3 +1,5 @@
+import { BASE_TELEHEALTH_STATUSES, getTelehealthStatusLabel } from '../../domain/statusPresentation';
+import { CAT_TIERS, DESERT_SCORE_FILTER_OPTIONS } from '../../domain/metrics';
 import { DataGapFilter, SidebarFilters } from './sidebarUtils';
 
 interface FilterControlsProps {
@@ -7,10 +9,10 @@ interface FilterControlsProps {
 
 const STATUS_OPTIONS = [
     { value: '', label: 'All statuses' },
-    { value: 'TELEHEALTH_READY', label: 'Ready' },
-    { value: 'COMMUNITY_ANCHOR', label: 'Anchor' },
-    { value: 'CRITICAL_GAP', label: 'Critical' },
-    { value: 'DATA_UNAVAILABLE', label: 'Unknown' },
+    ...BASE_TELEHEALTH_STATUSES.map(value => ({
+        value,
+        label: getTelehealthStatusLabel(value),
+    })),
 ];
 
 export default function FilterControls({ filters, onChange }: FilterControlsProps) {
@@ -20,13 +22,13 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 CAT tier
                 <select
                     value={filters.tier}
-                    onChange={(event) => onChange({ ...filters, tier: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        tier: event.target.value as SidebarFilters['tier'],
+                    })}
                 >
                     <option value="">All tiers</option>
-                    <option value="1">Tier 1</option>
-                    <option value="2">Tier 2</option>
-                    <option value="3">Tier 3</option>
-                    <option value="4">Tier 4</option>
+                    {CAT_TIERS.map(tier => <option key={tier} value={tier}>Tier {tier}</option>)}
                 </select>
             </label>
 
@@ -34,7 +36,10 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 Status
                 <select
                     value={filters.status}
-                    onChange={(event) => onChange({ ...filters, status: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        status: event.target.value as SidebarFilters['status'],
+                    })}
                 >
                     {STATUS_OPTIONS.map(option => (
                         <option key={option.value} value={option.value}>{option.label}</option>
@@ -46,13 +51,14 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 Desert score
                 <select
                     value={filters.desert}
-                    onChange={(event) => onChange({ ...filters, desert: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        desert: event.target.value as SidebarFilters['desert'],
+                    })}
                 >
-                    <option value="">All scores</option>
-                    <option value="70-plus">70+ severe need</option>
-                    <option value="50-plus">50+ high need</option>
-                    <option value="below-50">Below 50</option>
-                    <option value="unknown">Unknown score</option>
+                    {DESERT_SCORE_FILTER_OPTIONS.map(option => (
+                        <option key={option.value || 'all'} value={option.value}>{option.label}</option>
+                    ))}
                 </select>
             </label>
 

--- a/frontend/src/components/sidebar/QuickFilterChips.tsx
+++ b/frontend/src/components/sidebar/QuickFilterChips.tsx
@@ -1,0 +1,73 @@
+import type { SidebarFilters } from './sidebarUtils';
+
+interface QuickFilterChipsProps {
+    filters: SidebarFilters;
+    onChange: (filters: SidebarFilters) => void;
+}
+
+interface QuickFilter {
+    id: string;
+    label: string;
+    isActive: (filters: SidebarFilters) => boolean;
+    toggle: (filters: SidebarFilters) => SidebarFilters;
+}
+
+const QUICK_FILTERS: QuickFilter[] = [
+    {
+        id: 'critical',
+        label: 'Critical gaps',
+        isActive: filters => filters.status === 'CRITICAL_GAP',
+        toggle: filters => ({
+            ...filters,
+            status: filters.status === 'CRITICAL_GAP' ? '' : 'CRITICAL_GAP',
+        }),
+    },
+    {
+        id: 'desert',
+        label: 'High desert score',
+        isActive: filters => filters.desert === '75-plus',
+        toggle: filters => ({
+            ...filters,
+            desert: filters.desert === '75-plus' ? '' : '75-plus',
+        }),
+    },
+    {
+        id: 'incomplete',
+        label: 'Data incomplete',
+        isActive: filters => filters.dataGap === 'missing',
+        toggle: filters => ({
+            ...filters,
+            dataGap: filters.dataGap === 'missing' ? 'all' : 'missing',
+        }),
+    },
+    {
+        id: 'ready',
+        label: 'Telehealth ready',
+        isActive: filters => filters.status === 'TELEHEALTH_READY',
+        toggle: filters => ({
+            ...filters,
+            status: filters.status === 'TELEHEALTH_READY' ? '' : 'TELEHEALTH_READY',
+        }),
+    },
+];
+
+export default function QuickFilterChips({ filters, onChange }: QuickFilterChipsProps) {
+    return (
+        <div className="sidebar-quick-filters" aria-label="Quick filters">
+            {QUICK_FILTERS.map(filter => {
+                const active = filter.isActive(filters);
+                return (
+                    <button
+                        key={filter.id}
+                        type="button"
+                        className={`sidebar-filter-chip${active ? ' is-active' : ''}`}
+                        aria-pressed={active}
+                        onClick={() => onChange(filter.toggle(filters))}
+                    >
+                        {filter.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/sidebar/RegionCard.tsx
+++ b/frontend/src/components/sidebar/RegionCard.tsx
@@ -1,5 +1,12 @@
 import { RegionSummary } from '../../api/catApi';
-import { formatMissing, formatStatus, statusClassName } from './sidebarUtils';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
+import { getRegionSeverityClassName } from '../../domain/metrics';
+import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
+import {
+    formatMissing,
+    formatStatus,
+} from './sidebarUtils';
 
 interface RegionCardProps {
     region: RegionSummary;
@@ -28,7 +35,7 @@ export default function RegionCard({
 
     return (
         <article
-            className={`region-card ${selected ? 'selected' : ''}`}
+            className={`region-card ${getRegionSeverityClassName(region)} ${selected ? 'selected' : ''}`}
             data-testid="sidebar-result"
             data-region-code={region.region_code}
         >
@@ -41,30 +48,45 @@ export default function RegionCard({
                     <strong>{region.name}</strong>
                     <small>{region.region_code}</small>
                 </span>
-                <span className={`status-badge ${statusClassName(region.telehealth_status)}`}>
-                    {formatStatus(region.telehealth_status)}
-                </span>
+                <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)}>
+                    {getTelehealthStatusLabel(region.telehealth_status)}
+                </StatusBadge>
             </button>
 
             {showCatDetails && (
-                <div className="region-card-meta">
-                    <span>CAT {formatMissing(region.cat_tier)}</span>
-                    <span>Desert {desertScore}</span>
-                    <span>Confidence {formatStatus(region.data_confidence)}</span>
-                    <span>{region.has_data_gap ? 'Data incomplete' : 'Data complete'}</span>
+                <div className="region-card-metrics">
+                    <span className="region-card-metric" aria-label={`Desert score ${desertScore}`}>
+                        <small>Desert</small>
+                        <strong>{desertScore}</strong>
+                    </span>
+                    <span className="region-card-metric">
+                        <small>CAT tier</small>
+                        <strong>{formatMissing(region.cat_tier)}</strong>
+                    </span>
+                    <span
+                        className={`region-card-data-state${region.has_data_gap ? ' is-incomplete' : ''}`}
+                        aria-label={`${region.has_data_gap ? 'Data incomplete' : 'Data complete'}. ${formatStatus(region.data_confidence)} confidence`}
+                    >
+                        <i aria-hidden="true" />
+                        <span>
+                            {region.has_data_gap ? 'Incomplete' : 'Complete'}
+                            <small>{formatStatus(region.data_confidence)} confidence</small>
+                        </span>
+                    </span>
                 </div>
             )}
 
             {showPin && (
-                <button
-                    type="button"
+                <Button
+                    variant={pinned ? 'primary' : 'ghost'}
+                    size="small"
                     className={`pin-button ${pinned ? 'pinned' : ''}`}
                     aria-label={`${pinned ? 'Unpin' : 'Pin'} ${region.name}`}
                     disabled={!pinned && pinDisabled}
                     onClick={() => onTogglePin(region.region_code)}
                 >
                     {pinned ? 'Pinned' : 'Pin'}
-                </button>
+                </Button>
             )}
         </article>
     );

--- a/frontend/src/components/sidebar/SearchBar.tsx
+++ b/frontend/src/components/sidebar/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { KeyboardEvent, useMemo, useState } from 'react';
+import { KeyboardEvent, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { useRegionSearch } from '../../hooks/useRegionSearch';
-import { formatStatus, statusClassName } from './sidebarUtils';
+import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
+import StatusBadge from '../ui/StatusBadge';
 
 interface SearchBarProps {
     value: string;
@@ -11,9 +12,21 @@ interface SearchBarProps {
 
 export default function SearchBar({ value, onChange, onSelectRegion }: SearchBarProps) {
     const [isOpen, setIsOpen] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const listboxId = useId();
     const searchParams = useMemo(() => ({ q: value }), [value]);
     const { results } = useRegionSearch(searchParams);
     const dropdownResults = value.trim() ? results.slice(0, 8) : [];
+    const listboxOpen = isOpen && dropdownResults.length > 0;
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false);
+        };
+        document.addEventListener('pointerdown', handlePointerDown);
+        return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, [isOpen]);
 
     function selectRegion(region: RegionSummary) {
         onSelectRegion(region.region_code);
@@ -31,9 +44,13 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
     }
 
     return (
-        <div className="sidebar-search">
+        <div className="sidebar-search" ref={rootRef}>
             <input
+                role="combobox"
                 aria-label="Search communities"
+                aria-autocomplete="list"
+                aria-expanded={listboxOpen}
+                aria-controls={listboxId}
                 data-testid="community-search"
                 value={value}
                 onChange={(event) => {
@@ -45,13 +62,15 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
                 placeholder="Search communities"
                 className="sidebar-search-input"
             />
-            {isOpen && dropdownResults.length > 0 && (
-                <div className="sidebar-autocomplete" role="listbox">
+            {listboxOpen && (
+                <div className="sidebar-autocomplete" role="listbox" id={listboxId} aria-label="Community suggestions">
                     {dropdownResults.map(region => (
                         <button
                             key={region.region_code}
                             className="sidebar-autocomplete-row"
                             data-testid="sidebar-search-result"
+                            role="option"
+                            aria-selected="false"
                             onClick={() => selectRegion(region)}
                             type="button"
                         >
@@ -59,9 +78,9 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
                                 <strong>{region.name}</strong>
                                 <small>CAT {region.cat_tier ?? 'Unknown'}</small>
                             </span>
-                            <span className={`status-badge ${statusClassName(region.telehealth_status)}`}>
-                                {formatStatus(region.telehealth_status)}
-                            </span>
+                            <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)}>
+                                {getTelehealthStatusLabel(region.telehealth_status)}
+                            </StatusBadge>
                         </button>
                     ))}
                 </div>

--- a/frontend/src/components/sidebar/SelectedRegionPanel.test.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RegionSummary } from '../../api/catApi';
+import SelectedRegionPanel from './SelectedRegionPanel';
+
+vi.mock('../../hooks/useResearchProfile', () => ({
+    useResearchProfile: () => ({
+        profile: null,
+        loading: false,
+        error: null,
+    }),
+}));
+
+const region: RegionSummary = {
+    id: 1,
+    region_code: 'AK-BETHEL',
+    name: 'Bethel',
+    lat: 60.7922,
+    lon: -161.7558,
+    cat_tier: 3,
+    telehealth_status: 'COMMUNITY_ANCHOR',
+    desert_score: 55,
+    affordability_status: 'unaffordable',
+    data_confidence: 'medium',
+    has_data_gap: true,
+    region: 'Yukon-Kuskokwim',
+};
+
+function renderPanel(activeLayer: 'cat' | 'affordability') {
+    render(
+        <SelectedRegionPanel
+            region={region}
+            season="year_round"
+            activeLayer={activeLayer}
+            pinned={false}
+            pinDisabled={false}
+            onTogglePin={vi.fn()}
+        />,
+    );
+}
+
+describe('SelectedRegionPanel layer details', () => {
+    it('shows CAT-first details on the CAT layer', () => {
+        renderPanel('cat');
+
+        expect(screen.getByRole('heading', { name: 'CAT access' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Transport evidence' })).toBeInTheDocument();
+        expect(screen.getByText(/CAT details/)).toBeInTheDocument();
+        expect(screen.getByTestId('cat-region-summary')).toBeInTheDocument();
+        expect(screen.queryByTestId('affordability-region-summary')).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Affordability' })).not.toBeInTheDocument();
+        expect(screen.queryByText('Cost burden')).not.toBeInTheDocument();
+    });
+
+    it('shows affordability details on the affordability layer', () => {
+        renderPanel('affordability');
+
+        expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Connectivity' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Affordability' })).toBeInTheDocument();
+        expect(screen.getAllByText('Cost burden')).toHaveLength(2);
+        expect(screen.getByText(/Affordability details/)).toBeInTheDocument();
+        expect(screen.getByTestId('affordability-region-summary')).toBeInTheDocument();
+        expect(screen.queryByTestId('cat-region-summary')).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'CAT access' })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/sidebar/SelectedRegionPanel.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.tsx
@@ -1,17 +1,30 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { RegionSummary, Season } from '../../api/catApi';
+import type { BaseMapLayer } from '../../domain/mapMode';
 import type { ScenarioRegion } from '../../types/scenario';
 import { useResearchProfile } from '../../hooks/useResearchProfile';
 import { exportResearchProfileReport } from '../../utils/reportExport';
-import { formatMissing, formatStatus, statusClassName, telehealthNeedLabel } from './sidebarUtils';
+import {
+    getTelehealthStatusClassName,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+} from '../../domain/statusPresentation';
+import {
+    formatMissing,
+    formatStatus,
+    telehealthNeedLabel,
+} from './sidebarUtils';
 import { DATA_UNAVAILABLE, formatResearchValue } from '../../utils/formatResearchValue';
 import { ScenarioSidebarCard } from '../scenario/ScenarioLayer';
 import MetricTooltip from '../MetricTooltip';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
 
 interface SelectedRegionPanelProps {
     region: RegionSummary | null;
     season: Season;
     focusKey?: number;
+    activeLayer?: BaseMapLayer;
     pinned: boolean;
     pinDisabled: boolean;
     onTogglePin: (regionCode: string) => void;
@@ -22,6 +35,7 @@ export default function SelectedRegionPanel({
     region,
     season,
     focusKey = 0,
+    activeLayer = 'cat',
     pinned,
     pinDisabled,
     onTogglePin,
@@ -30,6 +44,7 @@ export default function SelectedRegionPanel({
     const { profile, loading, error } = useResearchProfile(region?.region_code ?? null, season);
     const panelRef = useRef<HTMLElement | null>(null);
     const [highlight, setHighlight] = useState(false);
+    const [actionStatus, setActionStatus] = useState<{ message: string; error: boolean } | null>(null);
 
     useEffect(() => {
         if (!region || focusKey === 0) return;
@@ -40,20 +55,135 @@ export default function SelectedRegionPanel({
     }, [focusKey, region]);
 
     if (!region) {
-        return null;
+        return (
+            <section className="selected-region-panel selected-region-empty">
+                <strong>Select a community</strong>
+                <span>Choose a result to inspect access, connectivity, and data quality.</span>
+            </section>
+        );
     }
 
     const handleDownloadReport = async () => {
         if (!profile) return;
-        await exportResearchProfileReport(
-            profile,
-            document.querySelector<HTMLElement>('.leaflet-container'),
-        );
+        try {
+            await exportResearchProfileReport(
+                profile,
+                document.querySelector<HTMLElement>('.leaflet-container'),
+            );
+            setActionStatus({ message: 'Report download started.', error: false });
+        } catch {
+            setActionStatus({ message: 'Report could not be generated.', error: true });
+        }
     };
 
     const handleCopyShareLink = async () => {
-        await navigator.clipboard?.writeText(window.location.href);
+        try {
+            if (!navigator.clipboard) throw new Error('Clipboard unavailable');
+            await navigator.clipboard.writeText(window.location.href);
+            setActionStatus({ message: 'Share link copied.', error: false });
+        } catch {
+            setActionStatus({ message: 'Share link could not be copied.', error: true });
+        }
     };
+
+    const profileFallback = loading
+        ? 'Loading…'
+        : error
+            ? 'Details unavailable'
+            : DATA_UNAVAILABLE;
+    const catDetailSections = (
+        <>
+            <DetailSection title="CAT access">
+                <DetailRow
+                    label={<>CAT tier<MetricTooltip term="CAT Tier">Transport access category. Higher tiers indicate more limited or fragile access.</MetricTooltip></>}
+                    value={formatMissing(region.cat_tier)}
+                />
+                <DetailRow
+                    label={<>Healthcare desert score<MetricTooltip term="Healthcare Desert Score">Higher scores mean greater need for telehealth due to healthcare access barriers.</MetricTooltip></>}
+                    value={formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}
+                />
+                <DetailRow
+                    label={<>Telehealth need<MetricTooltip term="Telehealth Need">Interprets healthcare desert score: below 25 adequate, 25-49 moderate, 50-74 high, and 75-100 critical.</MetricTooltip></>}
+                    value={telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}
+                />
+                <DetailRow label="Region" value={formatMissing(region.region)} />
+                <DetailRow label="Season" value={profile?.telehealth.season_note ?? formatStatus(season)} />
+            </DetailSection>
+
+            <DetailSection title="Transport evidence">
+                <DetailRow
+                    label={<>Telehealth status<MetricTooltip term="Telehealth Status">Combines affordability and clinic access into a practical access label.</MetricTooltip></>}
+                    value={<span className={`status-text ${getTelehealthStatusClassName(region.telehealth_status)}`}>{getTelehealthStatusLabel(region.telehealth_status)}</span>}
+                />
+                <DetailRow label="Nearest care" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_name) : profileFallback} />
+                <DetailRow label="Facility distance" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Data confidence">
+                <DetailRow
+                    label={<>Confidence<MetricTooltip term="Data Confidence">Confidence describes whether supporting coverage data is strong, weak, or missing.</MetricTooltip></>}
+                    value={formatStatus(region.data_confidence)}
+                />
+                <DetailRow
+                    label={<>Coverage<MetricTooltip term="Data Incomplete">Some required coverage, speed, affordability, or access evidence is missing.</MetricTooltip></>}
+                    value={region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}
+                />
+            </DetailSection>
+        </>
+    );
+    const telehealthDetailSections = (
+        <>
+            <DetailSection title="Access">
+                <DetailRow
+                    label={<>CAT tier<MetricTooltip term="CAT Tier">Transport access category. Higher tiers indicate more limited or fragile access.</MetricTooltip></>}
+                    value={formatMissing(region.cat_tier)}
+                />
+                <DetailRow
+                    label={<>Telehealth<MetricTooltip term="Telehealth Status">Combines affordability and clinic access into a practical access label.</MetricTooltip></>}
+                    value={<span className={`status-text ${getTelehealthStatusClassName(region.telehealth_status)}`}>{getTelehealthStatusLabel(region.telehealth_status)}</span>}
+                />
+                <DetailRow
+                    label={<>Telehealth need<MetricTooltip term="Telehealth Need">Interprets healthcare desert score: below 25 adequate, 25-49 moderate, 50-74 high, and 75-100 critical.</MetricTooltip></>}
+                    value={telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}
+                />
+                <DetailRow label="Region" value={formatMissing(region.region)} />
+            </DetailSection>
+
+            <DetailSection title="Connectivity">
+                <DetailRow label="Download speed" value={profile ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 }) : profileFallback} />
+                <DetailRow label="Upload speed" value={profile ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 }) : profileFallback} />
+                <DetailRow label="Latency" value={profile ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Affordability">
+                <DetailRow
+                    label={<>Status<MetricTooltip term="Affordability Burden">Whether monthly internet cost is affordable relative to income data.</MetricTooltip></>}
+                    value={formatStatus(profile?.affordability.status ?? region.affordability_status)}
+                />
+                <DetailRow label="Cost burden" value={profile ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Healthcare">
+                <DetailRow
+                    label={<>Desert score<MetricTooltip term="Healthcare Desert Score">Higher scores mean greater need for telehealth due to healthcare access barriers.</MetricTooltip></>}
+                    value={formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}
+                />
+                <DetailRow label="Nearest care" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_name) : profileFallback} />
+                <DetailRow label="Facility distance" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Data confidence">
+                <DetailRow
+                    label={<>Confidence<MetricTooltip term="Data Confidence">Confidence describes whether supporting coverage data is strong, weak, or missing.</MetricTooltip></>}
+                    value={formatStatus(region.data_confidence)}
+                />
+                <DetailRow
+                    label={<>Coverage<MetricTooltip term="Data Incomplete">Some required coverage, speed, affordability, or access evidence is missing.</MetricTooltip></>}
+                    value={region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}
+                />
+            </DetailSection>
+        </>
+    );
 
     return (
         <section
@@ -63,155 +193,101 @@ export default function SelectedRegionPanel({
             <div className="selected-region-header">
                 <div>
                     <h2>{region.name}</h2>
-                    <small>{region.region_code}</small>
+                    <small>{region.region_code} · {activeLayer === 'cat' ? 'CAT details' : activeLayer === 'affordability' ? 'Affordability details' : 'Gap Hunter details'}</small>
                 </div>
-                <button
-                    type="button"
-                    className={`pin-button ${pinned ? 'pinned' : ''}`}
+                <Button
+                    variant={pinned ? 'primary' : 'secondary'}
+                    size="small"
+                    className="selected-region-pin"
                     aria-label={`${pinned ? 'Unpin' : 'Pin'} ${region.name}`}
                     disabled={!pinned && pinDisabled}
                     onClick={() => onTogglePin(region.region_code)}
                 >
                     {pinned ? 'Pinned' : 'Pin'}
-                </button>
+                </Button>
             </div>
 
+            {activeLayer !== 'affordability' ? (
+                <div className="selected-region-summary" data-testid="cat-region-summary">
+                    <StatusBadge tone="neutral" showDot>
+                        CAT tier {formatMissing(region.cat_tier)}
+                    </StatusBadge>
+                    <span><small>Desert score</small><strong>{formatResearchValue(region.desert_score, { digits: 1 })}</strong></span>
+                    <span><small>Region</small><strong>{formatMissing(region.region)}</strong></span>
+                </div>
+            ) : (
+                <div className="selected-region-summary" data-testid="affordability-region-summary">
+                    <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)} showDot>
+                        {getTelehealthStatusLabel(region.telehealth_status)}
+                    </StatusBadge>
+                    <span><small>Affordability</small><strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong></span>
+                    <span><small>Cost burden</small><strong>{profile ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) : profileFallback}</strong></span>
+                </div>
+            )}
+
             <div className="selected-region-actions">
-                <button
-                    type="button"
-                    className="sidebar-action-button"
+                <Button
+                    variant="primary"
+                    size="small"
                     data-testid="download-report"
                     disabled={loading || !profile}
                     onClick={handleDownloadReport}
                     aria-label={`Download report for ${region.name}`}
                 >
                     Download Report
-                </button>
-                <button
-                    type="button"
-                    className="sidebar-action-button"
+                </Button>
+                <Button
+                    variant="secondary"
+                    size="small"
                     data-testid="copy-share-link"
                     onClick={handleCopyShareLink}
                     aria-label={`Copy share link for ${region.name}`}
                 >
                     Copy Share Link
-                </button>
+                </Button>
             </div>
 
-            {error && <div className="selected-region-note error">{error}</div>}
+            {actionStatus && (
+                <div
+                    className={`selected-region-action-status${actionStatus.error ? ' is-error' : ''}`}
+                    role={actionStatus.error ? 'alert' : 'status'}
+                >
+                    {actionStatus.message}
+                </div>
+            )}
+
+            {loading && <div className="selected-region-note" role="status">Loading community details…</div>}
+            {error && <div className="selected-region-note error" role="alert">Community details unavailable: {error}</div>}
             {profile?.region?.has_data_gap && (
-                <div className="selected-region-note">
+                <div className="selected-region-note" role="status">
                     {profile.region?.data_confidence ?? DATA_UNAVAILABLE} confidence · {profile.region?.missing_fields?.length ?? 0} data gaps
                 </div>
             )}
 
-            <div className="selected-detail-grid">
-                <span>
-                    CAT tier
-                    <MetricTooltip term="CAT Tier">
-                        Transport access category. Higher tiers indicate more limited or fragile access.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatMissing(region.cat_tier)}</strong>
-
-                <span>
-                    Telehealth
-                    <MetricTooltip term="Telehealth Status">
-                        Combines affordability and clinic access into a practical access label.
-                    </MetricTooltip>
-                </span>
-                <strong className={`status-text ${statusClassName(region.telehealth_status)}`}>
-                    {formatStatus(region.telehealth_status)}
-                </strong>
-
-                <span>
-                    Desert score
-                    <MetricTooltip term="Healthcare Desert Score">
-                        Higher scores mean greater need for telehealth due to healthcare access barriers.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}</strong>
-
-                <span>
-                    Telehealth need
-                    <MetricTooltip term="Telehealth Need">
-                        Interprets healthcare desert score: 0-30 low, 31-60 moderate, 61-80 high, and 81-100 critical.
-                    </MetricTooltip>
-                </span>
-                <strong>{telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}</strong>
-
-                <span>
-                    Affordability
-                    <MetricTooltip term="Affordability Burden">
-                        Whether monthly internet cost is affordable relative to income data.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong>
-
-                <span>
-                    Data confidence
-                    <MetricTooltip term="Data Confidence">
-                        Confidence describes whether supporting coverage data is strong, weak, or missing.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatStatus(region.data_confidence)}</strong>
-
-                <span>
-                    Data gap
-                    <MetricTooltip term="Data Incomplete">
-                        Some required coverage, speed, affordability, or access evidence is missing.
-                    </MetricTooltip>
-                </span>
-                <strong>{region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}</strong>
-
-                <span>Region</span>
-                <strong>{formatMissing(region.region)}</strong>
-
-                <span>Download speed</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Upload speed</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Latency</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Cost burden</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Nearest care</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.healthcare.nearest_facility_name)
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Facility distance</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
+            <div className="selected-region-detail-sections">
+                {activeLayer === 'affordability' ? telehealthDetailSections : catDetailSections}
             </div>
 
             {/* Scenario Sidebar Card */}
             <ScenarioSidebarCard region={scenarioRegion} />
         </section>
+    );
+}
+
+function DetailSection({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <section className="selected-detail-section">
+            <h3>{title}</h3>
+            <div className="selected-detail-grid">{children}</div>
+        </section>
+    );
+}
+
+function DetailRow({ label, value }: { label: ReactNode; value: ReactNode }) {
+    return (
+        <>
+            <span>{label}</span>
+            <strong>{value}</strong>
+        </>
     );
 }

--- a/frontend/src/components/sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/sidebar/Sidebar.test.tsx
@@ -132,8 +132,27 @@ describe('Sidebar discovery', () => {
         expect(screen.getByText('Eareckson')).toBeInTheDocument();
         expect(screen.getByText('Missing Data')).toBeInTheDocument();
         expect(screen.getAllByText('Data incomplete').length).toBeGreaterThan(0);
-        expect(screen.getAllByText('Confidence Missing').length).toBeGreaterThan(0);
-        expect(screen.getByText('Desert Unknown')).toBeInTheDocument();
+        expect(screen.getAllByLabelText(/Data incomplete\. Missing confidence/i).length).toBeGreaterThan(0);
+        expect(screen.getByLabelText('Desert score Unknown')).toBeInTheDocument();
+    });
+
+    it('keeps quick filters synchronized with the existing filter controls', () => {
+        renderSidebar();
+
+        const critical = screen.getByRole('button', { name: 'Critical gaps' });
+        fireEvent.click(critical);
+
+        expect(critical).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByLabelText(/^Status$/i)).toHaveValue('CRITICAL_GAP');
+        expect(resultCodes()).toEqual(['AK-EARECKSON']);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Data incomplete' }));
+        expect(screen.getByLabelText(/^Data gaps$/i)).toHaveValue('missing');
+        expect(resultCodes()).toEqual(['AK-EARECKSON']);
+
+        fireEvent.click(critical);
+        expect(screen.getByLabelText(/^Status$/i)).toHaveValue('');
+        expect(resultCodes()).toEqual(['AK-BETHEL', 'AK-EARECKSON', 'AK-MISSING']);
     });
 
     it('filters by CAT tier', async () => {
@@ -167,7 +186,7 @@ describe('Sidebar discovery', () => {
     it('filters by healthcare desert score', async () => {
         renderSidebar();
 
-        fireEvent.change(screen.getByLabelText(/Desert score/i), { target: { value: '70-plus' } });
+        fireEvent.change(screen.getByLabelText(/^Desert score$/i), { target: { value: '75-plus' } });
 
         expect(screen.getByText('Eareckson')).toBeInTheDocument();
         expect(screen.queryByText('Bethel')).not.toBeInTheDocument();

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,12 +1,22 @@
-import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { Season } from '../../api/catApi';
+import type { BaseMapLayer } from '../../domain/mapMode';
 import type { ScenarioRegion } from '../../types/scenario';
 import FilterControls from './FilterControls';
 import RegionList from './RegionList';
 import SearchBar from './SearchBar';
 import SelectedRegionPanel from './SelectedRegionPanel';
 import SortControls from './SortControls';
+import QuickFilterChips from './QuickFilterChips';
+import Button from '../ui/Button';
 import {
     filterRegions,
     RegionSortMode,
@@ -22,7 +32,7 @@ interface SidebarProps {
     selectedRegionCode: string | null;
     detailsFocusKey?: number;
     season?: Season;
-    activeLayer?: 'cat' | 'affordability' | 'gap';
+    activeLayer?: BaseMapLayer;
     pinnedRegionCodes?: string[];
     maxPinnedRegions?: number;
     scenarioRegion?: ScenarioRegion;
@@ -61,6 +71,7 @@ export default function Sidebar({
     const [query, setQuery] = useState('');
     const [filters, setFilters] = useState<SidebarFilters>(DEFAULT_FILTERS);
     const [sortMode, setSortMode] = useState<RegionSortMode>('name');
+    const [filtersOpen, setFiltersOpen] = useState(false);
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(360);
     const activePinnedRegionCodes = pinnedRegionCodes ?? [];
@@ -68,6 +79,9 @@ export default function Sidebar({
     const activeTogglePin = onTogglePin ?? (() => {});
     const activeIsPinned = isPinned ?? (() => false);
     const showCatTools = activeLayer === 'cat';
+    const activeFilterCount = [filters.tier, filters.status, filters.desert]
+        .filter(Boolean).length + (filters.dataGap === 'all' ? 0 : 1);
+    const hasActiveControls = Boolean(query) || activeFilterCount > 0 || sortMode !== 'name';
 
     const selectedRegion = useMemo(
         () => regions.find(region => region.region_code === selectedRegionCode) ?? null,
@@ -118,6 +132,21 @@ export default function Sidebar({
         document.addEventListener('mouseup', handleUp);
     }, [sidebarWidth]);
 
+    const resizeWithKeyboard = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+        event.preventDefault();
+        if (event.key === 'Home') {
+            setSidebarWidth(MIN_SIDEBAR_WIDTH);
+            return;
+        }
+        if (event.key === 'End') {
+            setSidebarWidth(MAX_SIDEBAR_WIDTH);
+            return;
+        }
+        const delta = event.key === 'ArrowRight' ? 16 : -16;
+        setSidebarWidth(width => Math.min(Math.max(width + delta, MIN_SIDEBAR_WIDTH), MAX_SIDEBAR_WIDTH));
+    }, []);
+
     if (isCollapsed) {
         return (
             <aside
@@ -125,14 +154,13 @@ export default function Sidebar({
                 style={{ width: 56, minWidth: 56 }}
                 aria-label="Collapsed community sidebar"
             >
-                <button
-                    type="button"
-                    className="sidebar-collapse-button"
+                <Button
+                    size="small"
                     onClick={() => setIsCollapsed(false)}
                     aria-label="Expand community sidebar"
                 >
                     Open
-                </button>
+                </Button>
                 <div className="sidebar-collapsed-label">Communities</div>
             </aside>
         );
@@ -149,22 +177,14 @@ export default function Sidebar({
                     <p>{loading ? 'Loading...' : `${visibleRegions.length} of ${regions.length}`}</p>
                 </div>
                 <div className="sidebar-header-actions">
-                    <button
-                        type="button"
-                        className="sidebar-action-button"
-                        onClick={resetSidebarControls}
-                        aria-label="Reset sidebar filters"
-                    >
-                        Reset
-                    </button>
-                    <button
-                        type="button"
-                        className="sidebar-collapse-button"
+                    <Button
+                        variant="ghost"
+                        size="small"
                         onClick={() => setIsCollapsed(true)}
                         aria-label="Collapse community sidebar"
                     >
                         Hide
-                    </button>
+                    </Button>
                 </div>
             </header>
 
@@ -176,8 +196,40 @@ export default function Sidebar({
 
             {showCatTools && (
                 <>
-                    <FilterControls filters={filters} onChange={setFilters} />
-                    <SortControls value={sortMode} onChange={setSortMode} />
+                    <QuickFilterChips filters={filters} onChange={setFilters} />
+                    <section className="sidebar-control-panel" aria-label="Community controls">
+                        <div className="sidebar-control-panel__header">
+                            <button
+                                type="button"
+                                className="sidebar-control-panel__toggle"
+                                aria-expanded={filtersOpen}
+                                aria-controls="sidebar-filter-controls"
+                                onClick={() => setFiltersOpen(value => !value)}
+                            >
+                                Filters &amp; sort
+                                {activeFilterCount > 0 && (
+                                    <span>{activeFilterCount} active</span>
+                                )}
+                            </button>
+                            <Button
+                                variant="ghost"
+                                size="small"
+                                onClick={resetSidebarControls}
+                                disabled={!hasActiveControls}
+                                aria-label="Reset sidebar filters"
+                            >
+                                Reset
+                            </Button>
+                        </div>
+                        <div
+                            id="sidebar-filter-controls"
+                            className="sidebar-control-panel__body"
+                            hidden={!filtersOpen}
+                        >
+                            <FilterControls filters={filters} onChange={setFilters} />
+                            <SortControls value={sortMode} onChange={setSortMode} />
+                        </div>
+                    </section>
                 </>
             )}
 
@@ -205,6 +257,7 @@ export default function Sidebar({
                 region={selectedRegion}
                 season={season}
                 focusKey={detailsFocusKey}
+                activeLayer={activeLayer}
                 pinned={selectedRegion ? activeIsPinned(selectedRegion.region_code) : false}
                 pinDisabled={activePinnedRegionCodes.length >= activeMaxPinnedRegions}
                 onTogglePin={activeTogglePin}
@@ -231,9 +284,15 @@ export default function Sidebar({
             <div
                 className="sidebar-resize-handle"
                 role="separator"
+                tabIndex={0}
                 aria-orientation="vertical"
                 aria-label="Resize community sidebar"
+                aria-valuemin={MIN_SIDEBAR_WIDTH}
+                aria-valuemax={MAX_SIDEBAR_WIDTH}
+                aria-valuenow={sidebarWidth}
+                aria-valuetext={`${sidebarWidth} pixels`}
                 onMouseDown={startResize}
+                onKeyDown={resizeWithKeyboard}
             />
         </aside>
     );

--- a/frontend/src/components/sidebar/sidebarUtils.ts
+++ b/frontend/src/components/sidebar/sidebarUtils.ts
@@ -1,12 +1,18 @@
-import { RegionSummary } from '../../api/catApi';
+import type { RegionSummary, TelehealthStatusName } from '../../api/catApi';
+import {
+    getDesertScorePresentation,
+    matchesDesertScoreFilter,
+    type CatTier,
+    type DesertScoreFilter,
+} from '../../domain/metrics';
 
 export type RegionSortMode = 'name' | 'tier' | 'desert';
 export type DataGapFilter = 'all' | 'missing' | 'complete';
 
 export interface SidebarFilters {
-    tier: string;
-    status: string;
-    desert: string;
+    tier: '' | `${CatTier}`;
+    status: '' | TelehealthStatusName;
+    desert: DesertScoreFilter;
     dataGap: DataGapFilter;
 }
 
@@ -28,22 +34,11 @@ export function formatStatus(status: string | null | undefined, fallback = 'Unkn
         .join(' ');
 }
 
-export function statusClassName(status: string | null | undefined) {
-    const normalized = (status || '').toLowerCase();
-    if (normalized.includes('ready')) return 'status-ready';
-    if (normalized.includes('anchor')) return 'status-anchor';
-    if (normalized.includes('critical')) return 'status-critical';
-    return 'status-unknown';
-}
-
 export function telehealthNeedLabel(score: number | null | undefined): string {
     if (score === null || score === undefined || !Number.isFinite(score)) {
         return 'Data unavailable';
     }
-    if (score <= 30) return `Low Need (${score.toFixed(1)})`;
-    if (score <= 60) return `Moderate Need (${score.toFixed(1)})`;
-    if (score <= 80) return `High Need (${score.toFixed(1)})`;
-    return `Critical Need (${score.toFixed(1)})`;
+    return `${getDesertScorePresentation(score).label} (${score.toFixed(1)})`;
 }
 
 export function sortRegions(regions: RegionSummary[], sortMode: RegionSortMode) {
@@ -85,19 +80,7 @@ export function filterRegions(
             return false;
         }
 
-        if (filters.desert === '70-plus' && (region.desert_score ?? -1) < 70) {
-            return false;
-        }
-
-        if (filters.desert === '50-plus' && (region.desert_score ?? -1) < 50) {
-            return false;
-        }
-
-        if (filters.desert === 'below-50' && (region.desert_score === null || region.desert_score === undefined || region.desert_score >= 50)) {
-            return false;
-        }
-
-        if (filters.desert === 'unknown' && region.desert_score !== null && region.desert_score !== undefined) {
+        if (!matchesDesertScoreFilter(region.desert_score, filters.desert)) {
             return false;
         }
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'small' | 'default';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    leadingIcon?: ReactNode;
+    trailingIcon?: ReactNode;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
+    variant = 'secondary',
+    size = 'default',
+    leadingIcon,
+    trailingIcon,
+    className = '',
+    children,
+    type = 'button',
+    ...props
+}, ref) {
+    const classes = ['ui-button', `ui-button--${variant}`, `ui-button--${size}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button ref={ref} type={type} className={classes} {...props}>
+            {leadingIcon && <span className="ui-button__icon" aria-hidden="true">{leadingIcon}</span>}
+            <span className="ui-button__label">{children}</span>
+            {trailingIcon && <span className="ui-button__icon" aria-hidden="true">{trailingIcon}</span>}
+        </button>
+    );
+});
+
+export default Button;

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import type { ButtonSize, ButtonVariant } from './Button';
+import './ui.css';
+
+export interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
+    'aria-label': string;
+    icon: ReactNode;
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+}
+
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
+    'aria-label': ariaLabel,
+    icon,
+    variant = 'ghost',
+    size = 'default',
+    className = '',
+    type = 'button',
+    ...props
+}, ref) {
+    const classes = ['ui-icon-button', `ui-button--${variant}`, `ui-icon-button--${size}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button
+            ref={ref}
+            type={type}
+            className={classes}
+            aria-label={ariaLabel}
+            {...props}
+        >
+            <span className="ui-icon-button__icon" aria-hidden="true">{icon}</span>
+        </button>
+    );
+});
+
+export default IconButton;

--- a/frontend/src/components/ui/MetricCard.tsx
+++ b/frontend/src/components/ui/MetricCard.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type MetricTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+
+export interface MetricCardProps extends HTMLAttributes<HTMLElement> {
+    label: string;
+    value: ReactNode;
+    supportingText?: ReactNode;
+    tone?: MetricTone;
+}
+
+const MetricCard = forwardRef<HTMLElement, MetricCardProps>(function MetricCard({
+    label,
+    value,
+    supportingText,
+    tone = 'neutral',
+    className = '',
+    ...props
+}, ref) {
+    const classes = ['ui-metric-card', `ui-metric-card--${tone}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <article ref={ref} className={classes} {...props}>
+            <span className="ui-metric-card__label">{label}</span>
+            <strong className="ui-metric-card__value">{value}</strong>
+            {supportingText && (
+                <span className="ui-metric-card__supporting-text">{supportingText}</span>
+            )}
+        </article>
+    );
+});
+
+export default MetricCard;

--- a/frontend/src/components/ui/Panel.tsx
+++ b/frontend/src/components/ui/Panel.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import './ui.css';
+
+export type PanelPadding = 'none' | 'small' | 'default';
+
+export interface PanelProps extends HTMLAttributes<HTMLDivElement> {
+    padding?: PanelPadding;
+    elevated?: boolean;
+}
+
+const Panel = forwardRef<HTMLDivElement, PanelProps>(function Panel({
+    padding = 'default',
+    elevated = false,
+    className = '',
+    ...props
+}, ref) {
+    const classes = [
+        'ui-panel',
+        `ui-panel--padding-${padding}`,
+        elevated ? 'ui-panel--elevated' : '',
+        className,
+    ].filter(Boolean).join(' ');
+
+    return <div ref={ref} className={classes} {...props} />;
+});
+
+export default Panel;

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type StatusTone = 'neutral' | 'ready' | 'anchor' | 'limited' | 'critical' | 'info';
+
+export interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+    children: ReactNode;
+    tone?: StatusTone;
+    showDot?: boolean;
+}
+
+const StatusBadge = forwardRef<HTMLSpanElement, StatusBadgeProps>(function StatusBadge({
+    children,
+    tone = 'neutral',
+    showDot = false,
+    className = '',
+    ...props
+}, ref) {
+    const classes = ['ui-status-badge', `ui-status-badge--${tone}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <span ref={ref} className={classes} {...props}>
+            {showDot && <span className="ui-status-badge__dot" aria-hidden="true" />}
+            {children}
+        </span>
+    );
+});
+
+export default StatusBadge;

--- a/frontend/src/components/ui/ui.css
+++ b/frontend/src/components/ui/ui.css
@@ -1,0 +1,263 @@
+.ui-button,
+.ui-icon-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow: var(--shadow-xs);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.ui-button:hover:not(:disabled),
+.ui-icon-button:hover:not(:disabled) {
+  box-shadow: var(--shadow-sm);
+}
+
+.ui-button:focus-visible,
+.ui-icon-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring), var(--shadow-xs);
+}
+
+.ui-button:disabled,
+.ui-icon-button:disabled {
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.ui-button--primary {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+}
+
+.ui-button--primary:hover:not(:disabled) {
+  border-color: var(--color-primary-hover);
+  background: var(--color-primary-hover);
+}
+
+.ui-button--primary:active:not(:disabled) {
+  border-color: var(--color-primary-active);
+  background: var(--color-primary-active);
+}
+
+.ui-button--secondary {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.ui-button--secondary:hover:not(:disabled) {
+  border-color: #94a3b8;
+  background: var(--color-surface-subtle);
+}
+
+.ui-button--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  box-shadow: none;
+}
+
+.ui-button--ghost:hover:not(:disabled) {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+.ui-button--danger {
+  border-color: var(--color-danger);
+  background: var(--color-danger);
+  color: var(--color-text-inverse);
+}
+
+.ui-button--danger:hover:not(:disabled) {
+  border-color: var(--color-danger-hover);
+  background: var(--color-danger-hover);
+}
+
+.ui-button {
+  gap: var(--spacing-2);
+  min-width: max-content;
+}
+
+.ui-button--small {
+  min-height: var(--control-height-sm);
+  padding: 0 var(--spacing-3);
+  font-size: var(--font-xs);
+}
+
+.ui-button--default {
+  min-height: var(--control-height);
+  padding: 0 var(--spacing-4);
+  font-size: var(--font-sm);
+}
+
+.ui-button__icon,
+.ui-icon-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+}
+
+.ui-button__icon > svg,
+.ui-icon-button__icon > svg {
+  width: 100%;
+  height: 100%;
+  stroke-width: 2;
+}
+
+.ui-icon-button {
+  padding: 0;
+}
+
+.ui-icon-button--small {
+  width: var(--control-icon-size-sm);
+  height: var(--control-icon-size-sm);
+  font-size: var(--font-sm);
+}
+
+.ui-icon-button--default {
+  width: var(--control-icon-size);
+  height: var(--control-icon-size);
+  font-size: var(--font-base);
+}
+
+.ui-panel {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-xs);
+}
+
+.ui-panel--padding-none {
+  padding: 0;
+}
+
+.ui-panel--padding-small {
+  padding: var(--spacing-3);
+}
+
+.ui-panel--padding-default {
+  padding: var(--spacing-4);
+}
+
+.ui-panel--elevated {
+  box-shadow: var(--shadow-md);
+}
+
+.ui-metric-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  border: 1px solid var(--color-border);
+  border-top: 3px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-xs);
+}
+
+.ui-metric-card--success {
+  border-top-color: var(--color-status-ready);
+}
+
+.ui-metric-card--warning {
+  border-top-color: var(--color-status-anchor);
+}
+
+.ui-metric-card--danger {
+  border-top-color: var(--color-status-gap);
+}
+
+.ui-metric-card--info {
+  border-top-color: var(--color-status-info);
+}
+
+.ui-metric-card__label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.ui-metric-card__value {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+}
+
+.ui-metric-card__supporting-text {
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+}
+
+.ui-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  width: fit-content;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-status-unknown-subtle);
+  color: var(--color-status-unknown);
+  padding: 0.1875rem var(--spacing-2);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.ui-status-badge--ready {
+  border-color: #bbf7d0;
+  background: var(--color-status-ready-subtle);
+  color: var(--color-status-ready);
+}
+
+.ui-status-badge--anchor {
+  border-color: #fde68a;
+  background: var(--color-status-anchor-subtle);
+  color: var(--color-status-anchor);
+}
+
+.ui-status-badge--limited {
+  border-color: #ddd6fe;
+  background: var(--color-status-limited-subtle);
+  color: var(--color-status-limited);
+}
+
+.ui-status-badge--critical {
+  border-color: #fecaca;
+  background: var(--color-status-gap-subtle);
+  color: var(--color-status-gap);
+}
+
+.ui-status-badge--info {
+  border-color: #bae6fd;
+  background: var(--color-status-info-subtle);
+  color: var(--color-status-info);
+}
+
+.ui-status-badge__dot {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: var(--radius-full);
+  background: currentColor;
+}

--- a/frontend/src/domain/domainPresentation.test.ts
+++ b/frontend/src/domain/domainPresentation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DESERT_SCORE_THRESHOLDS,
+    getDataGapPresentation,
+    getDesertScorePresentation,
+    matchesDesertScoreFilter,
+} from './metrics';
+import {
+    getTelehealthStatusColor,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+} from './statusPresentation';
+
+describe('desert score presentation', () => {
+    it.each([
+        [0, 'adequate', 'Adequate Need'],
+        [DESERT_SCORE_THRESHOLDS.moderate - 0.1, 'adequate', 'Adequate Need'],
+        [DESERT_SCORE_THRESHOLDS.moderate, 'moderate', 'Moderate Need'],
+        [DESERT_SCORE_THRESHOLDS.high, 'high', 'High Need'],
+        [DESERT_SCORE_THRESHOLDS.critical, 'critical', 'Critical Need'],
+        [100, 'critical', 'Critical Need'],
+    ])('classifies %s as %s', (score, level, label) => {
+        expect(getDesertScorePresentation(score)).toMatchObject({ level, label });
+    });
+
+    it('uses the same thresholds for sidebar score filters', () => {
+        expect(matchesDesertScoreFilter(75, '75-plus')).toBe(true);
+        expect(matchesDesertScoreFilter(74.9, '75-plus')).toBe(false);
+        expect(matchesDesertScoreFilter(50, '50-plus')).toBe(true);
+        expect(matchesDesertScoreFilter(49.9, 'below-50')).toBe(true);
+        expect(matchesDesertScoreFilter(null, 'unknown')).toBe(true);
+    });
+});
+
+describe('status presentation', () => {
+    it('provides one label, color, and tone for each shared status', () => {
+        expect(getTelehealthStatusLabel('COMMUNITY_ANCHOR')).toBe('Community Anchor');
+        expect(getTelehealthStatusColor('CRITICAL_GAP')).toBe('#ef4444');
+        expect(getTelehealthStatusColor('COMMUNITY_ANCHOR', 'scenario')).toBe('#f97316');
+        expect(getTelehealthStatusTone('LIMITED_TELEHEALTH')).toBe('limited');
+    });
+
+    it('names satellite dependency as connectivity, not affordability', () => {
+        expect(getDataGapPresentation('SATELLITE_DEPENDENT').label).toBe('Satellite-dependent access');
+    });
+});

--- a/frontend/src/domain/mapMode.ts
+++ b/frontend/src/domain/mapMode.ts
@@ -1,0 +1,27 @@
+export type BaseMapLayer = 'cat' | 'gap' | 'affordability';
+
+export type MapMode =
+    | { type: 'cat' }
+    | { type: 'gapHunter' }
+    | { type: 'telehealthAccess' }
+    | { type: 'scenario' };
+
+export const CAT_MAP_MODE: MapMode = { type: 'cat' };
+
+export function mapModeFromLayer(layer: BaseMapLayer): MapMode {
+    switch (layer) {
+        case 'gap': return { type: 'gapHunter' };
+        case 'affordability': return { type: 'telehealthAccess' };
+        case 'cat': return CAT_MAP_MODE;
+    }
+}
+
+export function baseLayerForMapMode(mode: MapMode): BaseMapLayer {
+    switch (mode.type) {
+        case 'gapHunter': return 'gap';
+        case 'telehealthAccess': return 'affordability';
+        case 'cat':
+        case 'scenario':
+            return 'cat';
+    }
+}

--- a/frontend/src/domain/mapUrlState.test.ts
+++ b/frontend/src/domain/mapUrlState.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { BASELINE_THRESHOLDS } from '../types/scenario';
+import {
+    ALASKA_CENTER,
+    ALASKA_ZOOM,
+    parseMapUrlState,
+    serializeMapUrlState,
+} from './mapUrlState';
+
+describe('map URL state', () => {
+    it('parses selection, viewport, layer, pins, and season', () => {
+        const state = parseMapUrlState(
+            '?region=AK-1&season=winter&layer=gap&pins=AK-1,AK-2&lat=64.5&lng=-151.25&zoom=7',
+        );
+
+        expect(state).toMatchObject({
+            selectedRegionCode: 'AK-1',
+            season: 'winter',
+            mapMode: { type: 'gapHunter' },
+            pinnedRegionCodes: ['AK-1', 'AK-2'],
+            center: [64.5, -151.25],
+            zoom: 7,
+        });
+    });
+
+    it('falls back for invalid or stale viewport values', () => {
+        expect(parseMapUrlState('?season=invalid&layer=unknown&lat=200&lng=nope&zoom=99')).toMatchObject({
+            season: 'year_round',
+            mapMode: { type: 'cat' },
+            center: ALASKA_CENTER,
+            zoom: ALASKA_ZOOM,
+        });
+        expect(parseMapUrlState('?lat=62.9752&lng=-154.95117&zoom=4')).toMatchObject({
+            center: ALASKA_CENTER,
+            zoom: ALASKA_ZOOM,
+        });
+    });
+
+    it('round-trips scenario mode and threshold parameters', () => {
+        const search = serializeMapUrlState('?unrelated=kept', {
+            selectedRegionCode: 'AK-9',
+            season: 'summer',
+            mapMode: { type: 'scenario' },
+            pinnedRegionCodes: [],
+            center: ALASKA_CENTER,
+            zoom: ALASKA_ZOOM,
+            scenario: {
+                thresholds: { ...BASELINE_THRESHOLDS, min_download_mbps: 100, max_latency_ms: null },
+                preset: 'equity',
+            },
+        });
+        const parsed = parseMapUrlState(`?${search}`);
+
+        expect(new URLSearchParams(search).get('unrelated')).toBe('kept');
+        expect(parsed.mapMode).toEqual({ type: 'scenario' });
+        expect(parsed.scenario).toEqual({
+            thresholds: {
+                min_download_mbps: 100,
+                min_upload_mbps: 3,
+                max_latency_ms: null,
+                affordability_burden_pct: 2,
+                clinic_proximity_km: null,
+            },
+            preset: 'equity',
+        });
+    });
+
+    it('removes stale owned parameters when returning to CAT mode', () => {
+        const search = serializeMapUrlState(
+            '?layer=gap&scenario=1&bd=100&preset=equity&external=1',
+            {
+                selectedRegionCode: null,
+                season: 'year_round',
+                mapMode: { type: 'cat' },
+                pinnedRegionCodes: [],
+                center: ALASKA_CENTER,
+                zoom: ALASKA_ZOOM,
+                scenario: { thresholds: BASELINE_THRESHOLDS, preset: null },
+            },
+        );
+
+        expect(search).toBe('external=1');
+    });
+});

--- a/frontend/src/domain/mapUrlState.ts
+++ b/frontend/src/domain/mapUrlState.ts
@@ -1,0 +1,157 @@
+import type { Season } from '../api/catApi';
+import type { ScenarioThresholds } from '../types/scenario';
+import type { MapMode } from './mapMode';
+
+export const ALASKA_CENTER: [number, number] = [64.2, -152.0];
+export const ALASKA_ZOOM = 4;
+export const ALASKA_BOUNDS: [[number, number], [number, number]] = [
+    [51.0, -188.0],
+    [72.0, -129.0],
+];
+
+const STALE_DEFAULT_CENTERS: Array<[number, number]> = [
+    [62.9752, -154.95117],
+    [62.35, -146.75],
+    [62.2, -141.8],
+    [62.2, -170.8],
+    [62.35, -136.5],
+];
+
+const OWNED_PARAMS = [
+    'region', 'layer', 'season', 'pins', 'lat', 'lng', 'zoom',
+    'scenario', 'bd', 'up', 'latency', 'aff', 'clinic', 'preset',
+] as const;
+
+export interface ParsedScenarioUrlState {
+    thresholds: Partial<ScenarioThresholds>;
+    preset: string | null;
+}
+
+export interface ParsedMapUrlState {
+    selectedRegionCode: string | null;
+    season: Season;
+    mapMode: MapMode;
+    pinnedRegionCodes: string[];
+    center: [number, number];
+    zoom: number;
+    scenario: ParsedScenarioUrlState;
+}
+
+export interface SerializableMapUrlState {
+    selectedRegionCode: string | null;
+    season: Season;
+    mapMode: MapMode;
+    pinnedRegionCodes: string[];
+    center: [number, number];
+    zoom: number;
+    scenario: {
+        thresholds: ScenarioThresholds;
+        preset: string | null;
+    };
+}
+
+function validNumber(value: string | null): number | null {
+    if (value === null || value.trim() === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseScenarioParams(params: URLSearchParams): ParsedScenarioUrlState {
+    if (params.get('scenario') !== '1') return { thresholds: {}, preset: null };
+
+    const thresholds: Partial<ScenarioThresholds> = {};
+    const download = validNumber(params.get('bd'));
+    const upload = validNumber(params.get('up'));
+    const affordability = validNumber(params.get('aff'));
+    const latencyParam = params.get('latency');
+    const clinicParam = params.get('clinic');
+
+    if (download !== null) thresholds.min_download_mbps = download;
+    if (upload !== null) thresholds.min_upload_mbps = upload;
+    if (affordability !== null) thresholds.affordability_burden_pct = affordability;
+    if (latencyParam === 'baseline') thresholds.max_latency_ms = null;
+    else {
+        const latency = validNumber(latencyParam);
+        if (latency !== null) thresholds.max_latency_ms = latency;
+    }
+    if (clinicParam === 'baseline') thresholds.clinic_proximity_km = null;
+    else {
+        const clinic = validNumber(clinicParam);
+        if (clinic !== null) thresholds.clinic_proximity_km = clinic;
+    }
+
+    return { thresholds, preset: params.get('preset') };
+}
+
+export function parseMapUrlState(search: string): ParsedMapUrlState {
+    const params = new URLSearchParams(search);
+    const seasonParam = params.get('season');
+    const layerParam = params.get('layer');
+    const lat = validNumber(params.get('lat'));
+    const lng = validNumber(params.get('lng'));
+    const zoom = validNumber(params.get('zoom'));
+    const hasSafeCenter = lat !== null && lng !== null
+        && lat >= ALASKA_BOUNDS[0][0] && lat <= ALASKA_BOUNDS[1][0]
+        && lng >= ALASKA_BOUNDS[0][1] && lng <= ALASKA_BOUNDS[1][1];
+    const hasSafeZoom = zoom !== null && zoom >= 4 && zoom <= 18;
+    const hasStaleDefaultViewport = hasSafeCenter && hasSafeZoom
+        && STALE_DEFAULT_CENTERS.some(([staleLat, staleLng]) => (
+            Math.abs(lat - staleLat) < 0.0001 && Math.abs(lng - staleLng) < 0.0001
+        ))
+        && zoom === ALASKA_ZOOM;
+
+    let mapMode: MapMode = { type: 'cat' };
+    if (params.get('scenario') === '1') mapMode = { type: 'scenario' };
+    else if (layerParam === 'gap') mapMode = { type: 'gapHunter' };
+    else if (layerParam === 'affordability') mapMode = { type: 'telehealthAccess' };
+
+    return {
+        selectedRegionCode: params.get('region'),
+        season: seasonParam === 'summer' || seasonParam === 'winter' || seasonParam === 'year_round'
+            ? seasonParam
+            : 'year_round',
+        mapMode,
+        pinnedRegionCodes: (params.get('pins') ?? '')
+            .split(',')
+            .map(code => code.trim())
+            .filter(Boolean)
+            .slice(0, 3),
+        center: hasSafeCenter && !hasStaleDefaultViewport ? [lat, lng] : ALASKA_CENTER,
+        zoom: hasSafeZoom && !hasStaleDefaultViewport ? zoom : ALASKA_ZOOM,
+        scenario: parseScenarioParams(params),
+    };
+}
+
+export function serializeMapUrlState(
+    currentSearch: string,
+    state: SerializableMapUrlState,
+): string {
+    const params = new URLSearchParams(currentSearch);
+    OWNED_PARAMS.forEach(param => params.delete(param));
+
+    if (state.selectedRegionCode) params.set('region', state.selectedRegionCode);
+    if (state.mapMode.type === 'gapHunter') params.set('layer', 'gap');
+    if (state.mapMode.type === 'telehealthAccess') params.set('layer', 'affordability');
+    if (state.season !== 'year_round') params.set('season', state.season);
+    if (state.pinnedRegionCodes.length) params.set('pins', state.pinnedRegionCodes.slice(0, 3).join(','));
+    if (state.center[0] !== ALASKA_CENTER[0]) params.set('lat', state.center[0].toFixed(5));
+    if (state.center[1] !== ALASKA_CENTER[1]) params.set('lng', state.center[1].toFixed(5));
+    if (state.zoom !== ALASKA_ZOOM) params.set('zoom', String(state.zoom));
+
+    if (state.mapMode.type === 'scenario') {
+        const { thresholds, preset } = state.scenario;
+        params.set('scenario', '1');
+        params.set('bd', String(thresholds.min_download_mbps));
+        params.set('up', String(thresholds.min_upload_mbps));
+        params.set('latency', thresholds.max_latency_ms === null
+            ? 'baseline'
+            : String(thresholds.max_latency_ms));
+        params.set('aff', String(thresholds.affordability_burden_pct));
+        params.set('clinic', thresholds.clinic_proximity_km === null
+            ? 'baseline'
+            : String(thresholds.clinic_proximity_km));
+        if (preset) params.set('preset', preset);
+    }
+
+    return params.toString();
+}

--- a/frontend/src/domain/metrics.ts
+++ b/frontend/src/domain/metrics.ts
@@ -1,0 +1,171 @@
+import type { StatusTone } from '../components/ui/StatusBadge';
+import type { TelehealthStatusName } from './statusPresentation';
+
+export type CatTier = 1 | 2 | 3 | 4;
+
+interface CatTierPresentation {
+    label: string;
+    shortDescription: string;
+    color: string;
+    tone: StatusTone;
+}
+
+export const CAT_TIER_PRESENTATION: Record<CatTier, CatTierPresentation> = {
+    1: {
+        label: 'Full Multimodal Access',
+        shortDescription: 'strongest access; road-connected or easier service reach.',
+        color: '#22c55e',
+        tone: 'ready',
+    },
+    2: {
+        label: 'Dual Mode Access',
+        shortDescription: 'moderate access; some travel or logistics constraints.',
+        color: '#eab308',
+        tone: 'info',
+    },
+    3: {
+        label: 'Limited Access',
+        shortDescription: 'limited access; remote travel makes care harder to reach.',
+        color: '#f97316',
+        tone: 'anchor',
+    },
+    4: {
+        label: 'Extreme/No Direct Access',
+        shortDescription: 'most isolated; highest transport and service-access barriers.',
+        color: '#ef4444',
+        tone: 'critical',
+    },
+};
+
+export const CAT_TIERS = [1, 2, 3, 4] as const;
+
+export interface DesertScorePresentation {
+    level: 'adequate' | 'moderate' | 'high' | 'critical';
+    label: string;
+    color: string;
+    tone: StatusTone;
+    description: string;
+}
+
+export const DESERT_SCORE_THRESHOLDS = {
+    moderate: 25,
+    high: 50,
+    critical: 75,
+} as const;
+
+const REGION_CARD_SEVERITY_THRESHOLDS = {
+    warning: 60,
+    critical: 80,
+} as const;
+
+export function getDesertScorePresentation(score: number): DesertScorePresentation {
+    if (score >= DESERT_SCORE_THRESHOLDS.critical) {
+        return {
+            level: 'critical',
+            label: 'Critical Need',
+            color: '#f43f5e',
+            tone: 'critical',
+            description: 'Severe lack of nearby healthcare facilities',
+        };
+    }
+    if (score >= DESERT_SCORE_THRESHOLDS.high) {
+        return {
+            level: 'high',
+            label: 'High Need',
+            color: '#fb923c',
+            tone: 'anchor',
+            description: 'Limited access to clinics or hospitals',
+        };
+    }
+    if (score >= DESERT_SCORE_THRESHOLDS.moderate) {
+        return {
+            level: 'moderate',
+            label: 'Moderate Need',
+            color: '#fbbf24',
+            tone: 'info',
+            description: 'Adequate access with some travel distance',
+        };
+    }
+    return {
+        level: 'adequate',
+        label: 'Adequate Need',
+        color: '#34d399',
+        tone: 'ready',
+        description: 'Good access to nearby healthcare facilities',
+    };
+}
+
+export type DesertScoreFilter = '' | '75-plus' | '50-plus' | 'below-50' | 'unknown';
+
+export const DESERT_SCORE_FILTER_OPTIONS: Array<{ value: DesertScoreFilter; label: string }> = [
+    { value: '', label: 'All scores' },
+    { value: '75-plus', label: `${DESERT_SCORE_THRESHOLDS.critical}+ critical need` },
+    { value: '50-plus', label: `${DESERT_SCORE_THRESHOLDS.high}+ high need` },
+    { value: 'below-50', label: `Below ${DESERT_SCORE_THRESHOLDS.high}` },
+    { value: 'unknown', label: 'Unknown score' },
+];
+
+export function matchesDesertScoreFilter(
+    score: number | null | undefined,
+    filter: DesertScoreFilter,
+): boolean {
+    if (!filter) return true;
+    if (filter === 'unknown') return score === null || score === undefined;
+    if (score === null || score === undefined) return false;
+    if (filter === '75-plus') return score >= DESERT_SCORE_THRESHOLDS.critical;
+    if (filter === '50-plus') return score >= DESERT_SCORE_THRESHOLDS.high;
+    return score < DESERT_SCORE_THRESHOLDS.high;
+}
+
+export function getRegionSeverityClassName(region: {
+    telehealth_status: TelehealthStatusName;
+    desert_score: number | null;
+}): string {
+    const status: TelehealthStatusName = region.telehealth_status;
+    const score = region.desert_score ?? -1;
+    // These existing card-emphasis cutoffs are intentionally distinct from the
+    // canonical 25/50/75 desert-score meaning bands above.
+    if (status === 'CRITICAL_GAP' || score >= REGION_CARD_SEVERITY_THRESHOLDS.critical) return 'severity-critical';
+    if (status === 'COMMUNITY_ANCHOR' || score >= REGION_CARD_SEVERITY_THRESHOLDS.warning) return 'severity-warning';
+    if (status === 'TELEHEALTH_READY') return 'severity-ready';
+    return 'severity-unknown';
+}
+
+export type DataGapSeverity = 'warning' | 'error' | 'info';
+
+export type DataConfidenceLevel = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export const DATA_CONFIDENCE_PRESENTATION: Record<DataConfidenceLevel, {
+    label: string;
+    className: string;
+}> = {
+    HIGH: { label: 'High', className: 'is-high' },
+    MEDIUM: { label: 'Medium', className: 'is-medium' },
+    LOW: { label: 'Low', className: 'is-low' },
+};
+
+export const DATA_CONFIDENCE_LEVELS: DataConfidenceLevel[] = ['HIGH', 'MEDIUM', 'LOW'];
+
+export function getDataGapPresentation(gap: string): { label: string; severity: DataGapSeverity } {
+    switch (gap) {
+        case 'SATELLITE_DEPENDENT':
+            return { label: 'Satellite-dependent access', severity: 'warning' };
+        case 'LOW_TERRESTRIAL':
+            return { label: 'Low wired coverage', severity: 'warning' };
+        case 'LOW_CONFIDENCE':
+            return { label: 'Low data confidence', severity: 'info' };
+        case 'INTERNET_DESERT':
+            return { label: 'No internet coverage', severity: 'error' };
+        case 'MISSING_WIRED_DATA':
+            return { label: 'Missing wired data', severity: 'info' };
+        case 'MISSING_SATELLITE_DATA':
+            return { label: 'Missing satellite data', severity: 'info' };
+        default:
+            return { label: gap, severity: 'info' };
+    }
+}
+
+export const SATELLITE_PRIMARY_METRIC = {
+    label: 'Satellite-primary places',
+    description: 'This is a connectivity access type, not a measure of affordability.',
+} as const;

--- a/frontend/src/domain/statusPresentation.ts
+++ b/frontend/src/domain/statusPresentation.ts
@@ -1,0 +1,101 @@
+import type { StatusTone } from '../components/ui/StatusBadge';
+
+export type TelehealthStatusName =
+    | 'TELEHEALTH_READY'
+    | 'COMMUNITY_ANCHOR'
+    | 'CRITICAL_GAP'
+    | 'DATA_UNAVAILABLE';
+
+export type ScenarioTelehealthStatusName = TelehealthStatusName | 'LIMITED_TELEHEALTH';
+
+interface TelehealthStatusPresentation {
+    label: string;
+    color: string;
+    scenarioColor?: string;
+    tone: StatusTone;
+    className: string;
+    description: string;
+}
+
+export const TELEHEALTH_STATUS_PRESENTATION: Record<ScenarioTelehealthStatusName, TelehealthStatusPresentation> = {
+    TELEHEALTH_READY: {
+        label: 'Telehealth Ready',
+        color: '#22c55e',
+        tone: 'ready',
+        className: 'status-ready',
+        description: 'Affordable home access',
+    },
+    COMMUNITY_ANCHOR: {
+        label: 'Community Anchor',
+        color: '#f59e0b',
+        scenarioColor: '#f97316',
+        tone: 'anchor',
+        className: 'status-anchor',
+        description: 'Nearby clinic safety net',
+    },
+    LIMITED_TELEHEALTH: {
+        label: 'Limited Telehealth',
+        color: '#eab308',
+        tone: 'limited',
+        className: 'status-limited',
+        description: 'Some access requirements are not met',
+    },
+    CRITICAL_GAP: {
+        label: 'Critical Gap',
+        color: '#ef4444',
+        tone: 'critical',
+        className: 'status-critical',
+        description: 'Unaffordable access and no nearby clinic',
+    },
+    DATA_UNAVAILABLE: {
+        label: 'Data Unavailable',
+        color: '#6b7280',
+        tone: 'neutral',
+        className: 'status-unknown',
+        description: 'Required classification data is missing',
+    },
+};
+
+export const BASE_TELEHEALTH_STATUSES: TelehealthStatusName[] = [
+    'TELEHEALTH_READY',
+    'COMMUNITY_ANCHOR',
+    'CRITICAL_GAP',
+    'DATA_UNAVAILABLE',
+];
+
+export const SCENARIO_TELEHEALTH_STATUSES: ScenarioTelehealthStatusName[] = [
+    'TELEHEALTH_READY',
+    'COMMUNITY_ANCHOR',
+    'LIMITED_TELEHEALTH',
+    'CRITICAL_GAP',
+    'DATA_UNAVAILABLE',
+];
+
+export function isScenarioTelehealthStatus(value: unknown): value is ScenarioTelehealthStatusName {
+    return typeof value === 'string'
+        && SCENARIO_TELEHEALTH_STATUSES.includes(value as ScenarioTelehealthStatusName);
+}
+
+export function getTelehealthStatusPresentation(status: ScenarioTelehealthStatusName) {
+    return TELEHEALTH_STATUS_PRESENTATION[status];
+}
+
+export function getTelehealthStatusLabel(status: ScenarioTelehealthStatusName): string {
+    return getTelehealthStatusPresentation(status).label;
+}
+
+export function getTelehealthStatusColor(
+    status: ScenarioTelehealthStatusName,
+    context: 'baseline' | 'scenario' = 'baseline',
+): string {
+    const presentation = getTelehealthStatusPresentation(status);
+    return context === 'scenario' ? presentation.scenarioColor ?? presentation.color : presentation.color;
+}
+
+export function getTelehealthStatusTone(status: ScenarioTelehealthStatusName): StatusTone {
+    return getTelehealthStatusPresentation(status).tone;
+}
+
+export function getTelehealthStatusClassName(status: ScenarioTelehealthStatusName): string {
+    return getTelehealthStatusPresentation(status).className;
+}

--- a/frontend/src/hooks/useComparisonProfiles.ts
+++ b/frontend/src/hooks/useComparisonProfiles.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Season } from '../api/catApi';
 import { fetchResearchProfiles } from '../api/researchApi';
 import { ResearchProfile } from '../types/research';
+import { errorMessage, isAbortError } from '../api/http';
 
 export function useComparisonProfiles(regionCodes: string[], season: Season) {
     const codesKey = regionCodes.slice(0, 3).join(',');
@@ -20,30 +21,30 @@ export function useComparisonProfiles(regionCodes: string[], season: Season) {
             return;
         }
 
-        let active = true;
+        const controller = new AbortController();
         setLoading(true);
         setError(null);
 
-        fetchResearchProfiles(codes, season)
+        fetchResearchProfiles(codes, season, controller.signal)
             .then(data => {
-                if (active) {
+                if (!controller.signal.aborted) {
                     setProfiles(data.profiles);
                     setMissingCodes(data.missing_codes);
                 }
             })
-            .catch(err => {
-                if (active) {
+            .catch((caught: unknown) => {
+                if (!isAbortError(caught)) {
                     setProfiles([]);
                     setMissingCodes([]);
-                    setError(err instanceof Error ? err.message : 'Failed to load comparison');
+                    setError(errorMessage(caught, 'Failed to load comparison'));
                 }
             })
             .finally(() => {
-                if (active) setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             });
 
         return () => {
-            active = false;
+            controller.abort();
         };
     }, [codesKey, season]);
 

--- a/frontend/src/hooks/useDashboardData.test.tsx
+++ b/frontend/src/hooks/useDashboardData.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    fetchAffordability,
+    fetchAllTelehealthStatus,
+    fetchDataGapsSummary,
+    fetchHealthcareSummary,
+    fetchPerformanceSummary,
+    fetchStatistics,
+} from '../api/catApi';
+import { useDashboardData } from './useDashboardData';
+
+vi.mock('../api/catApi', () => ({
+    fetchAffordability: vi.fn(),
+    fetchAllTelehealthStatus: vi.fn(),
+    fetchDataGapsSummary: vi.fn(),
+    fetchHealthcareSummary: vi.fn(),
+    fetchPerformanceSummary: vi.fn(),
+    fetchStatistics: vi.fn(),
+}));
+
+const mockedFetchStatistics = vi.mocked(fetchStatistics);
+const mockedFetchTelehealth = vi.mocked(fetchAllTelehealthStatus);
+const mockedFetchHealthcare = vi.mocked(fetchHealthcareSummary);
+const mockedFetchPerformance = vi.mocked(fetchPerformanceSummary);
+const mockedFetchDataGaps = vi.mocked(fetchDataGapsSummary);
+const mockedFetchAffordability = vi.mocked(fetchAffordability);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFetchStatistics.mockResolvedValue({
+        total_regions: 4,
+        total_data_points: 10,
+        total_uploads: 1,
+        completed_uploads: 1,
+        total_gating_rules: 0,
+        active_gating_rules: 0,
+        total_healthcare_sites: 2,
+        hospitals: 1,
+        clinics: 1,
+    });
+    mockedFetchTelehealth.mockResolvedValue({
+        regions: [],
+        count: 4,
+        summary: {
+            telehealth_ready: 1,
+            community_anchor: 1,
+            critical_gap: 1,
+            data_unavailable: 1,
+        },
+    });
+    mockedFetchHealthcare.mockResolvedValue({
+        total_facilities: 2,
+        by_type: { hospital: 1, clinic: 1, pharmacy: 0, health_center: 0 },
+        features: { with_emergency: 1, with_specialists: 0, with_telehealth: 1 },
+        data_source: 'test',
+    });
+    mockedFetchPerformance.mockResolvedValue({
+        has_data: true,
+        period: { year: 2025, quarter: 1, label: '2025 Q1' },
+        coverage: { total_tiles: 1, tiles_with_speed_data: 1, total_tests: 1, total_devices: 1 },
+        speeds: { avg_download_mbps: 25, max_download_mbps: 25, min_download_mbps: 25, median_download_mbps: 25 },
+        distribution: { excellent: 0, good: 1, moderate: 0, poor: 0, critical: 0 },
+        telehealth_viable_pct: 100,
+    });
+    mockedFetchDataGaps.mockResolvedValue({
+        total_places: 1,
+        places_with_gaps: 0,
+        gap_breakdown: {},
+        confidence_distribution: { HIGH: 1, MEDIUM: 0, LOW: 0 },
+        telehealth_viability: { YES: 1, NO: 0, UNCERTAIN: 0 },
+        primary_access: { WIRED: 1, SATELLITE: 0, LIMITED: 0 },
+    });
+    mockedFetchAffordability.mockResolvedValue({
+        zones: [],
+        count: 1,
+        monthly_cost: 120,
+        threshold_pct: 2,
+        summary: { affordable: 1, unaffordable: 0, affordable_pct: 100 },
+    });
+});
+
+describe('useDashboardData', () => {
+    it('keeps fulfilled sections and identifies a rejected section', async () => {
+        mockedFetchPerformance.mockRejectedValue(new Error('Performance period unavailable'));
+
+        const { result } = renderHook(() => useDashboardData());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.data.statistics?.total_regions).toBe(4);
+        expect(result.current.data.performance).toBeNull();
+        expect(result.current.sectionErrors).toEqual({
+            performance: 'Performance period unavailable',
+        });
+        expect(result.current.availableSectionCount).toBe(5);
+        expect(result.current.hasPartialData).toBe(true);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('passes one request signal to every dashboard source and aborts on unmount', async () => {
+        const { result, unmount } = renderHook(() => useDashboardData());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const signal = mockedFetchStatistics.mock.calls[0][0];
+        expect(signal).toBeInstanceOf(AbortSignal);
+        expect(mockedFetchTelehealth).toHaveBeenCalledWith(signal);
+        expect(mockedFetchHealthcare).toHaveBeenCalledWith(signal);
+        expect(mockedFetchPerformance).toHaveBeenCalledWith(signal);
+        expect(mockedFetchDataGaps).toHaveBeenCalledWith(signal);
+        expect(mockedFetchAffordability).toHaveBeenCalledWith(120, 2, signal);
+
+        unmount();
+        expect(signal?.aborted).toBe(true);
+    });
+});

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    fetchAffordability,
+    fetchAllTelehealthStatus,
+    fetchDataGapsSummary,
+    fetchHealthcareSummary,
+    fetchPerformanceSummary,
+    fetchStatistics,
+    type AffordabilityResponse,
+    type AllTelehealthStatusResponse,
+    type DataGapsSummary,
+    type HealthcareSummary,
+    type PerformanceSummary,
+    type StatisticsResponse,
+} from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+
+export interface DashboardData {
+    statistics: StatisticsResponse | null;
+    telehealthStatus: AllTelehealthStatusResponse | null;
+    healthcare: HealthcareSummary | null;
+    performance: PerformanceSummary | null;
+    dataGaps: DataGapsSummary | null;
+    affordability: AffordabilityResponse | null;
+}
+
+export type DashboardSection = keyof DashboardData;
+export type DashboardSectionErrors = Partial<Record<DashboardSection, string>>;
+
+const EMPTY_DATA: DashboardData = {
+    statistics: null,
+    telehealthStatus: null,
+    healthcare: null,
+    performance: null,
+    dataGaps: null,
+    affordability: null,
+};
+
+function rejectedMessage(result: PromiseSettledResult<unknown>): string | undefined {
+    return result.status === 'rejected' ? errorMessage(result.reason) : undefined;
+}
+
+export function useDashboardData() {
+    const [data, setData] = useState<DashboardData>(EMPTY_DATA);
+    const [sectionErrors, setSectionErrors] = useState<DashboardSectionErrors>({});
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+        const controller = new AbortController();
+
+        async function loadData() {
+            setLoading(true);
+            setError(null);
+            setSectionErrors({});
+
+            try {
+                const results = await Promise.allSettled([
+                    fetchStatistics(controller.signal),
+                    fetchAllTelehealthStatus(controller.signal),
+                    fetchHealthcareSummary(controller.signal),
+                    fetchPerformanceSummary(controller.signal),
+                    fetchDataGapsSummary(controller.signal),
+                    fetchAffordability(120, 2, controller.signal),
+                ] as const);
+
+                if (!isMounted || controller.signal.aborted) return;
+
+                const [
+                    statisticsResult,
+                    telehealthResult,
+                    healthcareResult,
+                    performanceResult,
+                    dataGapsResult,
+                    affordabilityResult,
+                ] = results;
+
+                const nextData: DashboardData = {
+                    statistics: statisticsResult.status === 'fulfilled' ? statisticsResult.value : null,
+                    telehealthStatus: telehealthResult.status === 'fulfilled' ? telehealthResult.value : null,
+                    healthcare: healthcareResult.status === 'fulfilled' ? healthcareResult.value : null,
+                    performance: performanceResult.status === 'fulfilled' ? performanceResult.value : null,
+                    dataGaps: dataGapsResult.status === 'fulfilled' ? dataGapsResult.value : null,
+                    affordability: affordabilityResult.status === 'fulfilled' ? affordabilityResult.value : null,
+                };
+
+                const nextSectionErrors: DashboardSectionErrors = {};
+                const resultBySection: Record<DashboardSection, PromiseSettledResult<unknown>> = {
+                    statistics: statisticsResult,
+                    telehealthStatus: telehealthResult,
+                    healthcare: healthcareResult,
+                    performance: performanceResult,
+                    dataGaps: dataGapsResult,
+                    affordability: affordabilityResult,
+                };
+
+                (Object.keys(resultBySection) as DashboardSection[]).forEach(section => {
+                    const message = rejectedMessage(resultBySection[section]);
+                    if (message) nextSectionErrors[section] = message;
+                });
+
+                const failedCount = Object.keys(nextSectionErrors).length;
+                setData(nextData);
+                setSectionErrors(nextSectionErrors);
+                setError(failedCount === results.length
+                    ? 'Statewide insight sources are currently unavailable. Return to the map and try again later.'
+                    : null);
+            } catch (caught: unknown) {
+                if (!isMounted || isAbortError(caught)) return;
+                setData(EMPTY_DATA);
+                setError(errorMessage(caught));
+            } finally {
+                if (isMounted) setLoading(false);
+            }
+        }
+
+        loadData();
+        return () => {
+            isMounted = false;
+            controller.abort();
+        };
+    }, []);
+
+    const availableSectionCount = useMemo(
+        () => Object.values(data).filter(Boolean).length,
+        [data],
+    );
+    const unavailableSectionCount = Object.keys(sectionErrors).length;
+
+    return {
+        data,
+        sectionErrors,
+        availableSectionCount,
+        hasPartialData: availableSectionCount > 0 && unavailableSectionCount > 0,
+        loading,
+        error,
+    };
+}

--- a/frontend/src/hooks/useMapSelection.test.tsx
+++ b/frontend/src/hooks/useMapSelection.test.tsx
@@ -1,0 +1,17 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useMapSelection } from './useMapSelection';
+
+describe('useMapSelection', () => {
+    it('requests selected-panel visibility for selections and detail actions', () => {
+        const { result } = renderHook(() => useMapSelection(null));
+
+        act(() => result.current.selectRegion('AK-ANCHORAGE'));
+        expect(result.current.selectedRegionCode).toBe('AK-ANCHORAGE');
+        expect(result.current.detailsFocusKey).toBe(1);
+
+        act(() => result.current.viewRegionDetails('AK-BETHEL'));
+        expect(result.current.selectedRegionCode).toBe('AK-BETHEL');
+        expect(result.current.detailsFocusKey).toBe(2);
+    });
+});

--- a/frontend/src/hooks/useMapSelection.ts
+++ b/frontend/src/hooks/useMapSelection.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from 'react';
+import type L from 'leaflet';
+
+export type SelectableMapMarker = L.Marker | L.CircleMarker;
+
+export function useMapSelection(initialRegionCode: string | null) {
+    const [selectedRegionCode, setSelectedRegionCode] = useState(initialRegionCode);
+    const [detailsFocusKey, setDetailsFocusKey] = useState(0);
+    const markerRefs = useRef<Record<string, SelectableMapMarker>>({});
+
+    const registerMarker = useCallback((regionCode: string, marker: SelectableMapMarker | null) => {
+        if (marker) markerRefs.current[regionCode] = marker;
+        else delete markerRefs.current[regionCode];
+    }, []);
+
+    const selectRegion = useCallback((regionCode: string) => {
+        setSelectedRegionCode(regionCode);
+        setDetailsFocusKey(key => key + 1);
+    }, []);
+
+    const viewRegionDetails = useCallback((regionCode: string) => {
+        setSelectedRegionCode(regionCode);
+        setDetailsFocusKey(key => key + 1);
+        markerRefs.current[regionCode]?.closePopup();
+    }, []);
+
+    return {
+        selectedRegionCode,
+        setSelectedRegionCode,
+        detailsFocusKey,
+        markerRefs,
+        registerMarker,
+        selectRegion,
+        viewRegionDetails,
+    };
+}

--- a/frontend/src/hooks/useMapUrlSync.test.tsx
+++ b/frontend/src/hooks/useMapUrlSync.test.tsx
@@ -1,0 +1,35 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ALASKA_CENTER, ALASKA_ZOOM } from '../domain/mapUrlState';
+import { BASELINE_THRESHOLDS } from '../types/scenario';
+import { useMapUrlSync } from './useMapUrlSync';
+
+const currentState = {
+    selectedRegionCode: null,
+    season: 'year_round' as const,
+    mapMode: { type: 'cat' as const },
+    pinnedRegionCodes: [],
+    center: ALASKA_CENTER,
+    zoom: ALASKA_ZOOM,
+    scenario: { thresholds: BASELINE_THRESHOLDS, preset: null },
+};
+
+describe('useMapUrlSync', () => {
+    it('restores the complete URL state on browser navigation', () => {
+        window.history.replaceState(null, '', '/');
+        const restoreState = vi.fn();
+        renderHook(() => useMapUrlSync(currentState, restoreState));
+
+        act(() => {
+            window.history.pushState(null, '', '/?region=AK-2&season=winter&layer=gap&zoom=6');
+            window.dispatchEvent(new PopStateEvent('popstate'));
+        });
+
+        expect(restoreState).toHaveBeenCalledWith(expect.objectContaining({
+            selectedRegionCode: 'AK-2',
+            season: 'winter',
+            mapMode: { type: 'gapHunter' },
+            zoom: 6,
+        }));
+    });
+});

--- a/frontend/src/hooks/useMapUrlSync.ts
+++ b/frontend/src/hooks/useMapUrlSync.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import {
+    parseMapUrlState,
+    serializeMapUrlState,
+    type ParsedMapUrlState,
+    type SerializableMapUrlState,
+} from '../domain/mapUrlState';
+
+export function useMapUrlSync(
+    state: SerializableMapUrlState,
+    restoreState: (state: ParsedMapUrlState) => void,
+): void {
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const search = serializeMapUrlState(window.location.search, state);
+        const nextUrl = `${window.location.pathname}${search ? `?${search}` : ''}`;
+        window.history.replaceState(null, '', nextUrl);
+    }, [state]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const handlePopState = () => restoreState(parseMapUrlState(window.location.search));
+        window.addEventListener('popstate', handlePopState);
+        return () => window.removeEventListener('popstate', handlePopState);
+    }, [restoreState]);
+}

--- a/frontend/src/hooks/useRegionSearch.ts
+++ b/frontend/src/hooks/useRegionSearch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RegionSearchParams, RegionSummary, searchRegions } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
 
 const SEARCH_DEBOUNCE_MS = 250;
 
@@ -12,7 +13,7 @@ export function useRegionSearch(params: RegionSearchParams) {
     const stableParams = useMemo(() => JSON.stringify(params), [params]);
 
     useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
         const parsedParams = JSON.parse(stableParams) as RegionSearchParams;
         const hasActiveParams = Object.values(parsedParams).some(
             value => value !== undefined && value !== null && value !== '',
@@ -26,7 +27,7 @@ export function useRegionSearch(params: RegionSearchParams) {
                 hasSearched.current = false;
             }
             return () => {
-                cancelled = true;
+                controller.abort();
             };
         }
         hasSearched.current = true;
@@ -34,24 +35,24 @@ export function useRegionSearch(params: RegionSearchParams) {
         const timeoutId = window.setTimeout(async () => {
             try {
                 setLoading(true);
-                const data = await searchRegions(parsedParams);
-                if (!cancelled) {
+                const data = await searchRegions(parsedParams, controller.signal);
+                if (!controller.signal.aborted) {
                     setResults(data);
                     setError(null);
                 }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : 'Failed to search regions');
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to search regions'));
                 }
             } finally {
-                if (!cancelled) {
+                if (!controller.signal.aborted) {
                     setLoading(false);
                 }
             }
         }, SEARCH_DEBOUNCE_MS);
 
         return () => {
-            cancelled = true;
+            controller.abort();
             window.clearTimeout(timeoutId);
         };
     }, [stableParams]);

--- a/frontend/src/hooks/useRegionSummary.ts
+++ b/frontend/src/hooks/useRegionSummary.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchRegionSummary, RegionSummary } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
 
 export function useRegionSummary() {
     const [regions, setRegions] = useState<RegionSummary[]>([]);
@@ -7,22 +8,22 @@ export function useRegionSummary() {
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
 
         async function loadSummary() {
             try {
                 setLoading(true);
-                const data = await fetchRegionSummary();
-                if (!cancelled) {
+                const data = await fetchRegionSummary(controller.signal);
+                if (!controller.signal.aborted) {
                     setRegions(data);
                     setError(null);
                 }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : 'Failed to load region summary');
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to load region summary'));
                 }
             } finally {
-                if (!cancelled) {
+                if (!controller.signal.aborted) {
                     setLoading(false);
                 }
             }
@@ -31,7 +32,7 @@ export function useRegionSummary() {
         loadSummary();
 
         return () => {
-            cancelled = true;
+            controller.abort();
         };
     }, []);
 

--- a/frontend/src/hooks/useResearchProfile.ts
+++ b/frontend/src/hooks/useResearchProfile.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Season } from '../api/catApi';
 import { fetchResearchProfile } from '../api/researchApi';
 import { ResearchProfile } from '../types/research';
+import { errorMessage, isAbortError } from '../api/http';
 
 export function useResearchProfile(regionCode: string | null, season: Season) {
     const [profile, setProfile] = useState<ResearchProfile | null>(null);
@@ -16,27 +17,27 @@ export function useResearchProfile(regionCode: string | null, season: Season) {
             return;
         }
 
-        let active = true;
+        const controller = new AbortController();
         setLoading(true);
         setProfile(null);
         setError(null);
 
-        fetchResearchProfile(regionCode, season)
+        fetchResearchProfile(regionCode, season, controller.signal)
             .then(data => {
-                if (active) setProfile(data);
+                if (!controller.signal.aborted) setProfile(data);
             })
-            .catch(err => {
-                if (active) {
+            .catch((caught: unknown) => {
+                if (!isAbortError(caught)) {
                     setProfile(null);
-                    setError(err instanceof Error ? err.message : 'Failed to load research profile');
+                    setError(errorMessage(caught, 'Failed to load research profile'));
                 }
             })
             .finally(() => {
-                if (active) setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             });
 
         return () => {
-            active = false;
+            controller.abort();
         };
     }, [regionCode, season]);
 

--- a/frontend/src/hooks/useScenarioPreview.test.tsx
+++ b/frontend/src/hooks/useScenarioPreview.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchScenarioPreview } from '../api/scenarioApi';
+import { BASELINE_THRESHOLDS, type ScenarioPreviewResponse } from '../types/scenario';
+import { useScenarioPreview } from './useScenarioPreview';
+
+vi.mock('../api/scenarioApi', () => ({
+    fetchScenarioPreview: vi.fn(),
+}));
+
+const preview: ScenarioPreviewResponse = {
+    scenario: {
+        season: 'year_round',
+        thresholds: BASELINE_THRESHOLDS,
+        is_baseline_equivalent: true,
+    },
+    summary: {
+        total_regions: 1,
+        status_changed_regions: 0,
+        score_changed_regions: 0,
+        improved_count: 0,
+        worsened_count: 0,
+        unchanged_count: 1,
+        telehealth_ready: 1,
+        community_anchor: 0,
+        limited_telehealth: 0,
+        critical_gap: 0,
+        data_unavailable: 0,
+    },
+    regions: [],
+};
+
+describe('useScenarioPreview', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it('clears stale output immediately when assumptions change or the refresh fails', async () => {
+        vi.useFakeTimers();
+        vi.mocked(fetchScenarioPreview)
+            .mockResolvedValueOnce(preview)
+            .mockRejectedValueOnce(new Error('Preview unavailable'));
+        const setMode = vi.fn();
+
+        const { result, rerender } = renderHook(
+            ({ thresholds }) => useScenarioPreview(
+                'active',
+                thresholds,
+                'year_round',
+                null,
+                setMode,
+            ),
+            { initialProps: { thresholds: BASELINE_THRESHOLDS } },
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(500);
+            await Promise.resolve();
+        });
+        expect(result.current.data).toEqual(preview);
+
+        rerender({ thresholds: { ...BASELINE_THRESHOLDS, min_download_mbps: 75 } });
+        expect(result.current.data).toBeNull();
+        expect(result.current.loading).toBe(true);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(500);
+            await Promise.resolve();
+        });
+        expect(result.current.data).toBeNull();
+        expect(result.current.error).toBe('Preview unavailable');
+    });
+});

--- a/frontend/src/hooks/useScenarioPreview.ts
+++ b/frontend/src/hooks/useScenarioPreview.ts
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchScenarioPreview } from '../api/scenarioApi';
 import type { Season } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
 import type {
     ScenarioMode,
     ScenarioPreviewResponse,
@@ -33,6 +34,7 @@ export function useScenarioPreview(
     regionCodes: string[] | null = null,
     setMode?: (mode: ScenarioMode) => void,
 ): ScenarioPreviewState {
+    const enabled = mode !== 'off';
     const [data, setData] = useState<ScenarioPreviewResponse | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -96,10 +98,11 @@ export function useScenarioPreview(
             setError(null);
             setMode?.('active');
             abortRef.current = null;
-        } catch (err: any) {
-            if (err?.name === 'AbortError') return;
+        } catch (err: unknown) {
+            if (isAbortError(err)) return;
             if (!controller.signal.aborted && abortRef.current === controller) {
-                setError(err?.message || 'Scenario preview failed');
+                setData(null);
+                setError(errorMessage(err, 'Scenario preview failed'));
                 setLoading(false);
                 setMode?.('active');
                 abortRef.current = null;
@@ -109,7 +112,7 @@ export function useScenarioPreview(
 
     // Debounced fetch
     useEffect(() => {
-        if (mode === 'off') {
+        if (!enabled) {
             setData(null);
             setError(null);
             setLoading(false);
@@ -126,6 +129,13 @@ export function useScenarioPreview(
             window.clearTimeout(timerRef.current);
         }
 
+        abortRef.current?.abort();
+        abortRef.current = null;
+        setData(null);
+        setError(null);
+        setLoading(true);
+        setMode?.('calculating');
+
         timerRef.current = window.setTimeout(() => {
             fetchPreview(thresholds, season, regionCodes);
         }, DEBOUNCE_MS);
@@ -136,7 +146,7 @@ export function useScenarioPreview(
                 timerRef.current = null;
             }
         };
-    }, [mode, thresholds, season, regionCodes, fetchPreview]);
+    }, [enabled, thresholds, season, regionCodes, fetchPreview, setMode]);
 
     // Cleanup on unmount
     useEffect(() => {

--- a/frontend/src/hooks/useScenarioState.test.tsx
+++ b/frontend/src/hooks/useScenarioState.test.tsx
@@ -1,17 +1,21 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BASELINE_THRESHOLDS } from '../types/scenario';
 import { useScenarioState } from './useScenarioState';
 
-describe('useScenarioState URL sync', () => {
-    it('restores scenario params and removes them when scenario mode is deactivated', async () => {
-        window.history.replaceState(
-            null,
-            '',
-            '/?scenario=1&bd=100&up=20&latency=90&aff=4&clinic=30&preset=equity',
-        );
-
-        const { result } = renderHook(() => useScenarioState('year_round'));
+describe('useScenarioState restoration', () => {
+    it('restores scenario state supplied by URL ownership and resets when deactivated', () => {
+        const { result } = renderHook(() => useScenarioState('year_round', {
+            active: true,
+            thresholds: {
+                min_download_mbps: 100,
+                min_upload_mbps: 20,
+                max_latency_ms: 90,
+                affordability_burden_pct: 4,
+                clinic_proximity_km: 30,
+            },
+            preset: 'equity',
+        }));
 
         expect(result.current.mode).toBe('active');
         expect(result.current.thresholds.min_download_mbps).toBe(100);
@@ -21,26 +25,11 @@ describe('useScenarioState URL sync', () => {
         expect(result.current.thresholds.clinic_proximity_km).toBe(30);
 
         act(() => {
-            result.current.setThreshold('min_download_mbps', 75);
-            result.current.setThreshold('max_latency_ms', 120);
-        });
-
-        await waitFor(() => {
-            const params = new URLSearchParams(window.location.search);
-            expect(params.get('bd')).toBe('75');
-            expect(params.get('latency')).toBe('120');
-        });
-
-        act(() => {
             result.current.deactivate();
         });
 
-        await waitFor(() => {
-            const params = new URLSearchParams(window.location.search);
-            expect(params.has('scenario')).toBe(false);
-            expect(params.has('bd')).toBe(false);
-            expect(params.has('latency')).toBe(false);
-        });
+        expect(result.current.mode).toBe('off');
         expect(result.current.thresholds).toEqual(BASELINE_THRESHOLDS);
+        expect(result.current.activePreset).toBeNull();
     });
 });

--- a/frontend/src/hooks/useScenarioState.ts
+++ b/frontend/src/hooks/useScenarioState.ts
@@ -1,17 +1,14 @@
 /**
- * useScenarioState – manages scenario thresholds, presets, and URL state
+ * useScenarioState – manages scenario thresholds and presets.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { Season } from '../api/catApi';
 import {
     BASELINE_THRESHOLDS,
     SCENARIO_PRESETS,
     type ScenarioMode,
-    type ScenarioPreset,
     type ScenarioThresholds,
 } from '../types/scenario';
-
-const URL_SYNC_DEBOUNCE_MS = 300;
 
 function thresholdsEqual(a: ScenarioThresholds, b: ScenarioThresholds): boolean {
     return (
@@ -23,45 +20,10 @@ function thresholdsEqual(a: ScenarioThresholds, b: ScenarioThresholds): boolean 
     );
 }
 
-function parseScenarioUrlParams(): {
+export interface ScenarioUrlState {
     active: boolean;
     thresholds: Partial<ScenarioThresholds>;
     preset: string | null;
-} {
-    if (typeof window === 'undefined') {
-        return { active: false, thresholds: {}, preset: null };
-    }
-
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('scenario') !== '1') {
-        return { active: false, thresholds: {}, preset: null };
-    }
-
-    const partial: Partial<ScenarioThresholds> = {};
-    const bd = params.get('bd');
-    if (bd !== null && !isNaN(Number(bd))) partial.min_download_mbps = Number(bd);
-    const up = params.get('up');
-    if (up !== null && !isNaN(Number(up))) partial.min_upload_mbps = Number(up);
-    const latency = params.get('latency');
-    if (latency !== null) {
-        if (latency === 'baseline') {
-            partial.max_latency_ms = null;
-        } else if (!isNaN(Number(latency))) {
-            partial.max_latency_ms = Number(latency);
-        }
-    }
-    const aff = params.get('aff');
-    if (aff !== null && !isNaN(Number(aff))) partial.affordability_burden_pct = Number(aff);
-    const clinic = params.get('clinic');
-    if (clinic !== null && clinic !== 'baseline') {
-        if (!isNaN(Number(clinic))) partial.clinic_proximity_km = Number(clinic);
-    }
-
-    return {
-        active: true,
-        thresholds: partial,
-        preset: params.get('preset'),
-    };
 }
 
 export interface ScenarioState {
@@ -82,74 +44,31 @@ export interface ScenarioState {
     resetToBaseline: () => void;
     /** Set mode directly (e.g. for 'calculating') */
     setMode: (mode: ScenarioMode) => void;
+    /** Restore scenario state from browser navigation. */
+    restoreFromUrl: (state: ScenarioUrlState) => void;
 }
 
-export function useScenarioState(season: Season): ScenarioState {
-    const initialUrl = useMemo(() => parseScenarioUrlParams(), []);
+const EMPTY_SCENARIO_URL_STATE: ScenarioUrlState = {
+    active: false,
+    thresholds: {},
+    preset: null,
+};
 
+export function useScenarioState(
+    _season: Season,
+    initialUrl: ScenarioUrlState = EMPTY_SCENARIO_URL_STATE,
+): ScenarioState {
     const [mode, setMode] = useState<ScenarioMode>(initialUrl.active ? 'active' : 'off');
     const [thresholds, setThresholds] = useState<ScenarioThresholds>(() => ({
         ...BASELINE_THRESHOLDS,
         ...initialUrl.thresholds,
     }));
     const [activePreset, setActivePreset] = useState<string | null>(initialUrl.preset);
-    const urlSyncTimerRef = useRef<number | null>(null);
 
     const isBaselineEquivalent = useMemo(
         () => thresholdsEqual(thresholds, BASELINE_THRESHOLDS),
         [thresholds],
     );
-
-    // ── URL state sync ─────────────────────────────────────────────────
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-
-        if (urlSyncTimerRef.current) {
-            window.clearTimeout(urlSyncTimerRef.current);
-        }
-
-        urlSyncTimerRef.current = window.setTimeout(() => {
-            const params = new URLSearchParams(window.location.search);
-
-            // Remove all scenario params first
-            params.delete('scenario');
-            params.delete('bd');
-            params.delete('up');
-            params.delete('latency');
-            params.delete('aff');
-            params.delete('clinic');
-            params.delete('preset');
-
-            if (mode !== 'off') {
-                params.set('scenario', '1');
-                params.set('bd', String(thresholds.min_download_mbps));
-                params.set('up', String(thresholds.min_upload_mbps));
-                if (thresholds.max_latency_ms !== null) {
-                    params.set('latency', String(thresholds.max_latency_ms));
-                } else {
-                    params.set('latency', 'baseline');
-                }
-                params.set('aff', String(thresholds.affordability_burden_pct));
-                if (thresholds.clinic_proximity_km !== null) {
-                    params.set('clinic', String(thresholds.clinic_proximity_km));
-                } else {
-                    params.set('clinic', 'baseline');
-                }
-                if (activePreset) params.set('preset', activePreset);
-            }
-
-            const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-            window.history.replaceState(null, '', nextUrl);
-            urlSyncTimerRef.current = null;
-        }, URL_SYNC_DEBOUNCE_MS);
-
-        return () => {
-            if (urlSyncTimerRef.current) {
-                window.clearTimeout(urlSyncTimerRef.current);
-                urlSyncTimerRef.current = null;
-            }
-        };
-    }, [mode, thresholds, activePreset]);
 
     // ── Actions ────────────────────────────────────────────────────────
     const activate = useCallback(() => setMode('active'), []);
@@ -186,6 +105,12 @@ export function useScenarioState(season: Season): ScenarioState {
         setActivePreset('baseline');
     }, []);
 
+    const restoreFromUrl = useCallback((state: ScenarioUrlState) => {
+        setMode(state.active ? 'active' : 'off');
+        setThresholds({ ...BASELINE_THRESHOLDS, ...state.thresholds });
+        setActivePreset(state.preset);
+    }, []);
+
     return {
         mode,
         thresholds,
@@ -197,5 +122,6 @@ export function useScenarioState(season: Season): ScenarioState {
         applyPreset,
         resetToBaseline,
         setMode,
+        restoreFromUrl,
     };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,206 @@
+/* TENeT shared design tokens
+ *
+ * The semantic tokens are the preferred API for new UI. The aliases near the
+ * end of :root keep existing screens working while they are migrated.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Neutral surfaces */
+  --color-canvas: #f4f7fa;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f8fafc;
+  --color-surface-muted: #eef2f6;
+  --color-surface-overlay: rgba(255, 255, 255, 0.94);
+
+  /* Text */
+  --color-text: #172033;
+  --color-text-secondary: #536176;
+  --color-text-muted: #64748b;
+  --color-text-inverse: #ffffff;
+  --color-text-link: #1d4ed8;
+
+  /* Borders */
+  --color-border: #d8e0e8;
+  --color-border-strong: #b8c4d0;
+  --color-border-subtle: #e8edf2;
+
+  /* Brand and interaction */
+  --color-primary: #1d4ed8;
+  --color-primary-hover: #1e40af;
+  --color-primary-active: #1e3a8a;
+  --color-primary-subtle: #eff6ff;
+  --color-danger: #b42318;
+  --color-danger-hover: #912018;
+  --color-danger-subtle: #fef3f2;
+
+  /* Operational status colors */
+  --color-status-ready: #15803d;
+  --color-status-ready-subtle: #f0fdf4;
+  --color-status-anchor: #b45309;
+  --color-status-anchor-subtle: #fffbeb;
+  --color-status-gap: #b42318;
+  --color-status-gap-subtle: #fef3f2;
+  --color-status-limited: #6d28d9;
+  --color-status-limited-subtle: #f5f3ff;
+  --color-status-info: #0369a1;
+  --color-status-info-subtle: #f0f9ff;
+  --color-status-unknown: #64748b;
+  --color-status-unknown-subtle: #f1f5f9;
+
+  /* Typography */
+  --font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-xs: 0.75rem;
+  --font-sm: 0.875rem;
+  --font-base: 1rem;
+  --font-lg: 1.125rem;
+  --font-xl: 1.25rem;
+  --font-2xl: 1.5rem;
+
+  /* Spacing (4px base) */
+  --spacing-0: 0;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
+
+  /* Shape */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Elevation */
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.05);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 6px 18px rgba(15, 23, 42, 0.1);
+  --shadow-lg: 0 16px 36px rgba(15, 23, 42, 0.14);
+
+  /* Controls and motion */
+  --control-height-sm: 2rem;
+  --control-height: 2.5rem;
+  --control-height-lg: 2.75rem;
+  --control-icon-size-sm: 2rem;
+  --control-icon-size: 2.5rem;
+  --focus-ring-color: rgba(37, 99, 235, 0.28);
+  --focus-ring: 0 0 0 3px var(--focus-ring-color);
+  --transition-fast: 150ms ease;
+
+  /* Layer order — matches actual overlay stacking across the app */
+  --z-map-controls: 1000;
+  --z-overlay: 1100;
+  --z-toast: 1150;
+  --z-sidebar: 1200;
+  --z-popover: 1500;
+  --z-tooltip: 2500;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  overflow: hidden;
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+p {
+  color: var(--color-text-secondary);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  background: none;
+}
+
+button:not(:disabled) {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+:where(button, input, select, textarea, a):focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: #dbeafe;
+  color: var(--color-text);
+}
+
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-full);
+  background: #c1cad4;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #98a6b6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
-
+import './index.css'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -1,7 +1,8 @@
 /**
  * Scenario Analysis types
  */
-import { Season, TelehealthStatusName } from '../api/catApi';
+import { Season } from '../api/catApi';
+import type { ScenarioTelehealthStatusName } from '../domain/statusPresentation';
 
 /** Scenario lifecycle states */
 export type ScenarioMode = 'off' | 'calculating' | 'active';
@@ -24,8 +25,8 @@ export interface ScenarioRegion {
     name: string;
     lat: number | null;
     lon: number | null;
-    baseline_status: string;
-    scenario_status: string;
+    baseline_status: ScenarioTelehealthStatusName;
+    scenario_status: ScenarioTelehealthStatusName;
     status_delta: StatusDelta;
     baseline_need_score: number;
     scenario_need_score: number;
@@ -75,7 +76,7 @@ export interface ScenarioPreset {
 export const SCENARIO_PRESETS: ScenarioPreset[] = [
     {
         id: 'fcc',
-        label: 'FCC Standard',
+        label: 'Baseline (25/3 Mbps)',
         thresholds: {
             min_download_mbps: 25,
             min_upload_mbps: 3,
@@ -108,22 +109,21 @@ export const BASELINE_THRESHOLDS: ScenarioThresholds = {
     affordability_burden_pct: 2,
 };
 
-/** Status color helper */
-export function getScenarioStatusColor(status: string): string {
-    switch (status) {
-        case 'TELEHEALTH_READY': return '#22c55e';
-        case 'LIMITED_TELEHEALTH': return '#eab308';
-        case 'COMMUNITY_ANCHOR': return '#f97316';
-        case 'CRITICAL_GAP': return '#ef4444';
-        case 'DATA_UNAVAILABLE': return '#6b7280';
-        default: return '#6b7280';
-    }
-}
-
 export function getScenarioDeltaColor(delta: StatusDelta): string {
     switch (delta) {
         case 'improved': return '#22c55e';
         case 'worsened': return '#ef4444';
         case 'unchanged': return '#94a3b8';
+    }
+}
+
+export function getScenarioStatusColor(status: ScenarioTelehealthStatusName | string): string {
+    switch (status) {
+        case 'TELEHEALTH_READY': return '#22c55e';
+        case 'COMMUNITY_ANCHOR': return '#f97316';
+        case 'LIMITED_TELEHEALTH': return '#eab308';
+        case 'CRITICAL_GAP': return '#ef4444';
+        case 'DATA_UNAVAILABLE': return '#6b7280';
+        default: return '#94a3b8';
     }
 }


### PR DESCRIPTION
## Description

Move App-level map mode and URL synchronization into focused ownership so `App.tsx` no longer has to carry loose layer booleans and URL parsing details.

## Scope

- Add typed map mode helpers.
- Add pure URL parse/serialize helpers for selected region, season, active mode, viewport, pinned regions, and scenario state.
- Move URL synchronization into a focused hook.
- Move selected-region marker focus behavior into a focused hook.
- Add unit tests for URL state and map selection helpers.
- Preserve browser back/forward behavior and existing map/sidebar/dashboard behavior.

## Validation

Validated on the final stacked branch:

- `npm run typecheck` passed
- `npm run test` passed: 14 files, 45 tests
- `npm run build` passed with the existing Vite large chunk warning
