### PR TITLE
Polish frontend QA and responsive details

### DIFF
--- a/frontend/ENGINEERING.md
+++ b/frontend/ENGINEERING.md
@@ -1,0 +1,27 @@
+# Frontend engineering boundaries
+
+Keep frontend changes small, behavior-preserving, and easy to review.
+
+## Ownership boundaries
+
+- `src/api` owns HTTP calls and the frontend contracts for backend responses. Components should not call endpoints directly.
+- `src/hooks` owns reusable state, data-loading, and orchestration logic. Hooks should not own presentation.
+- `src/components/ui` owns shared visual primitives; feature folders own feature composition and feature-specific styling.
+- `src/types` owns shared domain types that span more than one feature. Keep local-only props and types beside their consumer.
+
+## Change rules
+
+- Maintain one shared design system in `src/components/ui`. Extend or migrate the existing primitives instead of creating a parallel set.
+- Do not present inferred, partial, modeled, or unavailable data as an observed metric. Labels and supporting text must state the source or limitation clearly enough to avoid misleading users.
+- When a shared primitive exists, use it instead of introducing raw styling for the same UI role. Dynamic values that cannot be represented by an existing class or token may remain inline.
+- Every new abstraction must replace and delete or migrate the old code in the same change. Do not layer a second path over an obsolete one.
+
+## Quality gates
+
+- `npm run typecheck` checks the strict TypeScript project without emitting files.
+- `npm run test` runs the Vitest unit and component tests once.
+- `npm run build` creates the production Vite bundle.
+- `npm run validate` runs typecheck, tests, and build in sequence.
+- End-to-end coverage is available separately through `npm run e2e` because it requires a browser and an application/API environment.
+
+ESLint and Prettier are not currently installed. No lint or format-check script is declared until those tools and an agreed configuration are added; a script that only aliases typechecking would be misleading.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,19 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TENeT - Telehealth Network Tracker</title>
+    <title>TENeT - Telehealth effectiveness and Necessity Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
-      * { box-sizing: border-box; margin: 0; padding: 0; }
-      body {
-        font-family: "Haas", "Haas Groot Disp", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background-color: #ffffff;
-        color: #181d26;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-      }
+      /* Styles moved to src/index.css */
     </style>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,9 +14,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-leaflet-cluster": "^2.1.0",
-        "supercluster": "^8.0.1",
-        "use-supercluster": "^1.2.0"
+        "react-leaflet-cluster": "^2.1.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -25,7 +23,6 @@
         "@types/leaflet": "^1.9.8",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
-        "@types/supercluster": "^7.1.3",
         "@vitejs/plugin-react": "^4.2.1",
         "jsdom": "^24.1.3",
         "typescript": "^5.2.2",
@@ -394,6 +391,380 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -1153,14 +1524,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "license": "MIT",
@@ -1899,13 +2262,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3079,10 +3435,6 @@
         "html2canvas": "^1.0.0-rc.5"
       }
     },
-    "node_modules/kdbush": {
-      "version": "4.1.0",
-      "license": "ISC"
-    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "license": "BSD-2-Clause"
@@ -3934,13 +4286,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
-    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "license": "MIT",
@@ -4084,33 +4429,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/use-deep-compare-effect": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "dequal": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13"
-      }
-    },
-    "node_modules/use-supercluster": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-deep-compare-effect": "^1.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "supercluster": ">=8"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "validate": "npm run typecheck && npm run test && npm run build",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed"
   },
@@ -19,9 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "react-leaflet-cluster": "^2.1.0",
-    "supercluster": "^8.0.1",
-    "use-supercluster": "^1.2.0"
+    "react-leaflet-cluster": "^2.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
@@ -30,7 +29,6 @@
     "@types/leaflet": "^1.9.8",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@types/supercluster": "^7.1.3",
     "@vitejs/plugin-react": "^4.2.1",
     "jsdom": "^24.1.3",
     "typescript": "^5.2.2",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,113 @@
+.tenet-app {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.map-workspace {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  height: 100vh;
+  height: 100dvh;
+}
+
+.map-state-message {
+  position: absolute;
+  z-index: var(--z-toast);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-3) var(--spacing-5);
+  box-shadow: var(--shadow-md);
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  font-weight: 600;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.map-state-message--loading {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.map-state-message--error,
+.map-state-message--notice {
+  top: 92px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.map-state-message--error {
+  border-color: #fecaca;
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+}
+
+.map-state-message--notice {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  border-color: #fde68a;
+  background: var(--color-status-anchor-subtle);
+  color: #92400e;
+}
+
+.scenario-panel-shell {
+  position: absolute;
+  top: 90px;
+  right: var(--spacing-4);
+  z-index: var(--z-overlay);
+}
+
+@media (max-width: 1200px) {
+  .scenario-panel-shell {
+    top: 158px;
+  }
+
+  .map-state-message--error,
+  .map-state-message--notice {
+    top: 160px;
+  }
+}
+
+@media (max-width: 900px) {
+  .scenario-panel-shell #scenario-panel {
+    max-height: calc(54vh - 174px) !important;
+    max-height: calc(54dvh - 174px) !important;
+  }
+
+  .map-workspace .leaflet-bottom.leaflet-right {
+    bottom: calc(46vh + 60px);
+    bottom: calc(46dvh + 60px);
+  }
+}
+
+@media (max-width: 700px) {
+  .scenario-panel-shell {
+    top: 212px;
+    right: var(--spacing-3);
+    left: 60px;
+  }
+
+  .scenario-panel-shell #scenario-panel {
+    width: 100% !important;
+    max-height: max(140px, calc(54vh - 228px)) !important;
+    max-height: max(140px, calc(54dvh - 228px)) !important;
+  }
+
+  .map-workspace .leaflet-top.leaflet-left {
+    top: 206px;
+    left: var(--spacing-3);
+  }
+
+  .map-state-message--error,
+  .map-state-message--notice {
+    top: 212px;
+    max-width: calc(100% - var(--spacing-6));
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import {
 import { useMapSelection } from './hooks/useMapSelection';
 import { useMapUrlSync } from './hooks/useMapUrlSync';
 import './App.css';
+import './components/map/MapMarkers.css';
 
 delete (L.Icon.Default.prototype as L.Icon.Default & { _getIconUrl?: unknown })._getIconUrl;
 L.Icon.Default.mergeOptions({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,188 +1,87 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { MapContainer, TileLayer, useMap, useMapEvents } from 'react-leaflet';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { MapContainer, TileLayer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
-import { fetchRegions, CATRegion, RegionSummary, Season, AllTelehealthStatusResponse } from './api/catApi';
-import RegionMarker from './components/RegionMarker';
+import { fetchRegions, CATRegion, Season, AllTelehealthStatusResponse } from './api/catApi';
+import { errorMessage, isAbortError } from './api/http';
 import RegionClusters from './components/RegionClusters';
 import Legend from './components/Legend';
-import SeasonSelector from './components/SeasonSelector';
 import DataCoveragePanel from './components/DataCoveragePanel';
 import PerformanceLayer from './components/PerformanceLayer';
 import AffordabilityLayer, { AffordabilityLegend } from './components/AffordabilityLayer';
 import Sidebar from './components/sidebar/Sidebar';
 import ResearchComparisonPanel from './components/ResearchComparisonPanel';
 import ScenarioPanel from './components/scenario/ScenarioPanel';
-import ScenarioLayer, { ScenarioSidebarCard, ScenarioLegend } from './components/scenario/ScenarioLayer';
+import ScenarioLayer, { ScenarioLegend } from './components/scenario/ScenarioLayer';
 import { usePinnedRegions } from './hooks/usePinnedRegions';
 import { useRegionSummary } from './hooks/useRegionSummary';
 import { useScenarioState } from './hooks/useScenarioState';
 import { useScenarioPreview } from './hooks/useScenarioPreview';
+import Dashboard, { type InsightsMapLayer } from './components/dashboard/Dashboard';
+import IconButton from './components/ui/IconButton';
+import MapToolbar from './components/layout/MapToolbar';
+import LayerSwitcher from './components/layout/LayerSwitcher';
+import {
+  ComparisonMapController,
+  MapViewportController,
+  SelectionController,
+} from './components/map/MapControllers';
+import {
+  baseLayerForMapMode,
+  CAT_MAP_MODE,
+  mapModeFromLayer,
+  type BaseMapLayer,
+  type MapMode,
+} from './domain/mapMode';
+import {
+  ALASKA_BOUNDS,
+  parseMapUrlState,
+  type ParsedMapUrlState,
+} from './domain/mapUrlState';
+import { useMapSelection } from './hooks/useMapSelection';
+import { useMapUrlSync } from './hooks/useMapUrlSync';
+import './App.css';
 
-delete (L.Icon.Default.prototype as any)._getIconUrl;
+delete (L.Icon.Default.prototype as L.Icon.Default & { _getIconUrl?: unknown })._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
   iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
 });
 
-// Alaska-specific coordinates. This framing keeps Alaska in focus and avoids
-// opening with too much far-west Russia in the visible map area.
-const ALASKA_CENTER: [number, number] = [64.2, -152.0];
-const ALASKA_ZOOM = 4;
-const STALE_DEFAULT_CENTERS: Array<[number, number]> = [
-  [62.9752, -154.95117],
-  [62.35, -146.75],
-  [62.2, -141.8],
-  [62.2, -170.8],
-  [62.35, -136.5],
-];
-
-const ALASKA_BOUNDS: [[number, number], [number, number]] = [
-  [51.0, -179.5],
-  [72.0, -129.0]
-];
-
-type ActiveLayer = 'cat' | 'affordability' | 'gap';
-
-function parseInitialUrlState() {
-  if (typeof window === 'undefined') {
-    return {
-      region: null,
-      season: 'year_round' as Season,
-      layer: 'cat' as ActiveLayer,
-      pins: [] as string[],
-      center: ALASKA_CENTER,
-      zoom: ALASKA_ZOOM,
-    };
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  const seasonParam = params.get('season') as Season | null;
-  const layerParam = params.get('layer') as ActiveLayer | null;
-  const latParam = params.get('lat');
-  const lngParam = params.get('lng');
-  const zoomParam = params.get('zoom');
-  const lat = latParam === null ? NaN : Number(latParam);
-  const lng = lngParam === null ? NaN : Number(lngParam);
-  const zoom = zoomParam === null ? NaN : Number(zoomParam);
-  const hasSafeCenter = (
-    Number.isFinite(lat)
-    && Number.isFinite(lng)
-    && lat >= ALASKA_BOUNDS[0][0]
-    && lat <= ALASKA_BOUNDS[1][0]
-    && lng >= ALASKA_BOUNDS[0][1]
-    && lng <= ALASKA_BOUNDS[1][1]
-  );
-  const hasSafeZoom = Number.isFinite(zoom) && zoom >= 4 && zoom <= 18;
-  const hasStaleDefaultViewport = (
-    hasSafeCenter
-    && hasSafeZoom
-    && STALE_DEFAULT_CENTERS.some(([staleLat, staleLng]) => (
-      Math.abs(lat - staleLat) < 0.0001
-      && Math.abs(lng - staleLng) < 0.0001
-    ))
-    && zoom === ALASKA_ZOOM
-  );
-
-  return {
-    region: params.get('region'),
-    season: seasonParam && ['summer', 'winter', 'year_round'].includes(seasonParam)
-      ? seasonParam
-      : 'year_round',
-    layer: layerParam && ['cat', 'affordability', 'gap'].includes(layerParam)
-      ? layerParam
-      : 'cat',
-    pins: (params.get('pins') || '').split(',').map(pin => pin.trim()).filter(Boolean).slice(0, 3),
-    center: hasSafeCenter && !hasStaleDefaultViewport ? [lat, lng] as [number, number] : ALASKA_CENTER,
-    zoom: hasSafeZoom && !hasStaleDefaultViewport ? zoom : ALASKA_ZOOM,
-  };
-}
-
-interface SelectionControllerProps {
-  selectedRegionCode: string | null;
-  regionSummaries: RegionSummary[];
-  markerRefs: React.MutableRefObject<Record<string, L.Marker | L.CircleMarker>>;
-}
-
-interface MapUrlControllerProps {
-  onViewportChange: (center: [number, number], zoom: number) => void;
-}
-
-interface ComparisonMapControllerProps {
-  active: boolean;
-}
-
-function MapUrlController({ onViewportChange }: MapUrlControllerProps) {
-  const map = useMapEvents({
-    moveend: () => {
-      const center = map.getCenter();
-      onViewportChange([Number(center.lat.toFixed(5)), Number(center.lng.toFixed(5))], map.getZoom());
-    },
-    zoomend: () => {
-      const center = map.getCenter();
-      onViewportChange([Number(center.lat.toFixed(5)), Number(center.lng.toFixed(5))], map.getZoom());
-    },
-  });
-
-  return null;
-}
-
-function ComparisonMapController({ active }: ComparisonMapControllerProps) {
-  const map = useMap();
-
-  useEffect(() => {
-    if (!active) return;
-    map.closePopup();
-    map.panBy([0, 96], { animate: true, duration: 0.25 });
-  }, [active, map]);
-
-  return null;
-}
-
-function SelectionController({
-  selectedRegionCode,
-  regionSummaries,
-  markerRefs,
-}: SelectionControllerProps) {
-  const map = useMap();
-
-  useEffect(() => {
-    if (!selectedRegionCode) return;
-
-    const selected = regionSummaries.find(region => region.region_code === selectedRegionCode);
-    if (!selected || selected.lat === null || selected.lon === null) return;
-
-    map.flyTo([selected.lat, selected.lon], Math.max(map.getZoom(), 8), { duration: 1.1 });
-
-    window.setTimeout(() => {
-      markerRefs.current[selectedRegionCode]?.openPopup();
-    }, 350);
-  }, [map, markerRefs, regionSummaries, selectedRegionCode]);
-
-  return null;
-}
+type ActiveView = 'map' | 'dashboard';
 
 function App() {
-  const initialUrlState = useMemo(() => parseInitialUrlState(), []);
+  const initialUrlState = useMemo(
+    () => parseMapUrlState(typeof window === 'undefined' ? '' : window.location.search),
+    [],
+  );
+  const [activeView, setActiveView] = useState<ActiveView>('map');
   const [regions, setRegions] = useState<CATRegion[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [season, setSeason] = useState<Season>(initialUrlState.season);
-  const [performanceLayerVisible, setPerformanceLayerVisible] = useState(initialUrlState.layer === 'gap');
-  const [affordabilityLayerVisible, setAffordabilityLayerVisible] = useState(initialUrlState.layer === 'affordability');
-  const [gapModeActive, setGapModeActive] = useState(initialUrlState.layer === 'gap');
+  const [mapMode, setMapMode] = useState<MapMode>(initialUrlState.mapMode);
   const [affordabilitySummary, setAffordabilitySummary] = useState<AllTelehealthStatusResponse['summary'] | undefined>(undefined);
-  const [selectedRegionCode, setSelectedRegionCode] = useState<string | null>(initialUrlState.region);
-  const [detailsFocusKey, setDetailsFocusKey] = useState(0);
   const [visibleRegionCodes, setVisibleRegionCodes] = useState<string[] | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number]>(initialUrlState.center);
   const [mapZoom, setMapZoom] = useState(initialUrlState.zoom);
   const [urlNotice, setUrlNotice] = useState<string | null>(null);
-  const markerRefs = useRef<Record<string, L.Marker | L.CircleMarker>>({});
+  const {
+    selectedRegionCode,
+    setSelectedRegionCode,
+    detailsFocusKey,
+    markerRefs,
+    registerMarker,
+    selectRegion: handleSelectRegion,
+    viewRegionDetails: handleViewRegionDetails,
+  } = useMapSelection(initialUrlState.selectedRegionCode);
 
   // ── Scenario Mode ──────────────────────────────────────────────────
-  const scenarioState = useScenarioState(season);
+  const scenarioState = useScenarioState(season, {
+    active: initialUrlState.mapMode.type === 'scenario',
+    ...initialUrlState.scenario,
+  });
   const scenarioPreview = useScenarioPreview(
     scenarioState.mode,
     scenarioState.thresholds,
@@ -190,53 +89,20 @@ function App() {
     null,
     scenarioState.setMode,
   );
-  const scenarioActive = scenarioState.mode !== 'off';
+  const scenarioActive = mapMode.type === 'scenario';
   const {
     pinnedRegionCodes,
     isPinned,
     togglePinned,
     replacePinned,
     maxPinnedRegions,
-  } = usePinnedRegions(initialUrlState.pins);
+  } = usePinnedRegions(initialUrlState.pinnedRegionCodes);
   const {
     regions: regionSummaries,
     loading: summaryLoading,
     error: summaryError,
   } = useRegionSummary();
-
-  const registerMarker = useCallback((regionCode: string, marker: L.Marker | null) => {
-    if (marker) {
-      markerRefs.current[regionCode] = marker;
-    } else {
-      delete markerRefs.current[regionCode];
-    }
-  }, []);
-
-  const registerAffordabilityMarker = useCallback((regionCode: string, marker: L.CircleMarker | null) => {
-    if (marker) {
-      markerRefs.current[regionCode] = marker;
-    } else {
-      delete markerRefs.current[regionCode];
-    }
-  }, []);
-
-  const registerScenarioMarker = useCallback((regionCode: string, marker: L.Marker | null) => {
-    if (marker) {
-      markerRefs.current[regionCode] = marker;
-    } else {
-      delete markerRefs.current[regionCode];
-    }
-  }, []);
-
-  const handleSelectRegion = useCallback((regionCode: string) => {
-    setSelectedRegionCode(regionCode);
-  }, []);
-
-  const handleViewRegionDetails = useCallback((regionCode: string) => {
-    setSelectedRegionCode(regionCode);
-    setDetailsFocusKey(key => key + 1);
-    markerRefs.current[regionCode]?.closePopup();
-  }, []);
+  const restoreScenarioFromUrl = scenarioState.restoreFromUrl;
 
   const handleVisibleRegionsChange = useCallback((regionCodes: string[]) => {
     setVisibleRegionCodes(regionCodes);
@@ -256,11 +122,7 @@ function App() {
     if (!visibleRegionCodeSet) return regions;
     return regions.filter(region => visibleRegionCodeSet.has(region.region_code));
   }, [regions, visibleRegionCodeSet]);
-  const activeSidebarLayer = gapModeActive
-    ? 'gap'
-    : affordabilityLayerVisible
-      ? 'affordability'
-      : 'cat';
+  const activeSidebarLayer = baseLayerForMapMode(mapMode);
 
   useEffect(() => {
     if (summaryLoading || regionSummaries.length === 0) return;
@@ -291,55 +153,53 @@ function App() {
     return () => window.clearTimeout(timer);
   }, [urlNotice]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+  const restoreUrlState = useCallback((state: ParsedMapUrlState) => {
+    setSelectedRegionCode(state.selectedRegionCode);
+    setSeason(state.season);
+    setMapMode(state.mapMode);
+    replacePinned(state.pinnedRegionCodes);
+    setMapCenter(state.center);
+    setMapZoom(state.zoom);
+    restoreScenarioFromUrl({
+      active: state.mapMode.type === 'scenario',
+      ...state.scenario,
+    });
+  }, [replacePinned, restoreScenarioFromUrl, setSelectedRegionCode]);
 
-    const params = new URLSearchParams(window.location.search);
-    params.delete('region');
-    params.delete('layer');
-    params.delete('season');
-    params.delete('pins');
-    params.delete('lat');
-    params.delete('lng');
-    params.delete('zoom');
+  const serializedUrlState = useMemo(() => ({
+    selectedRegionCode,
+    season,
+    mapMode,
+    pinnedRegionCodes,
+    center: mapCenter,
+    zoom: mapZoom,
+    scenario: {
+      thresholds: scenarioState.thresholds,
+      preset: scenarioState.activePreset,
+    },
+  }), [
+    mapCenter,
+    mapMode,
+    mapZoom,
+    pinnedRegionCodes,
+    scenarioState.activePreset,
+    scenarioState.thresholds,
+    season,
+    selectedRegionCode,
+  ]);
+  useMapUrlSync(serializedUrlState, restoreUrlState);
 
-    if (selectedRegionCode) params.set('region', selectedRegionCode);
-    if (activeSidebarLayer !== 'cat') params.set('layer', activeSidebarLayer);
-    if (season !== 'year_round') params.set('season', season);
-    if (pinnedRegionCodes.length) params.set('pins', pinnedRegionCodes.join(','));
-    if (mapCenter[0] !== ALASKA_CENTER[0]) params.set('lat', mapCenter[0].toFixed(5));
-    if (mapCenter[1] !== ALASKA_CENTER[1]) params.set('lng', mapCenter[1].toFixed(5));
-    if (mapZoom !== ALASKA_ZOOM) params.set('zoom', String(mapZoom));
-
-    const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-    window.history.replaceState(null, '', nextUrl);
-  }, [activeSidebarLayer, mapCenter, mapZoom, pinnedRegionCodes, season, selectedRegionCode]);
-
-  const toggleAffordabilityLayer = () => {
-    if (!affordabilityLayerVisible) {
-      setGapModeActive(false);
-      setPerformanceLayerVisible(false);
-    }
-    setAffordabilityLayerVisible(!affordabilityLayerVisible);
-  };
-
-  const toggleGapMode = () => {
-    if (!gapModeActive) {
-      setAffordabilityLayerVisible(false);
-      setPerformanceLayerVisible(true);
-    } else {
-      setPerformanceLayerVisible(false);
-    }
-    setGapModeActive(!gapModeActive);
+  const handleLayerChange = (layer: BaseMapLayer) => {
+    if (scenarioActive) scenarioState.deactivate();
+    setMapMode(mapModeFromLayer(layer));
   };
 
   const toggleScenarioMode = () => {
-    if (scenarioState.mode === 'off') {
-      setGapModeActive(false);
-      setPerformanceLayerVisible(false);
-      setAffordabilityLayerVisible(false);
+    if (!scenarioActive) {
+      setMapMode({ type: 'scenario' });
       scenarioState.activate();
     } else {
+      setMapMode(CAT_MAP_MODE);
       scenarioState.deactivate();
     }
   };
@@ -351,32 +211,60 @@ function App() {
   }, [scenarioActive, scenarioPreview.data, selectedRegionCode]);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     async function loadData() {
       try {
         setLoading(true);
-        const data = await fetchRegions(season);
-        setRegions(data);
         setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load data');
-        console.error('Error loading regions:', err);
+        setRegions([]);
+        const data = await fetchRegions(season, undefined, controller.signal);
+        if (controller.signal.aborted) return;
+        setRegions(data);
+      } catch (caught: unknown) {
+        if (isAbortError(caught)) return;
+        setError(errorMessage(caught, 'Failed to load data'));
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     }
     loadData();
+
+    return () => {
+      controller.abort();
+    };
   }, [season]);
 
-  const getSeasonInfo = () => {
-    switch (season) {
-      case 'summer': return { label: 'Summer', note: 'All transport modes' };
-      case 'winter': return { label: 'Winter', note: 'Limited routes' };
-      case 'year_round': return { label: 'Year-Round', note: 'Average' };
-    }
+  const handleInsightsViewMap = (layer: InsightsMapLayer) => {
+    handleLayerChange(layer);
+    setActiveView('map');
   };
 
+  const handleInsightsViewRegion = (regionCode: string) => {
+    handleLayerChange('cat');
+    handleViewRegionDetails(regionCode);
+    setActiveView('map');
+  };
+
+  const closeInsights = () => {
+    setActiveView('map');
+    window.requestAnimationFrame(() => {
+      document.getElementById('insights-toolbar-button')?.focus();
+    });
+  };
+
+  if (activeView === 'dashboard') {
+    return (
+      <Dashboard
+        onClose={closeInsights}
+        onViewMap={handleInsightsViewMap}
+        onViewRegion={handleInsightsViewRegion}
+      />
+    );
+  }
+
   return (
-    <div style={{ height: '100vh', width: '100%', margin: 0, padding: 0, display: 'flex', overflow: 'hidden' }}>
+    <div className="tenet-app">
       <Sidebar
         regions={regionSummaries}
         loading={summaryLoading}
@@ -394,7 +282,7 @@ function App() {
         onVisibleRegionsChange={handleVisibleRegionsChange}
       />
 
-      <div style={{ position: 'relative', flex: 1, minWidth: 0, height: '100vh' }}>
+      <main className="map-workspace">
         <MapContainer
           center={mapCenter}
           zoom={mapZoom}
@@ -411,7 +299,7 @@ function App() {
             updateWhenZooming={false}
           />
 
-          {!gapModeActive && !affordabilityLayerVisible && !scenarioActive && (
+          {mapMode.type === 'cat' && (
             <RegionClusters
               regions={mapRegions}
               season={season}
@@ -428,318 +316,118 @@ function App() {
             markerRefs={markerRefs}
           />
 
-          <MapUrlController onViewportChange={handleViewportChange} />
+          <MapViewportController
+            center={mapCenter}
+            zoom={mapZoom}
+            onViewportChange={handleViewportChange}
+          />
 
           <ComparisonMapController active={pinnedRegionCodes.length >= 2} />
 
 
 
           <PerformanceLayer
-            visible={performanceLayerVisible}
-            onToggle={() => setPerformanceLayerVisible(false)}
-            onModeChange={setGapModeActive}
+            visible={mapMode.type === 'gapHunter'}
+            onToggle={() => setMapMode(CAT_MAP_MODE)}
           />
 
-          {!scenarioActive && (
-            <AffordabilityLayer
-              visible={affordabilityLayerVisible}
-              selectedRegionCode={selectedRegionCode}
-              onSelect={handleSelectRegion}
-              onViewDetails={handleViewRegionDetails}
-              onMarkerReady={registerAffordabilityMarker}
-              onDataLoad={setAffordabilitySummary}
-            />
-          )}
-
-          <ScenarioLayer
-            data={scenarioPreview.data}
-            active={scenarioActive && !gapModeActive}
+          <AffordabilityLayer
+            visible={mapMode.type === 'telehealthAccess'}
             selectedRegionCode={selectedRegionCode}
             onSelect={handleSelectRegion}
             onViewDetails={handleViewRegionDetails}
-            onMarkerReady={registerScenarioMarker}
+            onMarkerReady={registerMarker}
+            onDataLoad={setAffordabilitySummary}
+          />
+
+          <ScenarioLayer
+            data={scenarioPreview.data}
+            active={scenarioActive}
+            selectedRegionCode={selectedRegionCode}
+            onSelect={handleSelectRegion}
+            onViewDetails={handleViewRegionDetails}
+            onMarkerReady={registerMarker}
           />
         </MapContainer>
 
-      <ResearchComparisonPanel
-        pinnedRegionCodes={pinnedRegionCodes}
-        season={season}
-        onSelectRegion={handleSelectRegion}
-      />
+        <ResearchComparisonPanel
+          pinnedRegionCodes={pinnedRegionCodes}
+          season={season}
+          onSelectRegion={handleSelectRegion}
+        />
 
       {loading && (
-        <div style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          zIndex: 1000,
-          background: '#ffffff',
-          padding: '24px 48px',
-          borderRadius: '10px',
-          border: '1px solid #dddddd',
-          fontSize: '14px',
-          fontWeight: '500',
-          color: '#181d26'
-        }}>
+        <div className="map-state-message map-state-message--loading" role="status">
           Loading community data...
         </div>
       )}
 
       {error && (
-        <div style={{
-          position: 'absolute',
-          top: '40px',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          zIndex: 1000,
-          background: '#ffffff',
-          color: '#aa2d00',
-          padding: '12px 24px',
-          borderRadius: '6px',
-          border: '1px solid #dddddd',
-          fontSize: '14px',
-          fontWeight: '500'
-        }}>
+        <div className="map-state-message map-state-message--error" role="alert">
           {error}
         </div>
       )}
 
       {urlNotice && (
-        <div style={{
-          position: 'absolute',
-          top: '128px',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          zIndex: 1000,
-          background: 'rgba(255, 251, 235, 0.96)',
-          color: '#92400e',
-          padding: '10px 18px',
-          borderRadius: '8px',
-          fontSize: '13px',
-          fontWeight: '600',
-          border: '1px solid #f59e0b',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '12px'
-        }}>
+        <div className="map-state-message map-state-message--notice" role="status">
           <span>{urlNotice}</span>
-          <button
-            type="button"
+          <IconButton
             aria-label="Dismiss notice"
+            icon="×"
+            size="small"
             onClick={() => setUrlNotice(null)}
-            style={{
-              appearance: 'none',
-              border: 0,
-              background: 'transparent',
-              color: '#92400e',
-              cursor: 'pointer',
-              fontSize: '16px',
-              fontWeight: 700,
-              lineHeight: 1,
-              padding: 0
-            }}
-          >
-            ×
-          </button>
+            style={{ color: 'inherit' }}
+          />
         </div>
       )}
 
-      {!loading && !scenarioActive && (
-        <div style={{
-          position: 'absolute',
-          top: '20px',
-          left: '60px',
-          zIndex: 1000,
-          display: 'flex',
-          gap: '10px'
-        }}>
-          {/* Airtable Secondary Button Style */}
-          <button
-            onClick={toggleGapMode}
-            type="button"
-            aria-label="Open Gap Hunter layer"
-            style={{
-              backgroundColor: '#ffffff',
-              color: '#181d26',
-              border: '1px solid #dddddd',
-              borderRadius: '12px',
-              padding: '10px 16px',
-              fontSize: '14px',
-              fontWeight: '500',
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-              transition: 'all 0.15s ease'
-            }}
-          >
-            Gap Hunter
-          </button>
+      <MapToolbar
+        season={season}
+        scenarioActive={scenarioActive}
+        scenarioDisabled={loading}
+        onSeasonChange={setSeason}
+        onOpenInsights={() => setActiveView('dashboard')}
+        onToggleScenario={toggleScenarioMode}
+      />
 
-          <button
-            onClick={toggleAffordabilityLayer}
-            type="button"
-            aria-label="Open affordability layer"
-            style={{
-              backgroundColor: '#ffffff',
-              color: '#181d26',
-              border: '1px solid #dddddd',
-              borderRadius: '12px',
-              padding: '10px 16px',
-              fontSize: '14px',
-              fontWeight: '500',
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-              transition: 'all 0.15s ease'
-            }}
-          >
-            Affordability
-          </button>
-        </div>
+      {!loading && (
+        <LayerSwitcher
+          activeLayer={activeSidebarLayer}
+          scenarioActive={scenarioActive}
+          onChange={handleLayerChange}
+        />
       )}
 
-      {/* RIGHT SIDE: Title + Season Dropdown */}
-      <div style={{
-        position: 'absolute',
-        top: '20px',
-        right: '20px',
-        zIndex: 1001,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-end',
-        gap: '12px'
-      }}>
-        {/* Title Card with Dropdown (Airtable flat card style) */}
-        <div style={{
-          background: '#ffffff',
-          padding: '12px 16px',
-          borderRadius: '10px',
-          border: '1px solid #dddddd',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '16px'
-        }}>
-          <div>
-            <div style={{
-              fontSize: '16px',
-              fontWeight: '500',
-              color: '#181d26',
-              letterSpacing: '0'
-            }}>
-              TENeT
-            </div>
-            <div style={{
-              fontSize: '12px',
-              color: '#41454d'
-            }}>
-              Telehealth Network Tracker
-            </div>
-          </div>
-          <div style={{
-            width: '1px',
-            height: '32px',
-            backgroundColor: '#dddddd',
-            margin: '0 4px'
-          }}></div>
-          <div>
-            <SeasonSelector season={season} onChange={setSeason} />
-          </div>
-        </div>
-
-        {/* Scenario Mode Toggle */}
-        {!loading && (
-          <button
-            onClick={toggleScenarioMode}
-            id="scenario-toggle-button"
-            data-testid="scenario-button"
-            type="button"
-            aria-label={scenarioActive ? 'Exit scenario mode' : 'Open what-if scenario mode'}
-            style={{
-              background: scenarioActive
-                ? 'linear-gradient(135deg, #6D28D9 0%, #5B21B6 100%)'
-                : 'rgba(255, 255, 255, 0.92)',
-              backdropFilter: 'blur(12px)',
-              WebkitBackdropFilter: 'blur(12px)',
-              color: scenarioActive ? 'white' : '#6D28D9',
-              border: scenarioActive ? 'none' : '1px solid rgba(124, 58, 237, 0.25)',
-              borderRadius: '10px',
-              padding: '10px 18px',
-              fontSize: '13px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              boxShadow: scenarioActive
-                ? '0 4px 16px rgba(124, 58, 237, 0.35)'
-                : '0 4px 16px rgba(31, 38, 135, 0.1)',
-              transition: 'all 0.2s',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              alignSelf: 'flex-end',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-1px)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-            }}
-          >
-            <span style={{ fontSize: '14px' }}>🔬</span>
-            {scenarioActive ? '✕ Exit Scenarios' : 'What-If Scenarios'}
-          </button>
-        )}
-
-        {/* Scenario Panel */}
-        {scenarioActive && (
+      {scenarioActive && (
+        <div className="scenario-panel-shell">
           <ScenarioPanel
             scenario={scenarioState}
             preview={scenarioPreview}
-            gapModeActive={gapModeActive}
+            onClose={toggleScenarioMode}
           />
-        )}
-
-        {/* Close Affordability button */}
-        {affordabilityLayerVisible && (
-          <button
-            onClick={() => setAffordabilityLayerVisible(false)}
-            type="button"
-            aria-label="Close affordability layer"
-            style={{
-              background: 'rgba(55, 65, 81, 0.9)',
-              backdropFilter: 'blur(10px)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              padding: '10px 16px',
-              fontSize: '13px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
-            }}
-          >
-            ✕ Close Affordability
-          </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* BOTTOM LEFT: Data Coverage Panel */}
-      {!loading && !gapModeActive && !affordabilityLayerVisible && !scenarioActive && (
-        <DataCoveragePanel totalRegions={regions.length} />
+      {!loading && mapMode.type === 'cat' && (
+        <DataCoveragePanel />
       )}
 
       {/* BOTTOM RIGHT: Legend Panel */}
-      {!loading && !gapModeActive && !affordabilityLayerVisible && !scenarioActive && (
+      {!loading && mapMode.type === 'cat' && (
         <Legend totalRegions={regions.length} />
       )}
 
       {/* Affordability Legend */}
-      {!loading && affordabilityLayerVisible && !scenarioActive && (
+      {!loading && mapMode.type === 'telehealthAccess' && (
         <AffordabilityLegend summary={affordabilitySummary} />
       )}
 
       {/* Scenario Legend */}
-      {!loading && scenarioActive && !gapModeActive && (
+      {!loading && scenarioActive && (
         <ScenarioLegend />
       )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -43,7 +43,7 @@ export interface RegionSummary {
     lat: number | null;
     lon: number | null;
     cat_tier: number | null;
-    telehealth_status: TelehealthStatusName | string;
+    telehealth_status: TelehealthStatusName;
     desert_score: number | null;
     affordability_status: AffordabilityStatusName | string;
     data_confidence: 'high' | 'medium' | 'low' | 'missing' | 'unknown' | string;
@@ -354,8 +354,8 @@ export async function fetchBroadbandCoverage(filters?: {
 /**
  * Fetch data gaps summary for dashboard display
  */
-export async function fetchDataGapsSummary(): Promise<DataGapsSummary> {
-    const response = await fetch(`${API_BASE}/data-gaps`);
+export async function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
+    const response = await fetch(`${API_BASE}/data-gaps`, { signal });
     if (!response.ok) {
         throw new Error(`Failed to fetch data gaps: ${response.statusText}`);
     }

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -2,6 +2,13 @@
  * API client for CAT (Community Access Tier) data
  */
 
+import { CAT_TIER_PRESENTATION, getDesertScorePresentation, type CatTier } from '../domain/metrics';
+import type { TelehealthStatusName } from '../domain/statusPresentation';
+import type { Feature, FeatureCollection, MultiPolygon } from 'geojson';
+import { ApiError, fetchJson, withQuery } from './http';
+
+export type { TelehealthStatusName } from '../domain/statusPresentation';
+
 export const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
 
 // Season type for user-selected seasonal scenario
@@ -13,7 +20,7 @@ export type PerformanceFilterType = 'combined' | 'affordability' | 'latency';
 export interface CATRegion {
     region_code: string;
     region_name: string;
-    tier_level: number;
+    tier_level: CatTier;
     description: string;
     centroid_lat: number | null;
     centroid_lon: number | null;
@@ -28,13 +35,18 @@ export interface RegionsResponse {
     total: number;
 }
 
-export type TelehealthStatusName =
-    | 'TELEHEALTH_READY'
-    | 'COMMUNITY_ANCHOR'
-    | 'CRITICAL_GAP'
-    | 'DATA_UNAVAILABLE';
+export interface BoundaryProperties {
+    CommunityName: string;
+    EconomicRegion: string;
+    FIPS: string;
+    Census_Area: 'Y' | null;
+}
+
+export type BoundaryFeature = Feature<MultiPolygon, BoundaryProperties>;
+export type BoundaryCollection = FeatureCollection<MultiPolygon, BoundaryProperties>;
 
 export type AffordabilityStatusName = 'affordable' | 'unaffordable' | 'unknown';
+export type RegionDataConfidence = 'high' | 'medium' | 'low' | 'missing' | 'unknown';
 
 export interface RegionSummary {
     id: number;
@@ -42,11 +54,11 @@ export interface RegionSummary {
     name: string;
     lat: number | null;
     lon: number | null;
-    cat_tier: number | null;
+    cat_tier: CatTier | null;
     telehealth_status: TelehealthStatusName;
     desert_score: number | null;
-    affordability_status: AffordabilityStatusName | string;
-    data_confidence: 'high' | 'medium' | 'low' | 'missing' | 'unknown' | string;
+    affordability_status: AffordabilityStatusName;
+    data_confidence: RegionDataConfidence;
     has_data_gap: boolean;
     region: string | null;
 }
@@ -59,8 +71,8 @@ export interface RegionSummaryResponse {
 export interface RegionSearchParams {
     q?: string;
     name?: string;
-    tier?: number | string | null;
-    status?: string | null;
+    tier?: CatTier | `${CatTier}` | null;
+    status?: TelehealthStatusName | null;
     desert_min?: number | string | null;
     desert_max?: number | string | null;
     data_gap?: boolean | string | null;
@@ -93,7 +105,7 @@ export interface SeasonScenario {
 export interface TelehealthPriorityResponse {
     region_code: string;
     region_name: string;
-    cat_tier: number;
+    cat_tier: CatTier;
     necessity_score: number;
     connectivity_score: number;
     combined_priority: number;
@@ -125,65 +137,55 @@ export interface TelehealthPriorityResponse {
 /**
  * Fetch all CAT regions with optional season adjustment
  */
-export async function fetchRegions(season: Season = 'year_round', tier?: number): Promise<CATRegion[]> {
-    let url = `${API_BASE}/regions?season=${season}`;
-    if (tier) {
-        url += `&tier=${tier}`;
-    }
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch regions: ${response.statusText}`);
-    }
-
-    const data: RegionsResponse = await response.json();
+export async function fetchRegions(
+    season: Season = 'year_round',
+    tier?: number,
+    signal?: AbortSignal,
+): Promise<CATRegion[]> {
+    const data = await fetchJson<RegionsResponse>(
+        withQuery(`${API_BASE}/regions`, { season, tier: tier || undefined }),
+        { signal },
+        'Failed to fetch regions',
+    );
     return data.regions;
+}
+
+export function fetchBoundaries(signal?: AbortSignal): Promise<BoundaryCollection> {
+    return fetchJson(`${API_BASE}/boundaries`, { signal }, 'Failed to load boundaries');
 }
 
 /**
  * Fetch lightweight community summaries for sidebar navigation.
  */
-export async function fetchRegionSummary(): Promise<RegionSummary[]> {
-    const response = await fetch(`${API_BASE}/regions/summary`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch region summary: ${response.statusText}`);
-    }
-
-    const data: RegionSummaryResponse = await response.json();
+export async function fetchRegionSummary(signal?: AbortSignal): Promise<RegionSummary[]> {
+    const data = await fetchJson<RegionSummaryResponse>(
+        `${API_BASE}/regions/summary`,
+        { signal },
+        'Failed to fetch region summary',
+    );
     return data.regions;
 }
 
 /**
  * Search lightweight community summaries for sidebar discovery.
  */
-export async function searchRegions(params: RegionSearchParams = {}): Promise<RegionSummary[]> {
-    const query = new URLSearchParams();
-
-    Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null && value !== '') {
-            query.append(key, String(value));
-        }
-    });
-
-    const suffix = query.toString() ? `?${query.toString()}` : '';
-    const response = await fetch(`${API_BASE}/regions/search${suffix}`);
-    if (!response.ok) {
-        throw new Error(`Failed to search regions: ${response.statusText}`);
-    }
-
-    const data: RegionSearchResponse = await response.json();
+export async function searchRegions(
+    params: RegionSearchParams = {},
+    signal?: AbortSignal,
+): Promise<RegionSummary[]> {
+    const data = await fetchJson<RegionSearchResponse>(
+        withQuery(`${API_BASE}/regions/search`, params),
+        { signal },
+        'Failed to search regions',
+    );
     return data.regions;
 }
 
 /**
  * Fetch database statistics
  */
-export async function fetchStatistics(): Promise<StatisticsResponse> {
-    const response = await fetch(`${API_BASE}/statistics`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch statistics: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchStatistics(signal?: AbortSignal): Promise<StatisticsResponse> {
+    return fetchJson(`${API_BASE}/statistics`, { signal }, 'Failed to fetch statistics');
 }
 
 /**
@@ -191,75 +193,14 @@ export async function fetchStatistics(): Promise<StatisticsResponse> {
  */
 export async function fetchTelehealthPriority(
     regionCode: string,
-    season: Season = 'year_round'
+    season: Season = 'year_round',
+    signal?: AbortSignal,
 ): Promise<TelehealthPriorityResponse> {
-    const url = `${API_BASE}/telehealth-priority/${regionCode}?season=${season}`;
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch telehealth priority: ${response.statusText}`);
-    }
-
-    return response.json();
-}
-
-/**
- * Get tier color based on CAT tier level
- */
-export function getTierColor(tier: number): string {
-    switch (tier) {
-        case 1: return '#22c55e'; // Green - Full access
-        case 2: return '#eab308'; // Yellow - Dual mode
-        case 3: return '#f97316'; // Orange - Limited
-        case 4: return '#ef4444'; // Red - Extreme
-        default: return '#6b7280'; // Gray - Unknown
-    }
-}
-
-/**
- * Get map color based on Telehealth Necessity Score (0-100)
- */
-export function getNeedColor(score: number): string {
-    if (score >= 75) return '#f43f5e';      // Vibrant Rose (Professional Critical)
-    if (score >= 50) return '#fb923c';      // Warm Orange (High)
-    if (score >= 25) return '#fbbf24';      // Rich Amber (Moderate)
-    return '#34d399';                       // Fresh Emerald (Adequate)
-}
-
-/**
- * Get label based on Telehealth Necessity Score (0-100)
- */
-export function getNeedLabel(score: number): string {
-    if (score >= 75) return 'Critical Need';
-    if (score >= 50) return 'High Need';
-    if (score >= 25) return 'Moderate Need';
-    return 'Adequate Need';
-}
-
-/**
- * Get tier label based on CAT tier level
- */
-export function getTierLabel(tier: number): string {
-    switch (tier) {
-        case 1: return 'Full Multimodal Access';
-        case 2: return 'Dual Mode Access';
-        case 3: return 'Limited Access';
-        case 4: return 'Extreme/No Direct Access';
-        default: return 'Unknown';
-    }
-}
-
-/**
- * Get priority color for telehealth classification
- */
-export function getPriorityColor(priority: string): string {
-    switch (priority) {
-        case 'HIGH': return '#22c55e';      // Green
-        case 'CRITICAL': return '#ef4444';   // Red
-        case 'MODERATE': return '#f97316';   // Orange
-        case 'LOW': return '#3b82f6';        // Blue
-        default: return '#6b7280';           // Gray
-    }
+    return fetchJson(
+        withQuery(`${API_BASE}/telehealth-priority/${encodeURIComponent(regionCode)}`, { season }),
+        { signal },
+        'Failed to fetch telehealth priority',
+    );
 }
 
 // =============================================================================
@@ -331,69 +272,40 @@ export async function fetchBroadbandCoverage(filters?: {
     telehealth_viable?: string;
     primary_access?: string;
     has_gaps?: boolean;
-}): Promise<BroadbandResponse> {
-    let url = `${API_BASE}/broadband`;
-    const params = new URLSearchParams();
-
-    if (filters?.confidence) params.append('confidence', filters.confidence);
-    if (filters?.telehealth_viable) params.append('telehealth_viable', filters.telehealth_viable);
-    if (filters?.primary_access) params.append('primary_access', filters.primary_access);
-    if (filters?.has_gaps) params.append('has_gaps', 'true');
-
-    if (params.toString()) {
-        url += `?${params.toString()}`;
-    }
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch broadband data: ${response.statusText}`);
-    }
-    return response.json();
+}, signal?: AbortSignal): Promise<BroadbandResponse> {
+    return fetchJson(
+        withQuery(`${API_BASE}/broadband`, {
+            confidence: filters?.confidence,
+            telehealth_viable: filters?.telehealth_viable,
+            primary_access: filters?.primary_access,
+            has_gaps: filters?.has_gaps ? true : undefined,
+        }),
+        { signal },
+        'Failed to fetch broadband data',
+    );
 }
 
 /**
  * Fetch data gaps summary for dashboard display
  */
-export async function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
-    const response = await fetch(`${API_BASE}/data-gaps`, { signal });
-    if (!response.ok) {
-        throw new Error(`Failed to fetch data gaps: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchDataGapsSummary(signal?: AbortSignal): Promise<DataGapsSummary> {
+    return fetchJson(`${API_BASE}/data-gaps`, { signal }, 'Failed to fetch data gaps');
 }
 
-/**
- * Get confidence color for data quality visualization
- */
-export function getConfidenceColor(confidence: string): string {
-    switch (confidence) {
-        case 'HIGH': return '#22c55e';    // Green
-        case 'MEDIUM': return '#eab308';   // Yellow
-        case 'LOW': return '#ef4444';      // Red
-        default: return '#6b7280';         // Gray
-    }
+export function getNeedColor(score: number | null | undefined): string {
+    return getDesertScorePresentation(score ?? 0).color;
 }
 
-/**
- * Get icon/label for data gap types
- */
-export function getDataGapInfo(gap: string): { icon: string; label: string; severity: 'warning' | 'error' | 'info' } {
-    switch (gap) {
-        case 'SATELLITE_DEPENDENT':
-            return { icon: '', label: 'Satellite Only', severity: 'warning' };
-        case 'LOW_TERRESTRIAL':
-            return { icon: '📶', label: 'Low Wired Coverage', severity: 'warning' };
-        case 'LOW_CONFIDENCE':
-            return { icon: '❓', label: 'Low Data Confidence', severity: 'info' };
-        case 'INTERNET_DESERT':
-            return { icon: '🚫', label: 'No Internet Coverage', severity: 'error' };
-        case 'MISSING_WIRED_DATA':
-            return { icon: '📊', label: 'Missing Wired Data', severity: 'info' };
-        case 'MISSING_SATELLITE_DATA':
-            return { icon: '📊', label: 'Missing Satellite Data', severity: 'info' };
-        default:
-            return { icon: '', label: gap, severity: 'info' };
+export function getNeedLabel(score: number | null | undefined): string {
+    if (score === null || score === undefined) return 'Unknown Need';
+    return getDesertScorePresentation(score).label;
+}
+
+export function getTierColor(tier: CatTier | number | null | undefined): string {
+    if (tier === 1 || tier === 2 || tier === 3 || tier === 4) {
+        return CAT_TIER_PRESENTATION[tier].color;
     }
+    return '#94a3b8';
 }
 
 // =============================================================================
@@ -450,41 +362,23 @@ export interface HealthcareSummary {
 /**
  * Fetch healthcare facilities near a specific region
  */
-export async function fetchHealthcareByRegion(regionCode: string, limit = 10): Promise<HealthcareByRegion> {
-    const response = await fetch(`${API_BASE}/healthcare/by-region/${regionCode}?limit=${limit}`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch healthcare data: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchHealthcareByRegion(
+    regionCode: string,
+    limit = 10,
+    signal?: AbortSignal,
+): Promise<HealthcareByRegion> {
+    return fetchJson(
+        withQuery(`${API_BASE}/healthcare/by-region/${encodeURIComponent(regionCode)}`, { limit }),
+        { signal },
+        'Failed to fetch healthcare data',
+    );
 }
 
 /**
  * Fetch healthcare summary statistics
  */
-export async function fetchHealthcareSummary(): Promise<HealthcareSummary> {
-    const response = await fetch(`${API_BASE}/healthcare/summary`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch healthcare summary: ${response.statusText}`);
-    }
-    return response.json();
-}
-
-/**
- * Get facility type icon and color
- */
-export function getFacilityTypeInfo(type: string): { icon: string; color: string; label: string } {
-    switch (type) {
-        case 'hospital':
-            return { icon: '🏥', color: '#dc2626', label: 'Hospital' };
-        case 'clinic':
-            return { icon: '🩺', color: '#2563eb', label: 'Clinic' };
-        case 'pharmacy':
-            return { icon: '💊', color: '#16a34a', label: 'Pharmacy' };
-        case 'health_center':
-            return { icon: '🏨', color: '#7c3aed', label: 'Health Center' };
-        default:
-            return { icon: '🏥', color: '#6b7280', label: type };
-    }
+export function fetchHealthcareSummary(signal?: AbortSignal): Promise<HealthcareSummary> {
+    return fetchJson(`${API_BASE}/healthcare/summary`, { signal }, 'Failed to fetch healthcare summary');
 }
 
 // =============================================================================
@@ -606,74 +500,46 @@ export interface PerformanceSummary {
 export async function fetchPerformance(
     year?: number,
     quarter?: number,
-    minTests: number = 1
+    minTests: number = 1,
+    signal?: AbortSignal,
 ): Promise<PerformanceResponse> {
-    let url = `${API_BASE}/performance?min_tests=${minTests}`;
-    if (year) url += `&year=${year}`;
-    if (quarter) url += `&quarter=${quarter}`;
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch performance: ${response.statusText}`);
-    }
-    return response.json();
+    return fetchJson(
+        withQuery(`${API_BASE}/performance`, {
+            min_tests: minTests,
+            year: year || undefined,
+            quarter: quarter || undefined,
+        }),
+        { signal },
+        'Failed to fetch performance',
+    );
 }
 
 /**
  * Fetch service gaps (FCC claims vs Ookla measured)
  */
-export async function fetchServiceGaps(): Promise<ServiceGapsResponse> {
-    const response = await fetch(`${API_BASE}/performance/gaps`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch service gaps: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchServiceGaps(signal?: AbortSignal): Promise<ServiceGapsResponse> {
+    return fetchJson(`${API_BASE}/performance/gaps`, { signal }, 'Failed to fetch service gaps');
 }
 
 /**
  * Fetch performance for a specific region
  */
-export async function fetchRegionPerformance(regionCode: string): Promise<RegionPerformance> {
-    const response = await fetch(`${API_BASE}/performance/by-region/${regionCode}`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch region performance: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchRegionPerformance(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<RegionPerformance> {
+    return fetchJson(
+        `${API_BASE}/performance/by-region/${encodeURIComponent(regionCode)}`,
+        { signal },
+        'Failed to fetch region performance',
+    );
 }
 
 /**
  * Fetch performance summary
  */
-export async function fetchPerformanceSummary(): Promise<PerformanceSummary> {
-    const response = await fetch(`${API_BASE}/performance/summary`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch performance summary: ${response.statusText}`);
-    }
-    return response.json();
-}
-
-/**
- * Get speed color for visualization
- */
-export function getSpeedColor(speedMbps: number | null): string {
-    if (speedMbps === null) return '#6b7280';  // Gray - no data
-    if (speedMbps >= 50) return '#22c55e';     // Green - excellent
-    if (speedMbps >= 25) return '#84cc16';     // Lime - good
-    if (speedMbps >= 10) return '#eab308';     // Yellow - moderate
-    if (speedMbps >= 5) return '#f97316';      // Orange - poor
-    return '#ef4444';                           // Red - critical
-}
-
-/**
- * Get speed label
- */
-export function getSpeedLabel(speedMbps: number | null): string {
-    if (speedMbps === null) return 'No Data';
-    if (speedMbps >= 50) return 'Excellent';
-    if (speedMbps >= 25) return 'Good';
-    if (speedMbps >= 10) return 'Moderate';
-    if (speedMbps >= 5) return 'Poor';
-    return 'Critical';
+export function fetchPerformanceSummary(signal?: AbortSignal): Promise<PerformanceSummary> {
+    return fetchJson(`${API_BASE}/performance/summary`, { signal }, 'Failed to fetch performance summary');
 }
 
 // ============================================================================
@@ -706,12 +572,12 @@ export interface TopGapsResponse {
 /**
  * Fetch top priority gaps with location names
  */
-export async function fetchTopGaps(limit: number = 10): Promise<TopGapsResponse> {
-    const response = await fetch(`${API_BASE}/performance/top-gaps?limit=${limit}`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch top gaps: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchTopGaps(limit: number = 10, signal?: AbortSignal): Promise<TopGapsResponse> {
+    return fetchJson(
+        withQuery(`${API_BASE}/performance/top-gaps`, { limit }),
+        { signal },
+        'Failed to fetch top gaps',
+    );
 }
 
 export interface LocationInfo {
@@ -725,12 +591,23 @@ export interface LocationInfo {
 /**
  * Fetch location name for given coordinates (reverse geocoding)
  */
-export async function fetchLocationName(lat: number, lon: number): Promise<LocationInfo> {
-    const response = await fetch(`${API_BASE}/performance/location?lat=${lat}&lon=${lon}`);
-    if (!response.ok) {
-        return { name: 'Unknown', region: '', country: '', lat, lon };
+export async function fetchLocationName(
+    lat: number,
+    lon: number,
+    signal?: AbortSignal,
+): Promise<LocationInfo> {
+    try {
+        return await fetchJson(
+            withQuery(`${API_BASE}/performance/location`, { lat, lon }),
+            { signal },
+            'Failed to fetch location name',
+        );
+    } catch (error: unknown) {
+        if (error instanceof ApiError && error.status > 0) {
+            return { name: 'Unknown', region: '', country: '', lat, lon };
+        }
+        throw error;
     }
-    return response.json();
 }
 
 // =============================================================================
@@ -802,15 +679,17 @@ export interface CombinedAccessResponse {
  */
 export async function fetchAffordability(
     monthlyCost: number = 120,
-    threshold: number = 2.0
+    threshold: number = 2.0,
+    signal?: AbortSignal,
 ): Promise<AffordabilityResponse> {
-    const response = await fetch(
-        `${API_BASE}/performance/affordability?monthly_cost=${monthlyCost}&threshold=${threshold}`
+    return fetchJson(
+        withQuery(`${API_BASE}/performance/affordability`, {
+            monthly_cost: monthlyCost,
+            threshold,
+        }),
+        { signal },
+        'Failed to fetch affordability data',
     );
-    if (!response.ok) {
-        throw new Error(`Failed to fetch affordability data: ${response.statusText}`);
-    }
-    return response.json();
 }
 
 /**
@@ -818,14 +697,15 @@ export async function fetchAffordability(
  * Shows TRUE_ACCESS, COVERAGE_NO_ACCESS, and INFRASTRUCTURE_GAP zones
  * @param monthlyCost - Internet cost per month (default: $120)
  */
-export async function fetchCombinedAccess(monthlyCost: number = 120): Promise<CombinedAccessResponse> {
-    const response = await fetch(
-        `${API_BASE}/performance/affordability/combined?monthly_cost=${monthlyCost}`
+export function fetchCombinedAccess(
+    monthlyCost: number = 120,
+    signal?: AbortSignal,
+): Promise<CombinedAccessResponse> {
+    return fetchJson(
+        withQuery(`${API_BASE}/performance/affordability/combined`, { monthly_cost: monthlyCost }),
+        { signal },
+        'Failed to fetch combined access data',
     );
-    if (!response.ok) {
-        throw new Error(`Failed to fetch combined access data: ${response.statusText}`);
-    }
-    return response.json();
 }
 
 // =============================================================================
@@ -869,23 +749,29 @@ export interface SafetyNetClassification {
 /**
  * Fetch affordability analysis for a specific region
  */
-export async function fetchRegionAffordability(regionCode: string): Promise<RegionAffordability> {
-    const response = await fetch(`${API_BASE}/regions/${regionCode}/affordability`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch region affordability: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchRegionAffordability(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<RegionAffordability> {
+    return fetchJson(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/affordability`,
+        { signal },
+        'Failed to fetch region affordability',
+    );
 }
 
 /**
  * Fetch safety net classification for a specific region
  */
-export async function fetchRegionSafetyNet(regionCode: string): Promise<SafetyNetClassification> {
-    const response = await fetch(`${API_BASE}/regions/${regionCode}/safety-net`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch safety net classification: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchRegionSafetyNet(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<SafetyNetClassification> {
+    return fetchJson(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/safety-net`,
+        { signal },
+        'Failed to fetch safety net classification',
+    );
 }
 
 // =============================================================================
@@ -895,7 +781,7 @@ export async function fetchRegionSafetyNet(regionCode: string): Promise<SafetyNe
 export interface TelehealthStatus {
     region_code: string;
     region_name: string;
-    status: 'TELEHEALTH_READY' | 'COMMUNITY_ANCHOR' | 'CRITICAL_GAP' | 'DATA_UNAVAILABLE';
+    status: TelehealthStatusName;
     color: string;
     label: string;
     description: string;
@@ -917,29 +803,15 @@ export interface TelehealthStatus {
  * Fetch composite telehealth status for a region
  * Combines affordability + clinic proximity into a single classification
  */
-export async function fetchTelehealthStatus(regionCode: string): Promise<TelehealthStatus> {
-    const response = await fetch(`${API_BASE}/regions/${regionCode}/telehealth-status`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch telehealth status: ${response.statusText}`);
-    }
-    return response.json();
-}
-
-/**
- * Get the color to use for a region marker based on telehealth status
- */
-export function getTelehealthStatusColor(status: TelehealthStatus['status']): string {
-    switch (status) {
-        case 'TELEHEALTH_READY':
-            return '#22c55e';  // Green
-        case 'COMMUNITY_ANCHOR':
-            return '#f59e0b';  // Amber
-        case 'CRITICAL_GAP':
-            return '#ef4444';  // Red
-        case 'DATA_UNAVAILABLE':
-        default:
-            return '#6b7280';  // Gray
-    }
+export function fetchTelehealthStatus(
+    regionCode: string,
+    signal?: AbortSignal,
+): Promise<TelehealthStatus> {
+    return fetchJson(
+        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/telehealth-status`,
+        { signal },
+        'Failed to fetch telehealth status',
+    );
 }
 
 // Bulk telehealth status for all regions
@@ -948,7 +820,7 @@ export interface RegionTelehealthStatus {
     region_name: string;
     lat: number;
     lon: number;
-    status: 'TELEHEALTH_READY' | 'COMMUNITY_ANCHOR' | 'CRITICAL_GAP' | 'DATA_UNAVAILABLE';
+    status: TelehealthStatusName;
     color: string;
     internet_cost: number | null;
     isp_name: string;
@@ -975,10 +847,10 @@ export interface AllTelehealthStatusResponse {
 /**
  * Fetch telehealth status for ALL regions (used by Affordability Layer)
  */
-export async function fetchAllTelehealthStatus(): Promise<AllTelehealthStatusResponse> {
-    const response = await fetch(`${API_BASE}/telehealth-status/all`);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch all telehealth status: ${response.statusText}`);
-    }
-    return response.json();
+export function fetchAllTelehealthStatus(signal?: AbortSignal): Promise<AllTelehealthStatusResponse> {
+    return fetchJson(
+        `${API_BASE}/telehealth-status/all`,
+        { signal },
+        'Failed to fetch all telehealth status',
+    );
 }

--- a/frontend/src/api/http.test.ts
+++ b/frontend/src/api/http.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, fetchJson, isAbortError, withQuery } from './http';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('fetchJson', () => {
+    it('returns typed JSON and forwards the abort signal', async () => {
+        const controller = new AbortController();
+        const fetchMock = vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ count: 3 }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchJson<{ count: number }>('/api/example', {
+            signal: controller.signal,
+        })).resolves.toEqual({ count: 3 });
+        expect(fetchMock).toHaveBeenCalledWith('/api/example', { signal: controller.signal });
+    });
+
+    it('throws an ApiError with response metadata and backend detail', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ error: 'Not available for this period' }),
+            { status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'application/json' } },
+        )));
+
+        const request = fetchJson('/api/example', {}, 'Could not load example');
+        await expect(request).rejects.toMatchObject({
+            name: 'ApiError',
+            status: 404,
+            statusText: 'Not Found',
+            message: 'Could not load example: Not available for this period',
+        } satisfies Partial<ApiError>);
+    });
+
+    it('normalizes network failures but preserves abort errors', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new TypeError('offline')));
+        await expect(fetchJson('/api/example')).rejects.toMatchObject({
+            name: 'ApiError',
+            status: 0,
+            message: 'This data source is currently unavailable: network request failed',
+        });
+
+        const abortError = new DOMException('Cancelled', 'AbortError');
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(abortError));
+        await expect(fetchJson('/api/example')).rejects.toBe(abortError);
+    });
+});
+
+describe('HTTP helpers', () => {
+    it('builds queries without empty values', () => {
+        expect(withQuery('/api/example', {
+            season: 'winter',
+            limit: 0,
+            optional: null,
+        })).toBe('/api/example?season=winter&limit=0');
+    });
+
+    it('recognizes abort errors without treating ordinary failures as cancellation', () => {
+        expect(isAbortError(new DOMException('Cancelled', 'AbortError'))).toBe(true);
+        expect(isAbortError(new Error('Network unavailable'))).toBe(false);
+    });
+});

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,119 @@
+export type QueryValue = string | number | boolean | null | undefined;
+
+export class ApiError extends Error {
+    readonly status: number;
+    readonly statusText: string;
+    readonly url: string;
+    readonly body: unknown;
+
+    constructor({
+        message,
+        status,
+        statusText,
+        url,
+        body,
+        cause,
+    }: {
+        message: string;
+        status: number;
+        statusText: string;
+        url: string;
+        body?: unknown;
+        cause?: unknown;
+    }) {
+        super(message);
+        if (cause !== undefined) {
+            (this as Error & { cause?: unknown }).cause = cause;
+        }
+        this.name = 'ApiError';
+        this.status = status;
+        this.statusText = statusText;
+        this.url = url;
+        this.body = body;
+    }
+}
+
+function responseErrorDetail(body: unknown): string | null {
+    if (!body || typeof body !== 'object') return null;
+    const candidate = body as { error?: unknown; message?: unknown };
+    if (typeof candidate.error === 'string' && candidate.error.trim()) return candidate.error;
+    if (typeof candidate.message === 'string' && candidate.message.trim()) return candidate.message;
+    return null;
+}
+
+async function readErrorBody(response: Response): Promise<unknown> {
+    const contentType = response.headers.get('content-type') ?? '';
+    try {
+        return contentType.includes('application/json')
+            ? await response.json()
+            : await response.text();
+    } catch {
+        return null;
+    }
+}
+
+export async function fetchJson<T>(
+    url: string,
+    init: RequestInit = {},
+    errorMessage = 'This data source is currently unavailable',
+): Promise<T> {
+    let response: Response;
+    try {
+        response = await fetch(url, init);
+    } catch (cause: unknown) {
+        if (isAbortError(cause)) throw cause;
+        throw new ApiError({
+            message: `${errorMessage}: network request failed`,
+            status: 0,
+            statusText: '',
+            url,
+            cause,
+        });
+    }
+
+    if (!response.ok) {
+        const body = await readErrorBody(response);
+        const detail = responseErrorDetail(body) || response.statusText;
+        throw new ApiError({
+            message: detail ? `${errorMessage}: ${detail}` : errorMessage,
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url || url,
+            body,
+        });
+    }
+
+    try {
+        return await response.json() as T;
+    } catch (cause: unknown) {
+        throw new ApiError({
+            message: `${errorMessage}: invalid JSON response`,
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url || url,
+            cause,
+        });
+    }
+}
+
+export function withQuery<T extends object>(url: string, params: T): string {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]: [string, QueryValue]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            query.set(key, String(value));
+        }
+    });
+    const suffix = query.toString();
+    return suffix ? `${url}?${suffix}` : url;
+}
+
+export function isAbortError(error: unknown): boolean {
+    return error instanceof DOMException
+        ? error.name === 'AbortError'
+        : error instanceof Error && error.name === 'AbortError';
+}
+
+export function errorMessage(error: unknown, fallback = 'This data source is currently unavailable.'): string {
+    if (error instanceof Error && error.message.trim()) return error.message;
+    return fallback;
+}

--- a/frontend/src/api/researchApi.ts
+++ b/frontend/src/api/researchApi.ts
@@ -1,35 +1,30 @@
 import { Season, API_BASE } from './catApi';
 import { ResearchProfile, ResearchProfilesResponse } from '../types/research';
+import { fetchJson, withQuery } from './http';
 
 export async function fetchResearchProfile(
     regionCode: string,
     season: Season = 'year_round',
+    signal?: AbortSignal,
 ): Promise<ResearchProfile> {
-    const params = new URLSearchParams({ season });
-    const response = await fetch(
-        `${API_BASE}/regions/${encodeURIComponent(regionCode)}/research-profile?${params.toString()}`,
+    return fetchJson<ResearchProfile>(
+        withQuery(`${API_BASE}/regions/${encodeURIComponent(regionCode)}/research-profile`, { season }),
+        { signal },
+        'Failed to fetch research profile',
     );
-
-    if (!response.ok) {
-        throw new Error(response.status === 404 ? 'Community not found' : 'Failed to fetch research profile');
-    }
-
-    return response.json();
 }
 
 export async function fetchResearchProfiles(
     regionCodes: string[],
     season: Season = 'year_round',
+    signal?: AbortSignal,
 ): Promise<ResearchProfilesResponse> {
-    const params = new URLSearchParams({
-        codes: regionCodes.slice(0, 3).join(','),
-        season,
-    });
-    const response = await fetch(`${API_BASE}/regions/research-profiles?${params.toString()}`);
-
-    if (!response.ok) {
-        throw new Error('Failed to fetch comparison profiles');
-    }
-
-    return response.json();
+    return fetchJson<ResearchProfilesResponse>(
+        withQuery(`${API_BASE}/regions/research-profiles`, {
+            codes: regionCodes.slice(0, 3).join(','),
+            season,
+        }),
+        { signal },
+        'Failed to fetch comparison profiles',
+    );
 }

--- a/frontend/src/api/scenarioApi.ts
+++ b/frontend/src/api/scenarioApi.ts
@@ -5,6 +5,7 @@
 import type { Season } from './catApi';
 import { API_BASE } from './catApi';
 import type { ScenarioPreviewResponse, ScenarioThresholds } from '../types/scenario';
+import { fetchJson } from './http';
 
 export interface ScenarioPreviewRequest {
     mode: 'preview';
@@ -22,17 +23,10 @@ export async function fetchScenarioPreview(
     request: ScenarioPreviewRequest,
     signal?: AbortSignal,
 ): Promise<ScenarioPreviewResponse> {
-    const response = await fetch(`${API_BASE}/scenarios/preview`, {
+    return fetchJson<ScenarioPreviewResponse>(`${API_BASE}/scenarios/preview`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),
         signal,
-    });
-
-    if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({}));
-        throw new Error(errorBody.error || `Scenario preview failed: ${response.statusText}`);
-    }
-
-    return response.json();
+    }, 'Scenario preview failed');
 }

--- a/frontend/src/components/AffordabilityLayer.tsx
+++ b/frontend/src/components/AffordabilityLayer.tsx
@@ -1,10 +1,22 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CircleMarker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import {
     AllTelehealthStatusResponse,
     fetchAllTelehealthStatus
 } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+import Button from './ui/Button';
+import StatusBadge from './ui/StatusBadge';
+import {
+    BASE_TELEHEALTH_STATUSES,
+    getTelehealthStatusColor,
+    getTelehealthStatusLabel,
+    getTelehealthStatusPresentation,
+    getTelehealthStatusTone,
+} from '../domain/statusPresentation';
+import './MapModeLegends.css';
+import './map/MapLayers.css';
 
 interface AffordabilityLayerProps {
     visible: boolean;
@@ -18,7 +30,7 @@ interface AffordabilityLayerProps {
 const AFFORDABILITY_MARKER_PANE = 'affordability-marker-pane';
 
 /**
- * Affordability Layer - shows all regions colored by telehealth accessibility status
+ * Affordability layer - shows all regions colored by composite access status.
  * Green = Telehealth Ready (affordable home internet)
  * Amber = Community Anchor (unaffordable but has nearby clinic)
  * Red = Critical Gap (unaffordable AND no nearby clinic)
@@ -65,25 +77,31 @@ export default function AffordabilityLayer({
     }, [data, selectedRegionCode, visible]);
 
     useEffect(() => {
-        if (visible && !data) {
-            setLoading(true);
-            fetchAllTelehealthStatus()
-                .then(response => {
-                    setData(response);
-                    if (onDataLoad) {
-                        onDataLoad(response.summary);
-                    }
-                })
-                .catch(err => setError(err.message))
-                .finally(() => setLoading(false));
-        }
+        if (!visible || data) return;
+
+        const controller = new AbortController();
+        setLoading(true);
+        fetchAllTelehealthStatus(controller.signal)
+            .then(response => {
+                setData(response);
+                onDataLoad?.(response.summary);
+            })
+            .catch((caught: unknown) => {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Affordability layer unavailable'));
+                }
+            })
+            .finally(() => {
+                if (!controller.signal.aborted) setLoading(false);
+            });
+
+        return () => controller.abort();
     }, [visible, data, onDataLoad]);
 
     if (!visible) return null;
     if (loading) return null;
     if (error) {
-        console.error('AffordabilityLayer error:', error);
-        return null;
+        return <div className="map-layer-state is-error" role="status">{error}</div>;
     }
     if (!data) return null;
 
@@ -99,7 +117,7 @@ export default function AffordabilityLayer({
                     interactive
                     bubblingMouseEvents={false}
                     pathOptions={{
-                        fillColor: region.color,
+                        fillColor: getTelehealthStatusColor(region.status),
                         fillOpacity: region.region_code === selectedRegionCode ? 0.95 : 0.65,
                         color: '#ffffff',
                         weight: region.region_code === selectedRegionCode ? 2.5 : 1.5,
@@ -121,46 +139,23 @@ export default function AffordabilityLayer({
                         autoPanPaddingTopLeft={[64, 120]}
                         autoPanPaddingBottomRight={[64, 210]}
                     >
-                        <div style={{
-                            minWidth: '210px',
-                            maxWidth: '236px',
-                            color: '#172033',
-                            fontSize: '12px'
-                        }}>
-                            <h4 style={{
-                                margin: '0 0 2px 0',
-                                color: '#111827',
-                                fontSize: '15px',
-                                lineHeight: 1.2
-                            }}>
+                        <div className="telehealth-access-popup">
+                            <h4 className="telehealth-access-popup__title">
                                 {region.region_name}
                             </h4>
-                            <div style={{
-                                marginBottom: '9px',
-                                color: '#64748b',
-                                fontSize: '11px',
-                                fontWeight: 700
-                            }}>
+                            <div className="telehealth-access-popup__code">
                                 {region.region_code}
                             </div>
 
-                            <div style={{
-                                display: 'inline-flex',
-                                alignItems: 'center',
-                                minHeight: '22px',
-                                padding: '3px 8px',
-                                borderRadius: '999px',
-                                backgroundColor: region.color,
-                                color: 'white',
-                                fontSize: '11px',
-                                fontWeight: 800,
-                                marginBottom: '10px'
-                            }}>
-                                {region.status.replace(/_/g, ' ')}
-                            </div>
+                            <StatusBadge
+                                tone={getTelehealthStatusTone(region.status)}
+                                className="telehealth-access-popup__status"
+                            >
+                                {getTelehealthStatusLabel(region.status)}
+                            </StatusBadge>
 
-                            <button
-                                type="button"
+                            <Button
+                                size="small"
                                 onMouseDown={event => {
                                     event.preventDefault();
                                     event.stopPropagation();
@@ -175,20 +170,10 @@ export default function AffordabilityLayer({
                                         markerRefs.current[region.region_code]?.closePopup();
                                     }
                                 }}
-                                style={{
-                                    width: '100%',
-                                    border: '1px solid #c7d0da',
-                                    borderRadius: '6px',
-                                    background: '#ffffff',
-                                    color: '#334155',
-                                    padding: '6px 8px',
-                                    fontSize: '11px',
-                                    fontWeight: 800,
-                                    cursor: 'pointer'
-                                }}
+                                className="telehealth-access-popup__button"
                             >
                                 View details
-                            </button>
+                            </Button>
                         </div>
                     </Popup>
                 </CircleMarker>
@@ -201,63 +186,41 @@ export default function AffordabilityLayer({
  * Legend component for the affordability layer
  */
 export function AffordabilityLegend({ summary }: { summary?: AllTelehealthStatusResponse['summary'] }) {
-    const items = [
-        { color: '#10B981', label: 'Telehealth Ready', sub: 'Affordable + Fast', count: summary?.telehealth_ready },
-        { color: '#F59E0B', label: 'Community Anchor', sub: 'Has nearby clinic', count: summary?.community_anchor },
-        { color: '#EF4444', label: 'Critical Gap', sub: 'No affordable access', count: summary?.critical_gap },
-        { color: '#94A3B8', label: 'Data Unavailable', sub: 'Missing data', count: summary?.data_unavailable },
-    ];
+    const counts = {
+        TELEHEALTH_READY: summary?.telehealth_ready,
+        COMMUNITY_ANCHOR: summary?.community_anchor,
+        CRITICAL_GAP: summary?.critical_gap,
+        DATA_UNAVAILABLE: summary?.data_unavailable,
+    } as const;
+    const items = BASE_TELEHEALTH_STATUSES.map(status => ({
+        ...getTelehealthStatusPresentation(status),
+        sub: getTelehealthStatusPresentation(status).description,
+        count: counts[status],
+    }));
 
     return (
-        <div style={{
-            position: 'absolute',
-            bottom: '20px',
-            left: '20px',
-            zIndex: 1000,
-            minWidth: '220px',
-            // Glassmorphism
-            background: 'rgba(255, 255, 255, 0.92)',
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            padding: '16px 18px',
-            borderRadius: '12px',
-            border: '1px solid rgba(255, 255, 255, 0.3)',
-            boxShadow: '0 8px 32px rgba(31, 38, 135, 0.12)',
-            fontSize: '12px'
-        }}>
-            <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                marginBottom: '12px',
-                paddingBottom: '10px',
-                borderBottom: '1px solid rgba(0, 0, 0, 0.08)'
-            }}>
-                <div style={{ fontWeight: '700', color: '#0f172a', fontSize: '14px', letterSpacing: '-0.02em' }}>
-                    Telehealth Accessibility
+        <div className="affordability-legend">
+            <div className="affordability-legend__header">
+                <div className="affordability-legend__title">
+                    Affordability
                 </div>
-                <span style={{ fontSize: '10px', color: '#64748b', fontWeight: '500' }}>Safety Net</span>
+                <span className="affordability-legend__kicker">Safety Net</span>
             </div>
 
             {items.map(item => (
-                <div key={item.label} style={{ display: 'flex', alignItems: 'flex-start', marginBottom: '8px', gap: '10px' }}>
-                    <div style={{
-                        width: '12px',
-                        height: '12px',
-                        borderRadius: '50%',
-                        backgroundColor: item.color,
-                        flexShrink: 0,
-                        marginTop: '3px',
-                        boxShadow: '0 1px 2px rgba(0,0,0,0.15)'
-                    }} />
-                    <div style={{ flex: 1 }}>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                            <span style={{ color: '#1e293b', fontWeight: '500' }}>{item.label}</span>
+                <div key={item.label} className="affordability-legend__item">
+                    <div
+                        className="affordability-legend__swatch"
+                        style={{ backgroundColor: item.color }}
+                    />
+                    <div className="affordability-legend__content">
+                        <div className="affordability-legend__row">
+                            <span className="affordability-legend__label">{item.label}</span>
                             {item.count !== undefined && (
-                                <span style={{ fontSize: '10px', color: '#64748b', fontWeight: '600' }}>{item.count}</span>
+                                <span className="affordability-legend__count">{item.count}</span>
                             )}
                         </div>
-                        <div style={{ color: '#64748b', fontSize: '10px' }}>{item.sub}</div>
+                        <div className="affordability-legend__note">{item.sub}</div>
                     </div>
                 </div>
             ))}

--- a/frontend/src/components/ChoroplethLayer.tsx
+++ b/frontend/src/components/ChoroplethLayer.tsx
@@ -5,32 +5,25 @@
  * with aggregated performance data and context-rich tooltips.
  */
 import { useEffect, useState, useMemo } from 'react';
-import { useMap, GeoJSON } from 'react-leaflet';
+import { GeoJSON } from 'react-leaflet';
 import L from 'leaflet';
-import type { PerformanceTile, AffordabilityZone } from '../api/catApi';
+import type { MultiPolygon } from 'geojson';
+import {
+    fetchBoundaries,
+    type AffordabilityZone,
+    type BoundaryCollection,
+    type BoundaryProperties,
+    type PerformanceTile,
+} from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+import { escapeHtml } from '../utils/escapeHtml';
 import { getScenarioCost, getTrafficLightStatus } from '../utils/trafficLight';
-
-// GeoJSON Feature type
-interface BoundaryFeature {
-    type: 'Feature';
-    properties: {
-        CommunityName: string;
-        EconomicRegion: string;
-        FIPS: string;
-        Census_Area: 'Y' | null;
-    };
-    geometry: GeoJSON.MultiPolygon;
-}
-
-interface BoundaryCollection {
-    type: 'FeatureCollection';
-    features: BoundaryFeature[];
-}
+import './map/MapLayers.css';
 
 // Aggregated stats for a region
 interface RegionStats {
-    avgSpeed: number;
-    avgLatency: number;
+    avgSpeed: number | null;
+    avgLatency: number | null;
     avgBurden: number | null;
     tileCount: number;
     status: 'GREEN' | 'YELLOW' | 'ORANGE' | 'RED' | 'GRAY';
@@ -85,27 +78,29 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
     affordabilityData,
     useStarlink
 }) => {
-    const map = useMap();
     const [boundaries, setBoundaries] = useState<BoundaryCollection | null>(null);
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
     // Fetch boundaries GeoJSON
     useEffect(() => {
         if (!visible) return;
 
+        const controller = new AbortController();
         setLoading(true);
-        const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/cat';
-        fetch(`${API_BASE}/boundaries`)
-            .then(res => res.json())
+        setError(null);
+        fetchBoundaries(controller.signal)
             .then(data => {
-                console.log('Loaded boundaries:', data.features?.length, 'regions');
                 setBoundaries(data);
                 setLoading(false);
             })
-            .catch(err => {
-                console.error('Failed to load boundaries:', err);
+            .catch((error: unknown) => {
+                if (isAbortError(error)) return;
+                setError(errorMessage(error, 'Regional boundaries are unavailable.'));
                 setLoading(false);
             });
+
+        return () => controller.abort();
     }, [visible]);
 
     // Calculate which tiles fall within each region (simplified: use bounding box)
@@ -135,8 +130,8 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
 
             if (regionTiles.length === 0) {
                 stats.set(name, {
-                    avgSpeed: 0,
-                    avgLatency: 0,
+                    avgSpeed: null,
+                    avgLatency: null,
                     avgBurden: null,
                     tileCount: 0,
                     status: 'GRAY'
@@ -145,8 +140,18 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
             }
 
             // Calculate averages
-            const avgSpeed = regionTiles.reduce((sum, t) => sum + (t.avg_d_mbps || 0), 0) / regionTiles.length;
-            const avgLatency = regionTiles.reduce((sum, t) => sum + (t.avg_lat_ms || 0), 0) / regionTiles.length;
+            const measuredSpeeds = regionTiles
+                .map(tile => tile.avg_d_mbps)
+                .filter((speed): speed is number => speed !== null && Number.isFinite(speed));
+            const measuredLatencies = regionTiles
+                .map(tile => tile.avg_lat_ms)
+                .filter((latency): latency is number => latency !== null && Number.isFinite(latency));
+            const avgSpeed = measuredSpeeds.length
+                ? measuredSpeeds.reduce((sum, speed) => sum + speed, 0) / measuredSpeeds.length
+                : null;
+            const avgLatency = measuredLatencies.length
+                ? measuredLatencies.reduce((sum, latency) => sum + latency, 0) / measuredLatencies.length
+                : null;
 
             // Calculate average burden
             let totalBurden = 0;
@@ -164,11 +169,13 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
             const centerLat = (minLat + maxLat) / 2;
             const scenarioCost = getScenarioCost(centerLat, useStarlink);
 
-            const status = getTrafficLightStatus(avgSpeed, avgLatency, avgBurden, scenarioCost);
+            const status = avgSpeed === null || avgLatency === null
+                ? 'GRAY'
+                : getTrafficLightStatus(avgSpeed, avgLatency, avgBurden, scenarioCost);
 
             stats.set(name, {
-                avgSpeed: Math.round(avgSpeed * 10) / 10,
-                avgLatency: Math.round(avgLatency),
+                avgSpeed: avgSpeed === null ? null : Math.round(avgSpeed * 10) / 10,
+                avgLatency: avgLatency === null ? null : Math.round(avgLatency),
                 avgBurden: avgBurden !== null ? Math.round(avgBurden * 10) / 10 : null,
                 tileCount: regionTiles.length,
                 status
@@ -178,9 +185,9 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
         return stats;
     }, [boundaries, tiles, affordabilityData, useStarlink]);
 
-    const styleFeature = (feature: any) => {
-        const name = feature.properties?.CommunityName;
-        const stats = regionStats.get(name);
+    const styleFeature: L.StyleFunction<BoundaryProperties> = feature => {
+        const name = feature?.properties.CommunityName;
+        const stats = name ? regionStats.get(name) : undefined;
         const color = stats ? STATUS_COLORS[stats.status] : STATUS_COLORS.GRAY;
 
         return {
@@ -193,33 +200,34 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
     };
 
     // Event handlers for each feature - use tooltips for hover info
-    const onEachFeature = (feature: BoundaryFeature, layer: L.Layer) => {
+    const onEachFeature: L.GeoJSONOptions<BoundaryProperties, MultiPolygon>['onEachFeature'] = (feature, layer) => {
         const name = feature.properties.CommunityName;
         const stats = regionStats.get(name) || {
-            avgSpeed: 0, avgLatency: 0, avgBurden: null, tileCount: 0, status: 'GRAY' as const
+            avgSpeed: null, avgLatency: null, avgBurden: null, tileCount: 0, status: 'GRAY' as const
         };
         const statusInfo = STATUS_INFO[stats.status];
         const color = STATUS_COLORS[stats.status];
 
         // Bind tooltip for hover info
         const tooltipContent = `
-            <div style="min-width: 200px; font-family: system-ui, sans-serif;">
-                <div style="font-weight: 600; font-size: 13px; margin-bottom: 4px; border-bottom: 2px solid ${color}; padding-bottom: 4px;">
-                    ${name}
+            <div class="region-tooltip-content" style="--tooltip-color:${color}">
+                <div class="region-tooltip-title">
+                    ${escapeHtml(name)}
                 </div>
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 4px; font-size: 11px; margin-bottom: 6px;">
-                    <div>Speed: ${stats.avgSpeed} Mbps</div>
-                    <div>Latency: ${stats.avgLatency} ms</div>
+                <div class="region-tooltip-metrics">
+                    <div>Speed: ${stats.avgSpeed === null ? 'N/A' : `${stats.avgSpeed} Mbps`}</div>
+                    <div>Latency: ${stats.avgLatency === null ? 'N/A' : `${stats.avgLatency} ms`}</div>
                     <div>Burden: ${stats.avgBurden !== null ? stats.avgBurden + '%' : 'N/A'}</div>
                     <div>Data Pts: ${stats.tileCount}</div>
                 </div>
-                <div style="background: ${color}; color: ${stats.status === 'YELLOW' ? '#1f2937' : 'white'}; padding: 4px 8px; border-radius: 4px; text-align: center; font-size: 11px; font-weight: 600;">
-                    ${statusInfo.label}
+                <div class="region-tooltip-status${stats.status === 'YELLOW' ? ' has-dark-text' : ''}">
+                    ${escapeHtml(statusInfo.label)}
                 </div>
             </div>
         `;
 
-        (layer as L.Path).bindTooltip(tooltipContent, {
+        if (!(layer instanceof L.Path)) return;
+        layer.bindTooltip(tooltipContent, {
             sticky: true,
             direction: 'top',
             offset: [0, -10],
@@ -228,17 +236,17 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
 
         layer.on({
             mouseover: (e) => {
-                const layer = e.target;
-                layer.setStyle({
+                const target = e.target as L.Path;
+                target.setStyle({
                     fillOpacity: 0.35,  // Slightly more visible on hover
                     weight: 1,
                     color: '#ffffff'
                 });
-                layer.bringToFront();
+                target.bringToFront();
             },
             mouseout: (e) => {
-                const layer = e.target;
-                layer.setStyle({
+                const target = e.target as L.Path;
+                target.setStyle({
                     fillOpacity: 0.2,   // Back to ghost
                     weight: 0.5,
                     color: 'rgba(255,255,255,0.6)'
@@ -247,33 +255,27 @@ export const ChoroplethLayer: React.FC<ChoroplethLayerProps> = ({
         });
     };
 
-    if (!visible || !boundaries) return null;
+    if (!visible) return null;
+    if (!boundaries) {
+        if (loading) return <div className="map-layer-state" role="status">Loading regional boundaries…</div>;
+        if (error) return <div className="map-layer-state is-error" role="status">{error}</div>;
+        return null;
+    }
 
     return (
         <>
             <GeoJSON
                 key={`choropleth-${boundaries.features.length}-${useStarlink}`}
-                data={boundaries as any}
+                data={boundaries}
                 style={styleFeature}
-                onEachFeature={onEachFeature as any}
+                onEachFeature={onEachFeature}
                 bubblingMouseEvents={false}
             />
 
-            {/* Loading indicator */}
             {loading && (
-                <div style={{
-                    position: 'absolute',
-                    top: 10,
-                    right: 10,
-                    background: 'white',
-                    padding: '8px 12px',
-                    borderRadius: 4,
-                    boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-                    zIndex: 1000
-                }}>
-                    Loading regions...
-                </div>
+                <div className="map-layer-state" role="status">Refreshing regional boundaries…</div>
             )}
+            {error && <div className="map-layer-state is-error" role="status">{error}</div>}
         </>
     );
 };

--- a/frontend/src/components/DataCoveragePanel.css
+++ b/frontend/src/components/DataCoveragePanel.css
@@ -1,49 +1,233 @@
-.data-coverage-hover {
-    position: absolute;
-    left: 20px;
-    bottom: 80px;
-    z-index: 1000;
+.data-coverage-popover {
+  position: absolute;
+  bottom: var(--spacing-6);
+  left: var(--spacing-4);
+  z-index: var(--z-overlay);
 }
 
 .data-coverage-trigger {
-    border: 1px solid rgba(148, 163, 184, 0.75);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.94);
-    color: #1e293b;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.16);
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 800;
-    cursor: help;
+  box-shadow: var(--shadow-md);
 }
 
 .data-coverage-panel {
-    position: absolute;
-    left: 0;
-    bottom: calc(100% + 10px);
-    width: min(280px, calc(100vw - 32px));
-    max-height: min(70vh, 620px);
-    overflow: auto;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-    transition: opacity 0.16s ease, transform 0.16s ease;
+  position: absolute;
+  bottom: calc(100% + var(--spacing-2));
+  left: 0;
+  width: min(300px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-text);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.data-coverage-hover:hover .data-coverage-panel,
-.data-coverage-hover:focus-within .data-coverage-panel {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
+.data-coverage-panel[hidden] {
+  display: none;
+}
+
+.data-coverage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-2);
+}
+
+.data-coverage-header h4 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.data-coverage-header span,
+.data-coverage-source {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-state {
+  padding: var(--spacing-5) 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  text-align: center;
+}
+
+.data-coverage-state--error {
+  color: var(--color-danger);
+}
+
+.data-coverage-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+}
+
+.data-coverage-stats > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-3);
+}
+
+.data-coverage-stats span,
+.data-coverage-stats small {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-stats strong {
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+}
+
+.data-coverage-stat--alert strong,
+.data-coverage-stat--alert small {
+  color: var(--color-danger);
+}
+
+.data-coverage-section {
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-3);
+}
+
+.data-coverage-section h5 {
+  margin-bottom: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.data-coverage-distribution {
+  display: flex;
+  gap: 2px;
+  height: 8px;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-muted);
+}
+
+.data-coverage-distribution span {
+  min-width: 3px;
+}
+
+.data-coverage-distribution .is-high,
+.data-coverage-key .is-high {
+  background: var(--color-status-ready);
+}
+
+.data-coverage-distribution .is-medium,
+.data-coverage-key .is-medium {
+  background: #d97706;
+}
+
+.data-coverage-distribution .is-low,
+.data-coverage-key .is-low {
+  background: var(--color-status-gap);
+}
+
+.data-coverage-key {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-key span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.data-coverage-key i {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.data-coverage-access {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+}
+
+.data-coverage-access div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-2);
+}
+
+.data-coverage-access strong {
+  color: var(--color-text);
+  font-size: var(--font-base);
+}
+
+.data-coverage-access span {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.data-coverage-gaps {
+  display: grid;
+  gap: var(--spacing-1);
+}
+
+.data-coverage-gaps > div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-1);
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+}
+
+.data-coverage-gaps strong {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.data-coverage-gaps strong.is-error {
+  color: var(--color-danger);
+}
+
+.data-coverage-gaps strong.is-warning {
+  color: var(--color-status-anchor);
+}
+
+.data-coverage-source {
+  margin-top: var(--spacing-3);
 }
 
 @media (max-width: 900px) {
-    .data-coverage-hover {
-        left: 12px;
-        bottom: 14px;
-    }
+  .data-coverage-popover {
+    bottom: calc(46vh + var(--spacing-5));
+    left: var(--spacing-3);
+  }
 
-    .data-coverage-panel {
-        max-height: 52vh;
-    }
+  .data-coverage-panel {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 700px) {
+  .data-coverage-panel {
+    max-height: max(140px, calc(54dvh - 214px));
+  }
 }

--- a/frontend/src/components/DataCoveragePanel.tsx
+++ b/frontend/src/components/DataCoveragePanel.tsx
@@ -1,10 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import {
-    DataGapsSummary,
+    type DataGapsSummary,
     fetchDataGapsSummary,
-    getConfidenceColor,
-    getDataGapInfo
 } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+import {
+    DATA_CONFIDENCE_LEVELS,
+    DATA_CONFIDENCE_PRESENTATION,
+    getDataGapPresentation,
+} from '../domain/metrics';
+import Button from './ui/Button';
+import IconButton from './ui/IconButton';
 import './DataCoveragePanel.css';
 
 interface DataCoveragePanelProps {
@@ -13,250 +19,197 @@ interface DataCoveragePanelProps {
     totalRegions?: number;
 }
 
-/**
- * Panel showing data coverage and data gaps summary
- * Supports the 'data coverage/confidence' layer visualization
- */
-export default function DataCoveragePanel({ isExpanded = false, onToggle, totalRegions }: DataCoveragePanelProps) {
+export default function DataCoveragePanel({
+    isExpanded = false,
+    onToggle,
+}: DataCoveragePanelProps) {
     const [summary, setSummary] = useState<DataGapsSummary | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [open, setOpen] = useState(false);
+    const shellRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelId = useId();
 
     useEffect(() => {
+        const controller = new AbortController();
         async function loadData() {
             try {
                 setLoading(true);
-                const data = await fetchDataGapsSummary();
+                const data = await fetchDataGapsSummary(controller.signal);
                 setSummary(data);
                 setError(null);
-            } catch (err) {
-                setError(err instanceof Error ? err.message : 'Failed to load data gaps');
-                console.error('Error loading data gaps:', err);
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to load data gaps'));
+                }
             } finally {
-                setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             }
         }
         loadData();
+        return () => controller.abort();
     }, []);
 
-    const renderShell = (content: React.ReactNode) => (
-        <div className="data-coverage-hover">
-            <button type="button" className="data-coverage-trigger" aria-label="Show data coverage layer legend">
-                Data
-            </button>
-            <div className="data-coverage-panel" style={panelStyle}>
-                {content}
+    useEffect(() => {
+        if (!open) return;
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!shellRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            setOpen(false);
+            triggerRef.current?.focus();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [open]);
+
+    const close = () => {
+        setOpen(false);
+        triggerRef.current?.focus();
+    };
+
+    const totalPlaces = summary?.total_places ?? 0;
+    const gapsPercentage = summary && summary.total_places > 0
+        ? Math.round((summary.places_with_gaps / summary.total_places) * 100)
+        : 0;
+    const satellitePercent = summary && summary.total_places > 0
+        ? Math.round(((summary.primary_access.SATELLITE ?? 0) / summary.total_places) * 100)
+        : null;
+
+    return (
+        <div ref={shellRef} className="data-coverage-popover">
+            <Button
+                ref={triggerRef}
+                size="small"
+                className="data-coverage-trigger"
+                aria-label={open ? 'Close data coverage summary' : 'Open data coverage summary'}
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => setOpen(value => !value)}
+            >
+                Data coverage
+            </Button>
+
+            <div
+                id={panelId}
+                className="data-coverage-panel"
+                role="region"
+                aria-label="Data coverage summary"
+                hidden={!open}
+            >
+                <div className="data-coverage-header">
+                    <div>
+                        <h4>Data Coverage</h4>
+                        <span>Availability and confidence</span>
+                    </div>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        aria-label="Close data coverage summary"
+                        onClick={close}
+                    />
+                </div>
+
+                {loading && <div className="data-coverage-state" role="status">Loading coverage data…</div>}
+
+                {!loading && (error || !summary) && (
+                    <div className="data-coverage-state data-coverage-state--error" role="alert">
+                        {error || 'No data available'}
+                    </div>
+                )}
+
+                {!loading && summary && (
+                    <>
+                        <div className="data-coverage-stats">
+                            <div>
+                                <span>Broadband places</span>
+                                <strong>{totalPlaces}</strong>
+                            </div>
+                            <div className="data-coverage-stat--alert">
+                                <span>With data gaps</span>
+                                <strong>{summary.places_with_gaps}</strong>
+                                <small>{gapsPercentage}% of total</small>
+                            </div>
+                        </div>
+
+                        <section className="data-coverage-section">
+                            <h5>Data confidence</h5>
+                            <div className="data-coverage-distribution" aria-label="Data confidence distribution">
+                                {DATA_CONFIDENCE_LEVELS.map(level => {
+                                    const count = summary.confidence_distribution[level];
+                                    const presentation = DATA_CONFIDENCE_PRESENTATION[level];
+                                    return (
+                                        <span
+                                            key={level}
+                                            className={presentation.className}
+                                            style={{ flex: count, display: count > 0 ? undefined : 'none' }}
+                                            title={`${count} ${presentation.label.toLowerCase()}-confidence places`}
+                                        />
+                                    );
+                                })}
+                            </div>
+                            <div className="data-coverage-key">
+                                {DATA_CONFIDENCE_LEVELS.map(level => {
+                                    const presentation = DATA_CONFIDENCE_PRESENTATION[level];
+                                    return (
+                                        <span key={level}>
+                                            <i className={presentation.className} />
+                                            {presentation.label} {summary.confidence_distribution[level]}
+                                        </span>
+                                    );
+                                })}
+                            </div>
+                        </section>
+
+                        <section className="data-coverage-section">
+                            <h5>Primary internet access</h5>
+                            <div className="data-coverage-access">
+                                <div><strong>{satellitePercent === null ? '—' : `${satellitePercent}%`}</strong><span>Satellite</span></div>
+                                <div><strong>{satellitePercent === null ? '—' : `${100 - satellitePercent}%`}</strong><span>Wired or other</span></div>
+                            </div>
+                        </section>
+
+                        {(isExpanded || !onToggle) && (
+                            <section className="data-coverage-section">
+                                <h5>Most common gap types</h5>
+                                <div className="data-coverage-gaps">
+                                    {Object.entries(summary.gap_breakdown)
+                                        .filter(([, data]) => data.count > 0)
+                                        .sort(([, a], [, b]) => b.count - a.count)
+                                        .slice(0, 5)
+                                        .map(([gapType, data]) => {
+                                            const info = getDataGapPresentation(gapType);
+                                            return (
+                                                <div key={gapType}>
+                                                    <span>{info.label}</span>
+                                                    <strong className={`is-${info.severity}`}>
+                                                        {data.count} ({data.percentage}%)
+                                                    </strong>
+                                                </div>
+                                            );
+                                        })}
+                                </div>
+                            </section>
+                        )}
+
+                        {onToggle && (
+                            <Button size="small" variant="ghost" onClick={onToggle}>
+                                {isExpanded ? 'Show less detail' : 'Show more detail'}
+                            </Button>
+                        )}
+
+                        <div className="data-coverage-source">Source: FCC Broadband Availability</div>
+                    </>
+                )}
             </div>
         </div>
     );
-
-    if (loading) {
-        return renderShell(
-            <>
-                <div style={{ padding: '24px 24px 8px 24px', fontSize: '16px', fontWeight: '500', color: '#181d26' }}>
-                    <span>Data Coverage Layer</span>
-                </div>
-                <div style={{ padding: '8px 24px 24px 24px', fontSize: '12px', color: '#41454d' }}>
-                    Loading...
-                </div>
-            </>
-        );
-    }
-
-    if (error || !summary) {
-        return renderShell(
-            <>
-                <div style={{ padding: '24px 24px 8px 24px', fontSize: '16px', fontWeight: '500', color: '#181d26' }}>
-                    <span>Data Coverage Layer</span>
-                </div>
-                <div style={{ padding: '8px 24px 24px 24px', fontSize: '12px', color: '#dc2626' }}>
-                    {error || 'No data available'}
-                </div>
-            </>
-        );
-    }
-
-    const gapsPercentage = Math.round((summary.places_with_gaps / summary.total_places) * 100);
-    const satellitePercent = Math.round((summary.primary_access.SATELLITE / summary.total_places) * 100);
-
-    return renderShell(
-        <>
-            {/* Header */}
-            <div
-                style={{
-                    padding: '24px 24px 8px 24px',
-                    fontSize: '16px',
-                    fontWeight: '500',
-                    color: '#181d26',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    cursor: onToggle ? 'pointer' : 'default'
-                }}
-                onClick={onToggle}
-            >
-                <span>Data Coverage Layer</span>
-                {onToggle && (
-                    <span style={{ fontSize: '10px', marginLeft: '8px', color: '#9297a0' }}>
-                        {isExpanded ? '▼' : '▶'}
-                    </span>
-                )}
-            </div>
-
-            {/* Quick Stats */}
-            <div style={{ padding: '8px 24px 16px 24px' }}>
-                <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: '1fr 1fr',
-                    gap: '16px'
-                }}>
-                    <div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginBottom: '4px' }}>Total Places</div>
-                        <div style={{ fontWeight: '400', fontSize: '24px', color: '#181d26', letterSpacing: '-0.02em' }}>
-                            {summary.total_places}
-                        </div>
-                    </div>
-                    <div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginBottom: '4px' }}>With Data Gaps</div>
-                        <div style={{ fontWeight: '400', fontSize: '24px', color: '#aa2d00', letterSpacing: '-0.02em' }}>
-                            {summary.places_with_gaps} <span style={{ fontSize: '13px', fontWeight: '400', color: '#aa2d00' }}>({gapsPercentage}%)</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            {/* Confidence Distribution */}
-            <div style={{ padding: '16px 24px' }}>
-                <div style={{ fontSize: '12px', color: '#181d26', marginBottom: '12px', fontWeight: '500' }}>
-                    Data Confidence
-                </div>
-                <div style={{ display: 'flex', gap: '2px', height: '8px', borderRadius: '4px', overflow: 'hidden' }}>
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.HIGH,
-                            backgroundColor: '#006400',
-                            minWidth: summary.confidence_distribution.HIGH > 0 ? '4px' : '0'
-                        }}
-                    />
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.MEDIUM,
-                            backgroundColor: '#f4d35e',
-                            minWidth: summary.confidence_distribution.MEDIUM > 0 ? '4px' : '0'
-                        }}
-                    />
-                    <div
-                        style={{
-                            flex: summary.confidence_distribution.LOW,
-                            backgroundColor: '#aa2d00',
-                            minWidth: summary.confidence_distribution.LOW > 0 ? '4px' : '0'
-                        }}
-                    />
-                </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '10px', fontSize: '11px', color: '#41454d' }}>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#006400' }} />
-                        High
-                    </span>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#f4d35e' }} />
-                        Med
-                    </span>
-                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ width: '8px', height: '8px', borderRadius: '2px', backgroundColor: '#aa2d00' }} />
-                        Low
-                    </span>
-                </div>
-            </div>
-
-            {/* Primary Access Type */}
-            <div style={{ padding: '16px 24px' }}>
-                <div style={{ fontSize: '12px', color: '#181d26', marginBottom: '12px', fontWeight: '500' }}>
-                    Primary Internet Access
-                </div>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                    <div style={{
-                        flex: 1,
-                        padding: '12px',
-                        borderRadius: '6px',
-                        backgroundColor: '#f8fafc',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center'
-                    }}>
-                        <div style={{ fontWeight: '400', color: '#181d26', fontSize: '18px' }}>{satellitePercent}%</div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginTop: '4px' }}>Satellite</div>
-                    </div>
-                    <div style={{
-                        flex: 1,
-                        padding: '12px',
-                        borderRadius: '6px',
-                        backgroundColor: '#f8fafc',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center'
-                    }}>
-                        <div style={{ fontWeight: '400', color: '#181d26', fontSize: '18px' }}>{100 - satellitePercent}%</div>
-                        <div style={{ color: '#41454d', fontSize: '12px', marginTop: '4px' }}>Wired</div>
-                    </div>
-                </div>
-            </div>
-
-            {/* Expanded: Gap Breakdown */}
-            {(isExpanded || !onToggle) && (
-                <div style={{ padding: '10px 12px' }}>
-                    <div style={{ fontSize: '11px', color: '#6b7280', marginBottom: '6px', fontWeight: '600' }}>
-                        Data Gap Types
-                    </div>
-                    {Object.entries(summary.gap_breakdown)
-                        .filter(([_, data]) => data.count > 0)
-                        .sort(([_, a], [__, b]) => b.count - a.count)
-                        .slice(0, 5)
-                        .map(([gapType, data]) => {
-                            const info = getDataGapInfo(gapType);
-                            return (
-                                <div key={gapType} style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    padding: '4px 0',
-                                    fontSize: '11px',
-                                    borderBottom: '1px solid #f3f4f6'
-                                }}>
-                                    <span>{info.label}</span>
-                                    <span style={{
-                                        color: info.severity === 'error' ? '#dc2626' :
-                                            info.severity === 'warning' ? '#f97316' : '#6b7280',
-                                        fontWeight: '500'
-                                    }}>
-                                        {data.count} ({data.percentage}%)
-                                    </span>
-                                </div>
-                            );
-                        })}
-                </div>
-            )}
-
-            {/* Footer Note */}
-            <div style={{
-                padding: '16px 24px 24px 24px',
-                fontSize: '11px',
-                color: '#9297a0'
-            }}>
-                Data source: FCC Broadband Availability
-            </div>
-        </>
-    );
 }
-
-// Airtable Styles (Flat Canvas, Hairline Border)
-const panelStyle: React.CSSProperties = {
-    minWidth: '240px',
-    maxWidth: '280px',
-    background: '#ffffff',
-    borderRadius: '10px',
-    border: '1px solid #dddddd',
-    fontSize: '13px',
-    overflow: 'hidden',
-    fontFamily: 'inherit'
-};

--- a/frontend/src/components/Legend.css
+++ b/frontend/src/components/Legend.css
@@ -1,216 +1,174 @@
-.legend-hover-shell {
-    position: absolute;
-    right: 20px;
-    bottom: 80px;
-    z-index: 1000;
+.legend-popover {
+  position: absolute;
+  right: var(--spacing-4);
+  bottom: var(--spacing-6);
+  z-index: var(--z-overlay);
 }
 
-.legend-hover-shell-left {
-    right: auto;
-    left: 20px;
+.legend-popover--left {
+  right: auto;
+  left: var(--spacing-4);
 }
 
 .legend-trigger {
-    border: 1px solid rgba(148, 163, 184, 0.75);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.94);
-    color: #1e293b;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.16);
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 800;
-    cursor: help;
+  box-shadow: var(--shadow-md);
 }
 
 .legend-panel {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 10px);
-    width: min(320px, calc(100vw - 32px));
-    max-height: min(70vh, 620px);
-    overflow: auto;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-    transition: opacity 0.16s ease, transform 0.16s ease;
-    background: rgba(255, 255, 255, 0.94);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    padding: 16px 18px;
-    border-radius: 12px;
-    border: 1px solid rgba(203, 213, 225, 0.9);
-    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.18);
-    font-size: 12px;
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + var(--spacing-2));
+  width: min(320px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-text);
+  font-size: var(--font-xs);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.legend-hover-shell-left .legend-panel {
-    right: auto;
-    left: 0;
+.legend-panel[hidden] {
+  display: none;
 }
 
-.legend-hover-shell:hover .legend-panel,
-.legend-hover-shell:focus-within .legend-panel {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    transform: translateY(0);
+.legend-popover--left .legend-panel {
+  right: auto;
+  left: 0;
 }
 
 .legend-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 12px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-2);
 }
 
 .legend-header h4 {
-    margin: 0;
-    color: #0f172a;
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0;
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  font-weight: 700;
 }
 
 .legend-header span {
-    color: #64748b;
-    font-size: 10px;
-    font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 600;
 }
 
 .legend-section {
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid #e5e7eb;
-    display: grid;
-    gap: 8px;
+  display: grid;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-3);
 }
 
 .legend-section-title {
-    color: #334155;
-    font-weight: 800;
-    margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-weight: 700;
 }
 
 .legend-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    margin-bottom: 8px;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .legend-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    margin-top: 3px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  margin-top: 3px;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xs);
 }
 
 .legend-row-label {
-    color: #1e293b;
-    font-weight: 600;
+  color: var(--color-text);
+  font-weight: 600;
 }
 
 .legend-row-note,
 .legend-copy {
-    color: #64748b;
-    font-size: 11px;
-    line-height: 1.4;
-}
-
-.legend-copy {
-    color: #475569;
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+  line-height: 1.4;
 }
 
 .legend-tier-list {
-    display: grid;
-    gap: 6px;
-    color: #475569;
-    font-size: 11px;
-    line-height: 1.4;
+  display: grid;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.4;
 }
 
 .legend-tier-list strong {
-    color: #1e293b;
-}
-
-.legend-chip-row {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-}
-
-.legend-chip {
-    border-radius: 999px;
-    padding: 3px 7px;
-    font-size: 10px;
-    font-weight: 800;
-}
-
-.legend-chip.high {
-    background: #dcfce7;
-    color: #166534;
-}
-
-.legend-chip.low {
-    background: #fef3c7;
-    color: #92400e;
-}
-
-.legend-chip.missing {
-    background: #fee2e2;
-    color: #b91c1c;
+  color: var(--color-text);
 }
 
 .legend-footer-row {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid #e5e7eb;
-    color: #64748b;
-    display: flex;
-    justify-content: space-between;
-    font-size: 10px;
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
 }
 
 .legend-footer-row strong {
-    color: #334155;
+  color: var(--color-text-secondary);
 }
 
 .legend-scale {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid #e5e7eb;
+  margin-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
 }
 
 .legend-gradient {
-    height: 6px;
-    border-radius: 3px;
-    margin-bottom: 4px;
+  height: 6px;
+  margin-bottom: var(--spacing-1);
+  border-radius: var(--radius-full);
 }
 
 .legend-scale-labels {
-    display: flex;
-    justify-content: space-between;
-    color: #94a3b8;
-    font-size: 9px;
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
 }
 
 @media (max-width: 900px) {
-    .legend-hover-shell {
-        right: 12px;
-        bottom: 14px;
-    }
+  .legend-popover {
+    right: var(--spacing-3);
+    bottom: calc(46vh + var(--spacing-5));
+  }
 
-    .legend-hover-shell-left {
-        right: auto;
-        left: 12px;
-    }
+  .legend-popover--left {
+    right: auto;
+    left: var(--spacing-3);
+  }
 
-    .legend-panel {
-        max-height: 52vh;
-    }
+  .legend-panel {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 700px) {
+  .legend-panel {
+    max-height: max(140px, calc(54dvh - 214px));
+  }
 }

--- a/frontend/src/components/Legend.test.tsx
+++ b/frontend/src/components/Legend.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import Legend from './Legend';
 
@@ -25,5 +25,21 @@ describe('Legend', () => {
 
         expect(screen.getByLabelText(/Healthcare Desert Score: A 0-100 need score/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/CAT Tier: Community Access Tier summarizes/i)).toBeInTheDocument();
+    });
+
+    it('opens on click and closes with Escape', () => {
+        render(<Legend />);
+
+        const trigger = screen.getByRole('button', { name: 'Open discovery legend' });
+        const panel = document.querySelector('[role="region"][aria-label="Discovery legend"]') as HTMLElement;
+        expect(panel).not.toBeVisible();
+
+        fireEvent.click(trigger);
+        expect(panel).toBeVisible();
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(panel).not.toBeVisible();
+        expect(trigger).toHaveFocus();
     });
 });

--- a/frontend/src/components/Legend.tsx
+++ b/frontend/src/components/Legend.tsx
@@ -1,6 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { getNeedColor, getNeedLabel } from '../api/catApi';
+import { useEffect, useId, useRef, useState } from 'react';
+import {
+    CAT_TIERS,
+    CAT_TIER_PRESENTATION,
+    getDesertScorePresentation,
+} from '../domain/metrics';
 import MetricTooltip from './MetricTooltip';
+import Button from './ui/Button';
+import IconButton from './ui/IconButton';
 import './Legend.css';
 
 interface LegendProps {
@@ -8,26 +14,71 @@ interface LegendProps {
     position?: 'bottom-right' | 'bottom-left';
 }
 
-const getNeedCapability = (score: number): string => {
-    if (score >= 75) return 'Severe lack of nearby healthcare facilities';
-    if (score >= 50) return 'Limited access to clinics or hospitals';
-    if (score >= 25) return 'Adequate access with some travel distance';
-    return 'Good access to nearby healthcare facilities';
-};
-
 export default function Legend({ totalRegions, position = 'bottom-right' }: LegendProps) {
     const needLevels = [87, 62, 37, 12];
+    const [open, setOpen] = useState(false);
+    const shellRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelId = useId();
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!shellRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            setOpen(false);
+            triggerRef.current?.focus();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [open]);
 
     return (
-        <div className={`legend-hover-shell ${position === 'bottom-left' ? 'legend-hover-shell-left' : ''}`}>
-            <button type="button" className="legend-trigger" aria-label="Show discovery legend">
+        <div
+            ref={shellRef}
+            className={`legend-popover ${position === 'bottom-left' ? 'legend-popover--left' : ''}`}
+        >
+            <Button
+                ref={triggerRef}
+                size="small"
+                className="legend-trigger"
+                aria-label={open ? 'Close discovery legend' : 'Open discovery legend'}
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => setOpen(value => !value)}
+            >
                 Legend
-            </button>
+            </Button>
 
-            <div className="legend-panel">
+            <div
+                id={panelId}
+                className="legend-panel"
+                role="region"
+                aria-label="Discovery legend"
+                hidden={!open}
+            >
                 <div className="legend-header">
-                    <h4>Discovery Legend</h4>
-                    <span>Plain-language guide</span>
+                    <div>
+                        <h4>Discovery Legend</h4>
+                        <span>Plain-language guide</span>
+                    </div>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        aria-label="Close discovery legend"
+                        onClick={() => {
+                            setOpen(false);
+                            triggerRef.current?.focus();
+                        }}
+                    />
                 </div>
 
                 <div className="legend-section-title">
@@ -37,19 +88,22 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                     </MetricTooltip>
                 </div>
 
-                {needLevels.map(score => (
-                    <div key={score} className="legend-row">
-                        <span
-                            className="legend-dot"
-                            style={{ backgroundColor: getNeedColor(score) }}
-                            aria-hidden="true"
-                        />
-                        <div>
-                            <div className="legend-row-label">{getNeedLabel(score)}</div>
-                            <div className="legend-row-note">{getNeedCapability(score)}</div>
+                {needLevels.map(score => {
+                    const presentation = getDesertScorePresentation(score);
+                    return (
+                        <div key={score} className="legend-row">
+                            <span
+                                className="legend-dot"
+                                style={{ backgroundColor: presentation.color }}
+                                aria-hidden="true"
+                            />
+                            <div>
+                                <div className="legend-row-label">{presentation.label}</div>
+                                <div className="legend-row-note">{presentation.description}</div>
+                            </div>
                         </div>
-                    </div>
-                ))}
+                    );
+                })}
 
                 <div className="legend-section">
                     <div className="legend-section-title">
@@ -59,10 +113,11 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                         </MetricTooltip>
                     </div>
                     <div className="legend-tier-list">
-                        <div><strong>Tier 1:</strong> strongest access; road-connected or easier service reach.</div>
-                        <div><strong>Tier 2:</strong> moderate access; some travel or logistics constraints.</div>
-                        <div><strong>Tier 3:</strong> limited access; remote travel makes care harder to reach.</div>
-                        <div><strong>Tier 4:</strong> most isolated; highest transport and service-access barriers.</div>
+                        {CAT_TIERS.map(tier => (
+                            <div key={tier}>
+                                <strong>Tier {tier}:</strong> {CAT_TIER_PRESENTATION[tier].shortDescription}
+                            </div>
+                        ))}
                     </div>
                 </div>
 
@@ -77,7 +132,7 @@ export default function Legend({ totalRegions, position = 'bottom-right' }: Lege
                     <div
                         className="legend-gradient"
                         style={{
-                            background: `linear-gradient(to right, ${getNeedColor(12)}, ${getNeedColor(37)}, ${getNeedColor(62)}, ${getNeedColor(87)})`,
+                            background: `linear-gradient(to right, ${needLevels.slice().reverse().map(score => getDesertScorePresentation(score).color).join(', ')})`,
                         }}
                     />
                     <div className="legend-scale-labels">

--- a/frontend/src/components/MapModeLegends.css
+++ b/frontend/src/components/MapModeLegends.css
@@ -1,0 +1,120 @@
+.affordability-legend,
+.scenario-legend {
+  position: absolute;
+  bottom: var(--spacing-6);
+  left: var(--spacing-4);
+  z-index: var(--z-overlay);
+}
+
+.telehealth-access-popup {
+  min-width: 210px;
+  max-width: 236px;
+  color: var(--color-text);
+  font-size: 12px;
+}
+
+.telehealth-access-popup__title {
+  margin: 0 0 2px;
+  color: var(--color-text);
+  font-size: 15px;
+  line-height: 1.2;
+}
+
+.telehealth-access-popup__code {
+  margin-bottom: 9px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.telehealth-access-popup__status {
+  margin-bottom: 10px;
+}
+
+.telehealth-access-popup__button {
+  width: 100%;
+}
+
+.affordability-legend {
+  min-width: 220px;
+  padding: 16px 18px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  box-shadow: var(--shadow-md);
+  font-size: 12px;
+  backdrop-filter: blur(12px);
+}
+
+.affordability-legend__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.affordability-legend__title {
+  color: var(--color-text);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.affordability-legend__kicker,
+.affordability-legend__count,
+.affordability-legend__note {
+  color: var(--color-text-muted);
+  font-size: 10px;
+}
+
+.affordability-legend__kicker {
+  font-weight: 500;
+}
+
+.affordability-legend__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.affordability-legend__swatch {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  margin-top: 3px;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xs);
+}
+
+.affordability-legend__content {
+  flex: 1;
+}
+
+.affordability-legend__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.affordability-legend__label {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.affordability-legend__count {
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .affordability-legend,
+  .scenario-legend {
+    bottom: calc(46vh + var(--spacing-5));
+    bottom: calc(46dvh + var(--spacing-5));
+    left: var(--spacing-3);
+    max-height: 38vh;
+    overflow: auto;
+  }
+}

--- a/frontend/src/components/MetricTooltip.css
+++ b/frontend/src/components/MetricTooltip.css
@@ -7,10 +7,10 @@
 .metric-tooltip-trigger {
     width: 16px;
     height: 16px;
-    border: 1px solid #94a3b8;
-    border-radius: 50%;
-    background: #ffffff;
-    color: #475569;
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-full);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
     font-size: 10px;
     font-weight: 800;
     line-height: 1;
@@ -19,13 +19,13 @@
 
 .metric-tooltip-panel {
     position: fixed;
-    z-index: 2500;
+    z-index: var(--z-tooltip);
     width: min(260px, calc(100vw - 24px));
-    border: 1px solid #cbd5e1;
-    border-radius: 8px;
-    background: #ffffff;
-    color: #334155;
-    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.18);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    box-shadow: var(--shadow-lg);
     padding: 10px;
     font-size: 11px;
     line-height: 1.45;
@@ -35,7 +35,7 @@
 .metric-tooltip-panel strong {
     display: block;
     margin-bottom: 3px;
-    color: #0f172a;
+    color: var(--color-text);
     font-size: 12px;
 }
 

--- a/frontend/src/components/MetricTooltip.tsx
+++ b/frontend/src/components/MetricTooltip.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './MetricTooltip.css';
 
@@ -9,6 +9,7 @@ interface MetricTooltipProps {
 
 export default function MetricTooltip({ term, children }: MetricTooltipProps) {
     const triggerRef = useRef<HTMLButtonElement | null>(null);
+    const tooltipId = useId();
     const [open, setOpen] = useState(false);
     const [placement, setPlacement] = useState<'above' | 'below'>('above');
     const [position, setPosition] = useState({ top: 0, left: 0 });
@@ -52,6 +53,7 @@ export default function MetricTooltip({ term, children }: MetricTooltipProps) {
     const tooltipPanel = open
         ? createPortal(
             <span
+                id={tooltipId}
                 className={`metric-tooltip-panel ${placement}`}
                 role="tooltip"
                 style={position}
@@ -74,8 +76,12 @@ export default function MetricTooltip({ term, children }: MetricTooltipProps) {
                 type="button"
                 className="metric-tooltip-trigger"
                 aria-label={`${term}: ${children}`}
+                aria-describedby={open ? tooltipId : undefined}
                 onFocus={showTooltip}
                 onBlur={() => setOpen(false)}
+                onKeyDown={event => {
+                    if (event.key === 'Escape') setOpen(false);
+                }}
             >
                 i
             </button>

--- a/frontend/src/components/PerformanceLayer.css
+++ b/frontend/src/components/PerformanceLayer.css
@@ -1,0 +1,160 @@
+.performance-control-panel {
+  position: absolute;
+  top: 90px;
+  left: 60px;
+  z-index: var(--z-overlay);
+  width: 280px;
+  max-height: calc(100vh - 130px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  box-shadow: var(--shadow-md);
+  font-size: 13px;
+  backdrop-filter: blur(12px);
+}
+
+.performance-control-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-surface-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.performance-control-settings {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.performance-control-kicker {
+  margin-bottom: 4px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.performance-control-select {
+  width: 100%;
+  margin-bottom: 10px;
+  padding: 6px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.performance-control-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.performance-control-toggle.is-spaced {
+  margin-top: 8px;
+}
+
+.performance-control-toggle input.is-blue {
+  accent-color: #3b82f6;
+}
+
+.performance-control-toggle input.is-green {
+  accent-color: #10b981;
+}
+
+.performance-legend {
+  padding: 10px 12px;
+  font-size: 11px;
+}
+
+.performance-legend__title {
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.performance-legend-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.performance-legend-swatch {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  margin-top: 2px;
+  border: 0;
+  border-radius: 50%;
+}
+
+.performance-legend-swatch.has-border {
+  border-width: 2px;
+  border-style: solid;
+}
+
+.performance-legend-label {
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.performance-legend-note {
+  color: var(--color-text-muted);
+  font-size: 10px;
+}
+
+.performance-control-footer {
+  padding: 6px 12px;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+  font-size: 9px;
+}
+
+.performance-control-state {
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-primary-subtle);
+  padding: var(--spacing-2) var(--spacing-3);
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.performance-control-state.is-error {
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+}
+
+.performance-control-state.is-warning {
+  background: var(--color-status-anchor-subtle);
+  color: #92400e;
+}
+
+@media (max-width: 1200px) {
+  .performance-control-panel {
+    left: var(--spacing-4);
+  }
+}
+
+@media (max-width: 700px) {
+  .performance-control-panel {
+    top: 206px;
+    right: var(--spacing-3);
+    left: 60px;
+    width: auto;
+    min-height: 150px;
+    max-height: calc(54vh - 222px);
+    max-height: calc(54dvh - 222px);
+  }
+}

--- a/frontend/src/components/PerformanceLayer.tsx
+++ b/frontend/src/components/PerformanceLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useMemo } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { useMap, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import { ChoroplethLayer } from './ChoroplethLayer';
@@ -9,20 +9,24 @@ import {
     fetchPerformance,
     fetchAffordability
 } from '../api/catApi';
-import { getScenarioCost, getTrafficLightStatus, AFFORDABILITY_BURDEN_THRESHOLD } from '../utils/trafficLight';
+import { errorMessage, isAbortError } from '../api/http';
+import { escapeHtml } from '../utils/escapeHtml';
+import { getScenarioCost, getTrafficLightStatus } from '../utils/trafficLight';
+import IconButton from './ui/IconButton';
+import './PerformanceLayer.css';
 
 interface PerformanceLayerProps {
     visible: boolean;
     onToggle: () => void;
-    onModeChange?: (isGapMode: boolean) => void;
 }
 
 const DETAIL_ZOOM_THRESHOLD = 8;
 
-export default function PerformanceLayer({ visible, onToggle, onModeChange }: PerformanceLayerProps) {
+export default function PerformanceLayer({ visible, onToggle }: PerformanceLayerProps) {
     const [tiles, setTiles] = useState<PerformanceTile[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [partialWarning, setPartialWarning] = useState<string | null>(null);
     const [zoomLevel, setZoomLevel] = useState(5);
 
     // UI State for Filters
@@ -46,7 +50,9 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
 
     useEffect(() => {
         if (visible) {
-            loadData();
+            const controller = new AbortController();
+            loadData(controller.signal);
+            return () => controller.abort();
         } else {
             if (canvasLayerRef.current) {
                 canvasLayerRef.current.clearLayers();
@@ -54,14 +60,8 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
         }
     }, [visible]);
 
-    useEffect(() => {
-        if (onModeChange) {
-            onModeChange(visible);
-        }
-    }, [visible, onModeChange]);
-
     const getScenarioBurden = (afford: AffordabilityZone | undefined, lat: number): number | null => {
-        if (!afford || !afford.monthly_income || afford.monthly_income <= 0) return null;
+        if (!afford || afford.monthly_income <= 0) return null;
         const cost = getScenarioCost(lat, useStarlink);
         return (cost / afford.monthly_income) * 100;
     };
@@ -72,7 +72,7 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
         let minDist = Infinity;
         const MAX_DIST_DEG = 0.2;
         for (const zone of affordabilityData) {
-            if (!zone.lat || !zone.lon) continue;
+            if (zone.lat === null || zone.lon === null) continue;
             const dLat = zone.lat - lat;
             const dLon = zone.lon - lon;
             const distSq = dLat * dLat + dLon * dLon;
@@ -91,13 +91,14 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
         burden: number | null,
         scenarioCost: number
     ): 'RED' | 'ORANGE' | 'YELLOW' | 'GREEN' | 'GRAY' => {
-        return getTrafficLightStatus(tile.avg_d_mbps || 0, tile.avg_lat_ms || 0, burden, scenarioCost);
+        if (tile.avg_d_mbps === null || tile.avg_lat_ms === null || burden === null) return 'GRAY';
+        return getTrafficLightStatus(tile.avg_d_mbps, tile.avg_lat_ms, burden, scenarioCost);
     };
 
 
     const visibleTiles = useMemo(() => {
         return tiles.filter(t => {
-            if (!t.lat || !t.lon) return false;
+            if (!Number.isFinite(t.lat) || !Number.isFinite(t.lon)) return false;
             // Basic Bounds Check (Alaska)
             if (t.lat >= 59 && t.lat <= 61 && t.lon >= -134 && t.lon <= -130) return false; // BC Border
             return true;
@@ -111,20 +112,34 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
         }
     }, [visible, visibleTiles, zoomLevel, useStarlink, affordabilityData, filterMode]); // Dependencies updated
 
-    async function loadData() {
+    async function loadData(signal: AbortSignal) {
         try {
             setLoading(true);
             setError(null);
-            const [perfData, affordData] = await Promise.all([
-                fetchPerformance(),
-                fetchAffordability().catch(() => ({ zones: [] }))
+            setPartialWarning(null);
+            const [performanceResult, affordabilityResult] = await Promise.allSettled([
+                fetchPerformance(undefined, undefined, 1, signal),
+                fetchAffordability(120, 2, signal),
             ]);
-            setTiles(perfData.tiles);
-            setAffordabilityData(affordData.zones);
-        } catch (err) {
-            setError(err instanceof Error ? err.message : 'Failed to load data');
+            if (signal.aborted) return;
+            if (performanceResult.status === 'rejected') {
+                throw performanceResult.reason;
+            }
+            setTiles(performanceResult.value.tiles);
+            if (affordabilityResult.status === 'fulfilled') {
+                setAffordabilityData(affordabilityResult.value.zones);
+            } else {
+                setAffordabilityData([]);
+                setPartialWarning(
+                    errorMessage(affordabilityResult.reason, 'Affordability data unavailable'),
+                );
+            }
+        } catch (caught: unknown) {
+            if (!isAbortError(caught)) {
+                setError(errorMessage(caught, 'Failed to load data'));
+            }
         } finally {
-            setLoading(false);
+            if (!signal.aborted) setLoading(false);
         }
     }
 
@@ -139,7 +154,7 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
         const isDetailView = zoomLevel >= DETAIL_ZOOM_THRESHOLD;
 
         tilesToRender.forEach(tile => {
-            if (!tile.lat || !tile.lon) return;
+            if (!Number.isFinite(tile.lat) || !Number.isFinite(tile.lon)) return;
 
             const afford = getAffordabilityForTile(tile.lat, tile.lon);
             const scenarioCost = getScenarioCost(tile.lat, useStarlink);
@@ -147,14 +162,12 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
 
             let markerColor = '#ccc';
             let markerRadius = isDetailView ? 6 : Math.min(20, Math.max(4, (tile.tests / 5)));
-            let showTile = true;
-
             // --- FILTER LOGIC ---
             if (filterMode === 'affordability') {
                 const isRuralTier = scenarioCost >= 400;
 
                 if (burdenPct === null) {
-                    markerColor = isRuralTier ? '#f97316' : '#94a3b8';
+                    markerColor = '#94a3b8';
                     markerRadius = 4;
                 } else if (isRuralTier) {
                     if (burdenPct >= 2) {
@@ -178,8 +191,11 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
                 }
 
             } else if (filterMode === 'latency') {
-                const lat = tile.avg_lat_ms || 0;
-                if (lat < 50) {
+                const lat = tile.avg_lat_ms;
+                if (lat === null) {
+                    markerColor = '#94a3b8';
+                    markerRadius = 4;
+                } else if (lat < 50) {
                     markerColor = '#10B981'; // Emerald
                     markerRadius = 3;        // Small for good
                 } else if (lat < 150) {
@@ -228,29 +244,28 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
             });
 
             // Build Popup
-            const latencyDisplay = tile.avg_lat_ms ? `${tile.avg_lat_ms.toFixed(0)} ms` : 'N/A';
-            const costDisplay = burdenPct ? `${burdenPct.toFixed(1)}%` : 'N/A';
+            const latencyDisplay = tile.avg_lat_ms !== null ? `${tile.avg_lat_ms.toFixed(0)} ms` : 'N/A';
+            const costDisplay = burdenPct !== null ? `${burdenPct.toFixed(1)}%` : 'N/A';
+            const speedDisplay = tile.avg_d_mbps !== null ? `${tile.avg_d_mbps.toFixed(1)} Mbps` : 'N/A';
             const status = getTrafficLightStatusForTile(tile, burdenPct, scenarioCost);
 
-            let capabilityLabel = "";
+            let capabilityLabel = "Insufficient Data";
             if (status === 'RED') capabilityLabel = "Async / Text Only";
             else if (status === 'ORANGE') capabilityLabel = "Expensive Infrastructure";
             else if (status === 'YELLOW') capabilityLabel = "Audio / Low-Res Video";
             else if (status === 'GREEN') capabilityLabel = "HD Video Ready";
 
             marker.bindPopup(`
-                <div style="min-width: 200px; font-family: sans-serif;">
-                    <div style="margin-bottom: 8px; font-weight: bold; color: ${markerColor}">
-                        ${filterMode === 'combined' ? capabilityLabel : 'Location Details'}
+                <div class="performance-popup" style="--popup-color:${markerColor}">
+                    <div class="performance-popup__title">
+                        ${escapeHtml(filterMode === 'combined' ? capabilityLabel : 'Location Details')}
                     </div>
-                    
-                    <div style="background: #f3f4f6; padding: 6px; border-radius: 4px; margin-bottom: 8px; font-size: 11px;">
-                         <div><strong>Latency:</strong> ${latencyDisplay}</div>
-                         <div><strong>Burden:</strong> ${costDisplay} of Income</div>
-                         <div><strong>Speed:</strong> ${tile.avg_d_mbps?.toFixed(1) ?? 'N/A'} Mbps</div>
+                    <div class="performance-popup__metrics">
+                         <div><strong>Latency:</strong> ${escapeHtml(latencyDisplay)}</div>
+                         <div><strong>Burden:</strong> ${escapeHtml(costDisplay)} of Income</div>
+                         <div><strong>Speed:</strong> ${escapeHtml(speedDisplay)}</div>
                     </div>
-
-                    <div style="font-size: 10px; color: #6b7280;">
+                    <div class="performance-popup__source">
                          Generated by Gap Hunter v2
                     </div>
                 </div>
@@ -267,30 +282,35 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
 
     return (
         <>
-            <div style={panelStyle}>
+            <div className="performance-control-panel">
                 {/* Header */}
-                <div style={headerStyle} onClick={onToggle}>
+                <div className="performance-control-header">
                     <span>Gap Hunter</span>
-                    <span style={{ fontSize: '10px', cursor: 'pointer' }}>✕</span>
+                    <IconButton
+                        icon="×"
+                        size="small"
+                        onClick={onToggle}
+                        aria-label="Close Gap Hunter"
+                    />
                 </div>
 
+                {loading && <div className="performance-control-state" role="status">Loading measured performance…</div>}
+                {error && <div className="performance-control-state is-error" role="alert">{error}</div>}
+                {partialWarning && (
+                    <div className="performance-control-state is-warning" role="status">
+                        Affordability inputs unavailable; affected locations are shown as insufficient data.
+                    </div>
+                )}
+
                 {/* Filter Dropdown */}
-                <div style={{ padding: '10px 12px', background: '#f8fafc', borderBottom: '1px solid #e2e8f0' }}>
-                    <div style={{ fontSize: '11px', fontWeight: '600', color: '#64748b', marginBottom: '4px' }}>
+                <div className="performance-control-settings">
+                    <div className="performance-control-kicker">
                         ACTIVE LAYER
                     </div>
                     <select
                         value={filterMode}
                         onChange={(e) => setFilterMode(e.target.value as PerformanceFilterType)}
-                        style={{
-                            width: '100%',
-                            padding: '6px',
-                            borderRadius: '4px',
-                            border: '1px solid #cbd5e1',
-                            fontSize: '12px',
-                            marginBottom: '10px',
-                            cursor: 'pointer'
-                        }}
+                        className="performance-control-select"
                     >
                         <option value="combined">Combined Feasibility (Master)</option>
                         <option value="affordability">Affordability Cost/Income</option>
@@ -298,31 +318,31 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
                     </select>
 
                     {/* Starlink Toggle */}
-                    <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '12px' }}>
+                    <label className="performance-control-toggle">
                         <input
                             type="checkbox"
                             checked={useStarlink}
                             onChange={(e) => setUseStarlink(e.target.checked)}
-                            style={{ accentColor: '#3b82f6' }}
+                            className="is-blue"
                         />
                         <span>Simulate Starlink LEO ($120/mo)</span>
                     </label>
 
                     {/* Region Toggle */}
-                    <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '12px', marginTop: '8px' }}>
+                    <label className="performance-control-toggle is-spaced">
                         <input
                             type="checkbox"
                             checked={showRegions}
                             onChange={(e) => setShowRegions(e.target.checked)}
-                            style={{ accentColor: '#10b981' }}
+                            className="is-green"
                         />
                         <span>Show Region Polygons</span>
                     </label>
                 </div>
 
                 {/* Legend - Dynamic based on Filter */}
-                <div style={{ padding: '10px 12px', fontSize: '11px' }}>
-                    <div style={{ fontWeight: '600', marginBottom: '6px' }}>Legend</div>
+                <div className="performance-legend">
+                    <div className="performance-legend__title">Legend</div>
 
                     {filterMode === 'combined' && (
                         <>
@@ -351,7 +371,7 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
                     )}
                 </div>
 
-                <div style={{ padding: '6px 12px', fontSize: '9px', color: '#9ca3af', backgroundColor: '#f9fafb', borderTop: '1px solid #e5e7eb' }}>
+                <div className="performance-control-footer">
                     Traffic Light System v1.0
                 </div>
             </div>
@@ -373,51 +393,14 @@ export default function PerformanceLayer({ visible, onToggle, onModeChange }: Pe
 
 // Legend Component Helper
 const LegendItem = ({ color, border, label, sub }: { color: string, border?: string, label: string, sub?: string }) => (
-    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '6px' }}>
-        <div style={{
-            width: '12px',
-            height: '12px',
-            borderRadius: '50%',
-            background: color,
-            border: border ? `2px solid ${border}` : 'none',
-            flexShrink: 0,
-            marginTop: '2px',
-            boxSizing: 'border-box'
-        }} />
+    <div className="performance-legend-item">
+        <div
+            className={`performance-legend-swatch${border ? ' has-border' : ''}`}
+            style={{ backgroundColor: color, borderColor: border }}
+        />
         <div>
-            <div style={{ color: '#334155', fontWeight: '500' }}>{label}</div>
-            {sub && <div style={{ color: '#64748b', fontSize: '10px' }}>{sub}</div>}
+            <div className="performance-legend-label">{label}</div>
+            {sub && <div className="performance-legend-note">{sub}</div>}
         </div>
     </div>
 );
-
-const panelStyle: React.CSSProperties = {
-    position: 'absolute',
-    top: '20px',
-    left: '20px',
-    zIndex: 1000,
-    minWidth: '280px',
-    // Glassmorphism effect
-    background: 'rgba(255, 255, 255, 0.92)',
-    backdropFilter: 'blur(12px)',
-    WebkitBackdropFilter: 'blur(12px)',
-    border: '1px solid rgba(255, 255, 255, 0.3)',
-    boxShadow: '0 8px 32px 0 rgba(31, 38, 135, 0.12)',
-    borderRadius: '12px',
-    fontSize: '13px',
-    overflow: 'hidden'
-};
-
-// Clean header - no dark bar (Flaw 3 fix)
-const headerStyle: React.CSSProperties = {
-    padding: '14px 16px',
-    borderBottom: '1px solid rgba(0, 0, 0, 0.06)',
-    fontSize: '15px',
-    fontWeight: '700',
-    letterSpacing: '-0.02em',
-    color: '#0f172a',  // Dark text on white, no background
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    cursor: 'pointer'
-};

--- a/frontend/src/components/RegionClusters.tsx
+++ b/frontend/src/components/RegionClusters.tsx
@@ -1,7 +1,14 @@
 import React, { useMemo } from 'react';
 import MarkerClusterGroup from 'react-leaflet-cluster';
 import L from 'leaflet';
-import { CATRegion, Season, getNeedColor } from '../api/catApi';
+import { CATRegion, Season } from '../api/catApi';
+import { getDesertScorePresentation } from '../domain/metrics';
+import {
+  createMarkerIcon,
+  getClusterMarkerSize,
+  getMarkerMetadata,
+  type MarkerClusterLike,
+} from '../utils/markerUtils';
 import RegionMarker from './RegionMarker';
 
 interface RegionClustersProps {
@@ -13,53 +20,22 @@ interface RegionClustersProps {
   onMarkerReady?: (regionCode: string, marker: L.Marker | null) => void;
 }
 
-// Minimal CSS for hover states
-const customCSS = `
-  .healthsites-cluster-wrapper {
-    transition: transform 0.15s ease-out;
-  }
-  .healthsites-cluster-wrapper:hover {
-    transform: scale(1.15) !important;
-    z-index: 1000 !important;
-  }
-  .custom-css-marker {
-    background: transparent;
-    border: none;
-  }
-`;
-
-if (typeof document !== 'undefined') {
-  const styleId = 'healthsites-custom-css';
-  if (!document.getElementById(styleId)) {
-    const style = document.createElement('style');
-    style.id = styleId;
-    style.innerHTML = customCSS;
-    document.head.appendChild(style);
-  }
-}
-
-import { createMarkerIcon } from '../utils/markerUtils';
-
 // Define globally to prevent infinite loop re-renders!
-const createClusterCustomIcon = function (cluster: any) {
+const createClusterCustomIcon = function (cluster: MarkerClusterLike) {
   const pointCount = cluster.getChildCount();
   const markers = cluster.getAllChildMarkers();
 
-  // calculate average need score for the cluster
-  let sumNeed = 0;
-  markers.forEach((marker: any) => {
-    sumNeed += marker.options.needScore || 0;
-  });
+  const needScores = markers
+    .map(marker => getMarkerMetadata(marker).needScore)
+    .filter((score): score is number => score !== undefined && Number.isFinite(score));
+  const averageNeed = needScores.length
+    ? needScores.reduce((sum, score) => sum + score, 0) / needScores.length
+    : null;
+  const clusterColor = averageNeed === null
+    ? '#94a3b8'
+    : getDesertScorePresentation(averageNeed).color;
 
-  const avgNeed = sumNeed / pointCount;
-  const clusterColor = getNeedColor(avgNeed);
-
-  let scale = 1.0;
-  if (pointCount >= 200) scale = 1.5;
-  else if (pointCount >= 50) scale = 1.35;
-  else if (pointCount >= 10) scale = 1.2;
-
-  const size = 24 * scale;
+  const size = getClusterMarkerSize(pointCount);
   return createMarkerIcon(clusterColor, false, size, pointCount.toString());
 };
 

--- a/frontend/src/components/RegionMarker.tsx
+++ b/frontend/src/components/RegionMarker.tsx
@@ -1,14 +1,15 @@
-import React, { useCallback, useRef, useMemo } from 'react';
+import { useCallback, useRef, useMemo } from 'react';
 import { Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import {
     CATRegion,
-    getNeedColor,
-    getNeedLabel,
-    getTierColor,
     Season
 } from '../api/catApi';
-import { createMarkerIcon } from '../utils/markerUtils';
+import { CAT_TIER_PRESENTATION, getDesertScorePresentation } from '../domain/metrics';
+import { createMarkerIcon, setMarkerMetadata } from '../utils/markerUtils';
+import Button from './ui/Button';
+import StatusBadge from './ui/StatusBadge';
+import './map/MapLayers.css';
 
 interface RegionMarkerProps {
     region: CATRegion;
@@ -19,22 +20,6 @@ interface RegionMarkerProps {
     activeSeason?: Season;
     onClick?: () => void;
     needScore?: number;
-}
-
-function badgeStyle(backgroundColor: string) {
-    return {
-        display: 'inline-flex',
-        alignItems: 'center',
-        minHeight: 22,
-        padding: '3px 8px',
-        borderRadius: 999,
-        backgroundColor,
-        color: '#ffffff',
-        fontSize: 11,
-        fontWeight: 800,
-        lineHeight: 1.2,
-        whiteSpace: 'nowrap' as const,
-    };
 }
 
 export default function RegionMarker({
@@ -53,7 +38,8 @@ export default function RegionMarker({
         if (marker) {
             // Attach score directly to leaflet marker options so the clustering
             // algorithm in RegionClusters can read it to calculate average color
-            (marker.options as any).needScore = needScore ?? region.necessity_score;
+            const score = needScore ?? region.necessity_score;
+            setMarkerMetadata(marker, { needScore: Number.isFinite(score) ? score : undefined });
         }
         onMarkerReady?.(region.region_code, marker);
     }, [onMarkerReady, region.region_code, needScore, region.necessity_score]);
@@ -62,17 +48,21 @@ export default function RegionMarker({
         return null;
     }
 
-    const needColor = getNeedColor(region.necessity_score);
-    const needLabel = getNeedLabel(region.necessity_score);
-    const tierColor = getTierColor(region.tier_level);
-
-    const markerIcon = useMemo(() => createMarkerIcon(needColor, selected), [needColor, selected]);
+    const needPresentation = Number.isFinite(region.necessity_score)
+        ? getDesertScorePresentation(region.necessity_score)
+        : null;
+    const markerIcon = useMemo(
+        () => createMarkerIcon(needPresentation?.color ?? '#94a3b8', selected),
+        [needPresentation?.color, selected],
+    );
 
     return (
         <Marker
             ref={markerRefCallback}
             position={[region.centroid_lat, region.centroid_lon]}
             icon={markerIcon}
+            alt={`${region.region_name} community marker`}
+            title={region.region_name}
             eventHandlers={{
                 click: () => {
                     onSelect?.(region.region_code);
@@ -88,42 +78,23 @@ export default function RegionMarker({
                 autoPanPaddingTopLeft={[64, 120]}
                 autoPanPaddingBottomRight={[64, 210]}
             >
-                <div style={{
-                    minWidth: 210,
-                    maxWidth: 236,
-                    color: '#172033',
-                    fontSize: 12,
-                }}>
-                    <h3 style={{
-                        margin: '0 0 2px',
-                        color: '#111827',
-                        fontSize: 15,
-                        lineHeight: 1.2,
-                        fontWeight: 800,
-                    }}>
+                <div className="region-marker-popup">
+                    <h3 className="region-marker-popup__title">
                         {region.region_name}
                     </h3>
-                    <div style={{
-                        marginBottom: 9,
-                        color: '#64748b',
-                        fontSize: 11,
-                        fontWeight: 700,
-                    }}>
+                    <div className="region-marker-popup__code">
                         {region.region_code}
                     </div>
 
-                    <div style={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: 6,
-                        marginBottom: 10,
-                    }}>
-                        <span style={badgeStyle(tierColor)}>CAT {region.tier_level}</span>
-                        <span style={badgeStyle(needColor)}>{needLabel}</span>
+                    <div className="region-marker-popup__badges">
+                        <StatusBadge tone={CAT_TIER_PRESENTATION[region.tier_level].tone}>CAT {region.tier_level}</StatusBadge>
+                        <StatusBadge tone={needPresentation?.tone ?? 'neutral'}>
+                            {needPresentation?.label ?? 'Data unavailable'}
+                        </StatusBadge>
                     </div>
 
-                    <button
-                        type="button"
+                    <Button
+                        size="small"
                         onMouseDown={event => {
                             event.preventDefault();
                             event.stopPropagation();
@@ -138,20 +109,10 @@ export default function RegionMarker({
                                 markerRef.current?.closePopup();
                             }
                         }}
-                        style={{
-                            width: '100%',
-                            border: '1px solid #c7d0da',
-                            borderRadius: 6,
-                            background: '#ffffff',
-                            color: '#334155',
-                            padding: '6px 8px',
-                            fontSize: 11,
-                            fontWeight: 800,
-                            cursor: 'pointer',
-                        }}
+                        className="region-marker-popup__button"
                     >
                         View details
-                    </button>
+                    </Button>
                 </div>
             </Popup>
         </Marker>

--- a/frontend/src/components/ResearchComparisonPanel.css
+++ b/frontend/src/components/ResearchComparisonPanel.css
@@ -3,16 +3,16 @@
     left: 24px;
     right: 24px;
     bottom: 16px;
-    z-index: 650;
+    z-index: var(--z-overlay);
     max-height: min(34vh, 340px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    border: 1px solid #c7d0da;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.96);
-    box-shadow: 0 14px 36px rgba(15, 23, 42, 0.18);
-    color: #172033;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-overlay);
+    box-shadow: var(--shadow-lg);
+    color: var(--color-text);
 }
 
 .research-comparison-panel.collapsed {
@@ -24,12 +24,12 @@
     position: absolute;
     right: 24px;
     bottom: 16px;
-    z-index: 650;
-    border: 1px solid #c7d0da;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.96);
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.16);
-    color: #334155;
+    z-index: var(--z-overlay);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-overlay);
+    box-shadow: var(--shadow-md);
+    color: var(--color-text-secondary);
     padding: 10px 12px;
     font-size: 12px;
     font-weight: 800;
@@ -43,19 +43,19 @@
     justify-content: space-between;
     gap: 12px;
     padding: 12px 14px;
-    border-bottom: 1px solid #e2e8f0;
+    border-bottom: 1px solid var(--color-border);
 }
 
 .research-comparison-header h2 {
     margin: 0;
-    color: #111827;
+    color: var(--color-text);
     font-size: 16px;
     line-height: 1.2;
 }
 
 .research-comparison-header p {
     margin: 3px 0 0;
-    color: #64748b;
+    color: var(--color-text-muted);
     font-size: 12px;
 }
 
@@ -65,22 +65,9 @@
     gap: 6px;
 }
 
-.research-comparison-actions button {
-    border: 1px solid #c7d0da;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #334155;
-    padding: 5px 8px;
-    font-size: 11px;
-    font-weight: 800;
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.research-comparison-actions button:hover,
 .research-comparison-reopen:hover {
-    background: #f8fbff;
-    border-color: #93c5fd;
+    background: var(--color-surface-subtle);
+    border-color: var(--color-primary);
 }
 
 .research-comparison-body {
@@ -97,15 +84,15 @@
 }
 
 .comparison-muted {
-    border: 1px solid #dbe3ea;
-    background: #f8fafc;
-    color: #64748b;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-muted);
 }
 
 .comparison-error {
     border: 1px solid #fecaca;
-    background: #fef2f2;
-    color: #b91c1c;
+    background: var(--color-danger-subtle);
+    color: var(--color-danger);
 }
 
 .comparison-table {
@@ -118,7 +105,7 @@
     gap: 8px;
     align-items: stretch;
     padding: 9px 14px;
-    border-bottom: 1px solid #edf2f7;
+    border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .comparison-grid:last-child {
@@ -129,8 +116,8 @@
     position: sticky;
     top: 0;
     z-index: 1;
-    background: #f8fafc;
-    color: #536176;
+    background: var(--color-surface-subtle);
+    color: var(--color-text-secondary);
     font-size: 11px;
     font-weight: 800;
     text-transform: uppercase;
@@ -149,7 +136,7 @@
 
 .comparison-metric-label {
     align-self: center;
-    color: #475569;
+    color: var(--color-text-secondary);
     font-size: 12px;
     font-weight: 800;
 }
@@ -167,7 +154,7 @@
 
 .comparison-value-line strong {
     min-width: 0;
-    color: #111827;
+    color: var(--color-text);
     font-size: 12px;
     overflow-wrap: anywhere;
 }
@@ -195,7 +182,7 @@
     margin-top: 5px;
     overflow: hidden;
     border-radius: 999px;
-    background: #e2e8f0;
+    background: var(--color-surface-muted);
 }
 
 .comparison-bar-track span {
@@ -208,7 +195,7 @@
 .comparison-cell small {
     display: block;
     margin-top: 4px;
-    color: #64748b;
+    color: var(--color-text-muted);
     font-size: 10px;
     line-height: 1.3;
 }
@@ -217,7 +204,8 @@
     .research-comparison-panel {
         left: 10px;
         right: 10px;
-        bottom: 10px;
+        bottom: calc(46vh + var(--spacing-5));
+        bottom: calc(46dvh + var(--spacing-5));
         width: auto;
         max-height: 32vh;
     }
@@ -230,6 +218,8 @@
     .research-comparison-reopen {
         left: 10px;
         right: 10px;
+        bottom: calc(46vh + var(--spacing-5));
+        bottom: calc(46dvh + var(--spacing-5));
         width: auto;
     }
 }

--- a/frontend/src/components/ResearchComparisonPanel.tsx
+++ b/frontend/src/components/ResearchComparisonPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import { Season } from '../api/catApi';
 import { useComparisonProfiles } from '../hooks/useComparisonProfiles';
 import { ResearchProfile } from '../types/research';
 import { DATA_UNAVAILABLE, formatResearchValue } from '../utils/formatResearchValue';
+import Button from './ui/Button';
 import './ResearchComparisonPanel.css';
 
 interface ResearchComparisonPanelProps {
@@ -76,6 +77,7 @@ export default function ResearchComparisonPanel({
     const { profiles, missingCodes, loading, error } = useComparisonProfiles(pinnedRegionCodes, season);
     const [collapsed, setCollapsed] = useState(false);
     const [closed, setClosed] = useState(false);
+    const bodyId = useId();
     const pinnedKey = useMemo(() => pinnedRegionCodes.join('|'), [pinnedRegionCodes]);
 
     useEffect(() => {
@@ -89,8 +91,9 @@ export default function ResearchComparisonPanel({
 
     if (closed) {
         return (
-            <button
-                type="button"
+            <Button
+                variant="secondary"
+                size="small"
                 className="research-comparison-reopen"
                 data-testid="comparison-panel"
                 onClick={() => {
@@ -99,7 +102,7 @@ export default function ResearchComparisonPanel({
                 }}
             >
                 Compare pinned communities
-            </button>
+            </Button>
         );
     }
 
@@ -108,7 +111,6 @@ export default function ResearchComparisonPanel({
             className={`research-comparison-panel ${collapsed ? 'collapsed' : ''}`}
             data-testid="comparison-panel"
             aria-label="Pinned community comparison"
-            aria-expanded={!collapsed}
         >
             <div className="research-comparison-header">
                 <div>
@@ -116,25 +118,29 @@ export default function ResearchComparisonPanel({
                     <p>{profiles.length} pinned communities</p>
                 </div>
                 <div className="research-comparison-actions">
-                    <button
-                        type="button"
+                    <Button
+                        variant="ghost"
+                        size="small"
                         onClick={() => setCollapsed(value => !value)}
                         aria-label={collapsed ? 'Expand comparison panel' : 'Collapse comparison panel'}
+                        aria-expanded={!collapsed}
+                        aria-controls={bodyId}
                     >
                         {collapsed ? 'Expand' : 'Collapse'}
-                    </button>
-                    <button
-                        type="button"
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="small"
                         onClick={() => setClosed(true)}
                         aria-label="Close comparison panel"
                     >
                         Close
-                    </button>
+                    </Button>
                 </div>
             </div>
 
             {!collapsed && (
-                <div className="research-comparison-body">
+                <div className="research-comparison-body" id={bodyId}>
                     {loading && <div className="comparison-muted">Loading comparison...</div>}
                     {error && <div className="comparison-error">{error}</div>}
                     {!loading && missingCodes.length > 0 && (
@@ -153,6 +159,7 @@ export default function ResearchComparisonPanel({
                                         type="button"
                                         key={profile.region.region_code}
                                         onClick={() => onSelectRegion(profile.region.region_code)}
+                                        aria-label={`Select ${profile.region.name}`}
                                     >
                                         {profile.region.name}
                                     </button>

--- a/frontend/src/components/SeasonSelector.css
+++ b/frontend/src/components/SeasonSelector.css
@@ -1,0 +1,33 @@
+.season-selector {
+  width: 100%;
+  min-width: 134px;
+  height: var(--control-height-sm);
+  appearance: none;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23536176' d='M3 4.5L6 7.5L9 4.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  color: var(--color-text-secondary);
+  padding: 0 32px 0 var(--spacing-3);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.season-selector:hover {
+  border-color: #94a3b8;
+}
+
+.season-selector:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
+}
+
+@media (max-width: 430px) {
+  .season-selector {
+    min-width: 0;
+  }
+}

--- a/frontend/src/components/SeasonSelector.tsx
+++ b/frontend/src/components/SeasonSelector.tsx
@@ -1,47 +1,19 @@
 import type { Season } from '../api/catApi';
+import './SeasonSelector.css';
 
 interface SeasonSelectorProps {
     season: Season;
     onChange: (season: Season) => void;
 }
 
-/**
- * Season selector dropdown for TENeT.
- * Clean dropdown design for the top-right info panel.
- */
 export default function SeasonSelector({ season, onChange }: SeasonSelectorProps) {
-    const getLabel = (s: Season): string => {
-        switch (s) {
-            case 'summer': return 'Summer';
-            case 'winter': return 'Winter';
-            case 'year_round': return 'Year-Round Average';
-        }
-    };
-
     return (
         <select
+            className="season-selector"
             aria-label="Season scenario"
             data-testid="season-selector"
             value={season}
             onChange={(e) => onChange(e.target.value as Season)}
-            style={{
-                padding: '8px 12px',
-                fontSize: '12px',
-                fontWeight: '500',
-                color: '#475569',
-                backgroundColor: 'white',
-                border: '1px solid rgba(0, 0, 0, 0.1)',
-                borderRadius: '8px',
-                cursor: 'pointer',
-                outline: 'none',
-                appearance: 'none',
-                WebkitAppearance: 'none',
-                backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23475569' d='M3 4.5L6 7.5L9 4.5'/%3E%3C/svg%3E")`,
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'right 10px center',
-                paddingRight: '32px',
-                minWidth: '140px'
-            }}
             title="Select season scenario"
         >
             <option value="summer">Summer</option>

--- a/frontend/src/components/dashboard/Dashboard.css
+++ b/frontend/src/components/dashboard/Dashboard.css
@@ -1,0 +1,534 @@
+.insights-page {
+  position: relative;
+  z-index: var(--z-overlay);
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background: var(--color-canvas);
+  color: var(--color-text);
+}
+
+.insights-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-6);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-4) max(var(--spacing-6), calc((100vw - 1320px) / 2));
+  box-shadow: var(--shadow-xs);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.insights-header h1 {
+  margin: 2px 0;
+  color: var(--color-text);
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.insights-header p {
+  max-width: 720px;
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.insights-content {
+  display: grid;
+  gap: var(--spacing-5);
+  width: min(1320px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: var(--spacing-6) 0 var(--spacing-10);
+}
+
+.insights-eyebrow {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.insights-partial-notice {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  border: 1px solid #fde68a;
+  border-radius: var(--radius-md);
+  background: var(--color-status-anchor-subtle);
+  padding: var(--spacing-3) var(--spacing-4);
+  color: #78350f;
+  font-size: var(--font-xs);
+}
+
+.insights-overview {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.insights-section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.insights-section-heading h2,
+.insights-panel__header h2 {
+  margin: 2px 0 0;
+  color: var(--color-text);
+  font-size: var(--font-lg);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.insights-source-note {
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+}
+
+.insights-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--spacing-3);
+}
+
+.insights-metric-grid .ui-metric-card,
+.insights-inline-metrics .ui-metric-card {
+  min-height: 112px;
+}
+
+.insights-panel {
+  min-width: 0;
+  padding: var(--spacing-5);
+  box-shadow: var(--shadow-sm);
+}
+
+.insights-panel--critical {
+  border-top: 3px solid var(--color-status-gap);
+}
+
+.insights-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--spacing-3);
+}
+
+.insights-panel__header > div:first-child {
+  min-width: 0;
+}
+
+.insights-panel__header p {
+  max-width: 680px;
+  margin: var(--spacing-1) 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+  line-height: 1.45;
+}
+
+.insights-panel__action {
+  flex: 0 0 auto;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-4);
+  align-items: start;
+}
+
+.insights-priority-list {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--spacing-2);
+}
+
+.insights-priority-row {
+  display: flex;
+  min-width: 0;
+  min-height: 152px;
+  flex-direction: column;
+  align-items: flex-start;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-3);
+}
+
+.insights-priority-main {
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.insights-priority-main > div {
+  min-width: 0;
+}
+
+.insights-priority-main strong,
+.insights-priority-main span {
+  display: block;
+}
+
+.insights-priority-main strong {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  line-height: 1.3;
+  text-overflow: ellipsis;
+}
+
+.insights-priority-main > div > span {
+  margin-top: 2px;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.insights-priority-row p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: var(--spacing-2) 0;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.insights-priority-row > .ui-button {
+  margin-top: auto;
+  padding-inline: 0;
+}
+
+.insights-list-note {
+  grid-column: 1 / -1;
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+}
+
+.insights-inline-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-3);
+}
+
+.insights-inline-metrics--four {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.insights-inline-metrics--four .ui-metric-card {
+  min-height: 94px;
+  padding: var(--spacing-3);
+}
+
+.insights-inline-metrics--four .ui-metric-card__value {
+  font-size: var(--font-lg);
+}
+
+.insights-distribution {
+  margin-top: var(--spacing-4);
+}
+
+.insights-distribution__bar {
+  display: flex;
+  width: 100%;
+  height: 10px;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-muted);
+}
+
+.insights-distribution__bar span {
+  min-width: 2px;
+}
+
+.insights-distribution .is-excellent {
+  background: var(--color-status-ready);
+}
+
+.insights-distribution .is-good {
+  background: #65a30d;
+}
+
+.insights-distribution .is-moderate {
+  background: #ca8a04;
+}
+
+.insights-distribution .is-poor {
+  background: #ea580c;
+}
+
+.insights-distribution .is-critical {
+  background: var(--color-status-gap);
+}
+
+.insights-distribution__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2) var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.insights-distribution__legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  color: var(--color-text-secondary);
+  font-size: 0.625rem;
+  text-transform: capitalize;
+}
+
+.insights-distribution__legend i {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.insights-distribution > small,
+.insights-summary-list > small {
+  display: block;
+  margin-top: var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.insights-summary-list {
+  display: grid;
+}
+
+.insights-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: 7px 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.insights-summary-row strong {
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.insights-summary-row.is-strong {
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-2) var(--spacing-3);
+  color: var(--color-text);
+  font-weight: 650;
+}
+
+.insights-summary-row.is-strong strong {
+  font-size: var(--font-lg);
+}
+
+.insights-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-3);
+  border: 1px solid #fde68a;
+  border-radius: var(--radius-md);
+  background: var(--color-status-anchor-subtle);
+  padding: var(--spacing-3);
+}
+
+.insights-callout > div {
+  display: flex;
+  min-width: 126px;
+  flex-direction: column;
+}
+
+.insights-callout strong {
+  color: #92400e;
+  font-size: var(--font-xl);
+  line-height: 1.2;
+}
+
+.insights-callout span {
+  color: #78350f;
+  font-size: 0.6875rem;
+  font-weight: 650;
+}
+
+.insights-callout p,
+.insights-method-note {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.45;
+}
+
+.insights-method-note {
+  margin-top: var(--spacing-3);
+  border-left: 3px solid var(--color-primary);
+  background: var(--color-primary-subtle);
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.insights-unavailable,
+.insights-empty-state {
+  display: flex;
+  min-height: 104px;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  text-align: center;
+}
+
+.insights-state-shell {
+  display: grid;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  place-items: center;
+  background: var(--color-canvas);
+  padding: var(--spacing-6);
+}
+
+.insights-state-card {
+  display: flex;
+  width: min(480px, 100%);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-8);
+  text-align: center;
+}
+
+.insights-state-card h1 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-xl);
+}
+
+.insights-state-card p {
+  margin: 0 0 var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.insights-state-card--error {
+  border-top: 3px solid var(--color-danger);
+}
+
+.insights-spinner {
+  width: 34px;
+  height: 34px;
+  border: 3px solid #dbeafe;
+  border-top-color: var(--color-primary);
+  border-radius: var(--radius-full);
+  animation: insights-spin 0.8s linear infinite;
+}
+
+@keyframes insights-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 1100px) {
+  .insights-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .insights-priority-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .insights-header {
+    padding-inline: var(--spacing-4);
+  }
+
+  .insights-content {
+    width: min(100% - 32px, 680px);
+    padding-top: var(--spacing-4);
+  }
+
+  .insights-grid,
+  .insights-priority-list {
+    grid-template-columns: 1fr;
+  }
+
+  .insights-priority-row {
+    min-height: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  .insights-header {
+    align-items: flex-start;
+    padding: var(--spacing-3);
+  }
+
+  .insights-header p {
+    display: none;
+  }
+
+  .insights-content {
+    width: calc(100% - 24px);
+  }
+
+  .insights-partial-notice,
+  .insights-section-heading,
+  .insights-panel__header,
+  .insights-callout {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .insights-section-heading {
+    gap: var(--spacing-1);
+  }
+
+  .insights-metric-grid,
+  .insights-inline-metrics,
+  .insights-inline-metrics--four {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .insights-panel {
+    padding: var(--spacing-4);
+  }
+
+  .insights-panel__action,
+  .insights-panel__action .ui-button {
+    width: 100%;
+  }
+
+  .insights-callout > div {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 390px) {
+  .insights-metric-grid,
+  .insights-inline-metrics,
+  .insights-inline-metrics--four {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/dashboard/Dashboard.test.tsx
+++ b/frontend/src/components/dashboard/Dashboard.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDashboardData, type DashboardData } from '../../hooks/useDashboardData';
+import Dashboard from './Dashboard';
+
+vi.mock('../../hooks/useDashboardData', () => ({
+    useDashboardData: vi.fn(),
+}));
+
+const dashboardData: DashboardData = {
+    statistics: {
+        total_regions: 2,
+        total_data_points: 20,
+        total_uploads: 5,
+        completed_uploads: 5,
+        total_gating_rules: 2,
+        active_gating_rules: 2,
+        total_healthcare_sites: 4,
+        hospitals: 1,
+        clinics: 2,
+    },
+    telehealthStatus: {
+        count: 2,
+        summary: {
+            telehealth_ready: 1,
+            community_anchor: 0,
+            critical_gap: 1,
+            data_unavailable: 0,
+        },
+        regions: [
+            {
+                region_code: 'AK-CRITICAL',
+                region_name: 'Critical Community',
+                lat: 60,
+                lon: -150,
+                status: 'CRITICAL_GAP',
+                color: '#b42318',
+                internet_cost: 120,
+                isp_name: 'Provider',
+                burden_pct: 3.2,
+                median_income: 40000,
+                has_nearby_clinic: false,
+                nearest_clinic_name: null,
+                nearest_clinic_km: null,
+                access_mode: 'air',
+                recommendation: 'Prioritize connectivity and supported care access.',
+            },
+        ],
+    },
+    healthcare: {
+        total_facilities: 4,
+        by_type: { hospital: 1, clinic: 2, pharmacy: 0, health_center: 1 },
+        features: { with_emergency: 1, with_specialists: 1, with_telehealth: 2 },
+        data_source: 'Test inventory',
+    },
+    performance: {
+        has_data: true,
+        period: { year: 2025, quarter: 4, label: 'Q4 2025' },
+        coverage: { total_tiles: 10, tiles_with_speed_data: 8, total_tests: 100, total_devices: 40 },
+        speeds: { avg_download_mbps: 24, max_download_mbps: 80, min_download_mbps: 2, median_download_mbps: 20 },
+        distribution: { excellent: 2, good: 2, moderate: 2, poor: 1, critical: 1 },
+        telehealth_viable_pct: 50,
+    },
+    dataGaps: {
+        total_places: 10,
+        places_with_gaps: 3,
+        gap_breakdown: {},
+        confidence_distribution: { HIGH: 6, MEDIUM: 3, LOW: 1 },
+        telehealth_viability: { YES: 5, NO: 2, UNCERTAIN: 3 },
+        primary_access: { WIRED: 7, SATELLITE: 2, LIMITED: 1 },
+    },
+    affordability: {
+        zones: [],
+        count: 10,
+        monthly_cost: 120,
+        threshold_pct: 2,
+        summary: { affordable: 6, unaffordable: 4, affordable_pct: 60 },
+    },
+};
+
+describe('Statewide Insights', () => {
+    beforeEach(() => {
+        vi.mocked(useDashboardData).mockReturnValue({
+            data: dashboardData,
+            sectionErrors: {},
+            availableSectionCount: 6,
+            hasPartialData: false,
+            loading: false,
+            error: null,
+        });
+    });
+
+    it('uses accurate affordability and satellite-dependency labels', () => {
+        render(<Dashboard onClose={vi.fn()} />);
+
+        expect(screen.getByRole('heading', { name: 'Statewide Insights' })).toBeInTheDocument();
+        expect(screen.getByText('Unaffordable analyzed zones')).toBeInTheDocument();
+        expect(screen.getByText('Satellite-primary places')).toBeInTheDocument();
+        expect(screen.getByText(/not a measure of affordability/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Open telehealth access map' })).toBeInTheDocument();
+        expect(screen.queryByText('Unaffordable Areas')).not.toBeInTheDocument();
+    });
+
+    it('routes section and community actions back to the map', () => {
+        const onViewMap = vi.fn();
+        const onViewRegion = vi.fn();
+        render(
+            <Dashboard
+                onClose={vi.fn()}
+                onViewMap={onViewMap}
+                onViewRegion={onViewRegion}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open Gap Hunter' }));
+        expect(onViewMap).toHaveBeenCalledWith('gap');
+
+        fireEvent.click(screen.getByRole('button', { name: 'View on map' }));
+        expect(onViewRegion).toHaveBeenCalledWith('AK-CRITICAL');
+    });
+});

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,388 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useDashboardData, type DashboardSection } from '../../hooks/useDashboardData';
+import Button from '../ui/Button';
+import MetricCard from '../ui/MetricCard';
+import Panel from '../ui/Panel';
+import StatusBadge from '../ui/StatusBadge';
+import { SATELLITE_PRIMARY_METRIC } from '../../domain/metrics';
+import { getTelehealthStatusLabel } from '../../domain/statusPresentation';
+import type { BaseMapLayer } from '../../domain/mapMode';
+import './Dashboard.css';
+
+export type InsightsMapLayer = BaseMapLayer;
+
+interface DashboardProps {
+    onClose: () => void;
+    onViewMap?: (layer: InsightsMapLayer) => void;
+    onViewRegion?: (regionCode: string) => void;
+}
+
+const SECTION_LABELS: Record<DashboardSection, string> = {
+    statistics: 'statewide totals',
+    telehealthStatus: 'telehealth status',
+    healthcare: 'healthcare infrastructure',
+    performance: 'network performance',
+    dataGaps: 'data quality',
+    affordability: 'affordability',
+};
+
+function displayNumber(value: number | null | undefined, digits = 0): string {
+    if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+    return value.toLocaleString(undefined, {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+    });
+}
+
+function percentage(value: number | null | undefined, digits = 0): string {
+    return value === null || value === undefined || !Number.isFinite(value)
+        ? '—'
+        : `${displayNumber(value, digits)}%`;
+}
+
+function ratioPercent(value: number | null | undefined, total: number | null | undefined): number | null {
+    if (value === null || value === undefined || !total) return null;
+    return (value / total) * 100;
+}
+
+export default function Dashboard({ onClose, onViewMap, onViewRegion }: DashboardProps) {
+    const titleRef = useRef<HTMLHeadingElement>(null);
+    const {
+        data,
+        loading,
+        error,
+        sectionErrors,
+        hasPartialData,
+        availableSectionCount,
+    } = useDashboardData();
+
+    useEffect(() => {
+        if (!loading) titleRef.current?.focus();
+    }, [loading]);
+
+    const viewMap = (layer: InsightsMapLayer = 'cat') => {
+        if (onViewMap) onViewMap(layer);
+        else onClose();
+    };
+
+    if (loading) {
+        return (
+            <div className="insights-state-shell">
+                <Panel elevated className="insights-state-card" role="status">
+                    <span className="insights-spinner" aria-hidden="true" />
+                    <h1>Preparing Statewide Insights</h1>
+                    <p>Combining telehealth, network, healthcare, and data-quality summaries.</p>
+                    <Button variant="secondary" onClick={onClose}>View map</Button>
+                </Panel>
+            </div>
+        );
+    }
+
+    if (error && availableSectionCount === 0) {
+        return (
+            <div className="insights-state-shell">
+                <Panel elevated className="insights-state-card insights-state-card--error" role="alert">
+                    <StatusBadge tone="critical">Insights unavailable</StatusBadge>
+                    <h1 ref={titleRef} tabIndex={-1}>Statewide data could not be loaded</h1>
+                    <p>{error}</p>
+                    <Button variant="primary" onClick={onClose}>Return to map</Button>
+                </Panel>
+            </div>
+        );
+    }
+
+    const { statistics, telehealthStatus, healthcare, performance, dataGaps, affordability } = data;
+    const totalCommunities = telehealthStatus?.count ?? null;
+    const criticalCount = telehealthStatus?.summary.critical_gap;
+    const readyCount = telehealthStatus?.summary.telehealth_ready;
+    const criticalRegions = telehealthStatus?.regions
+        .filter(region => region.status === 'CRITICAL_GAP')
+        .slice(0, 5) ?? [];
+    const speedDistribution = performance?.distribution;
+    const speedTileCount = speedDistribution
+        ? Object.values(speedDistribution).reduce((sum, count) => sum + count, 0)
+        : 0;
+    const unavailableSections = (Object.keys(sectionErrors) as DashboardSection[])
+        .map(section => SECTION_LABELS[section]);
+
+    return (
+        <div className="insights-page">
+            <header className="insights-header">
+                <div>
+                    <span className="insights-eyebrow">TENeT statewide view</span>
+                    <h1 ref={titleRef} tabIndex={-1}>Statewide Insights</h1>
+                    <p>Prioritize telehealth gaps, validate evidence quality, and move directly back to the map.</p>
+                </div>
+                <Button variant="primary" onClick={onClose}>View map</Button>
+            </header>
+
+            <main className="insights-content">
+                {hasPartialData && (
+                    <div className="insights-partial-notice" role="status">
+                        <StatusBadge tone="anchor">Partial data</StatusBadge>
+                        <span>
+                            Showing available statewide results. Unavailable sections: {unavailableSections.join(', ')}.
+                        </span>
+                    </div>
+                )}
+
+                <section className="insights-overview" aria-labelledby="statewide-overview-title">
+                    <div className="insights-section-heading">
+                        <div>
+                            <span className="insights-eyebrow">At a glance</span>
+                            <h2 id="statewide-overview-title">Statewide operating picture</h2>
+                        </div>
+                        <span className="insights-source-note">Counts reflect the latest available source for each section.</span>
+                    </div>
+                    <div className="insights-metric-grid">
+                        <MetricCard
+                            label="Communities classified"
+                            value={displayNumber(totalCommunities)}
+                            supportingText="Communities in the telehealth status dataset"
+                            tone="info"
+                        />
+                        <MetricCard
+                            label="Critical telehealth gaps"
+                            value={displayNumber(criticalCount)}
+                            supportingText={criticalCount === undefined
+                                ? 'Telehealth classification unavailable'
+                                : `${percentage(ratioPercent(criticalCount, totalCommunities), 1)} of classified communities`}
+                            tone="danger"
+                        />
+                        <MetricCard
+                            label="Telehealth ready"
+                            value={displayNumber(readyCount)}
+                            supportingText={readyCount === undefined
+                                ? 'Telehealth classification unavailable'
+                                : `${percentage(ratioPercent(readyCount, totalCommunities), 1)} of classified communities`}
+                            tone="success"
+                        />
+                        <MetricCard
+                            label="Broadband places with data gaps"
+                            value={displayNumber(dataGaps?.places_with_gaps)}
+                            supportingText={dataGaps
+                                ? `${percentage(ratioPercent(dataGaps.places_with_gaps, dataGaps.total_places), 1)} of ${displayNumber(dataGaps.total_places)} evaluated places`
+                                : 'Data-quality summary unavailable'}
+                            tone="warning"
+                        />
+                    </div>
+                </section>
+
+                <Panel className="insights-panel insights-panel--critical" elevated>
+                    <SectionHeading
+                        eyebrow="Action queue"
+                        title="Critical telehealth gaps"
+                        description="Communities classified with affordability constraints and insufficient nearby care support."
+                        action={<Button size="small" onClick={() => viewMap('cat')}>View CAT map</Button>}
+                    />
+
+                    {!telehealthStatus ? (
+                        <SectionUnavailable message={sectionErrors.telehealthStatus} />
+                    ) : criticalRegions.length === 0 ? (
+                        <div className="insights-empty-state">No critical-gap communities are present in the current statewide classification.</div>
+                    ) : (
+                        <div className="insights-priority-list">
+                            {criticalRegions.map(region => (
+                                <article key={region.region_code} className="insights-priority-row">
+                                    <div className="insights-priority-main">
+                                        <div>
+                                            <strong>{region.region_name}</strong>
+                                            <span>{region.region_code}</span>
+                                        </div>
+                                        <StatusBadge tone="critical">{getTelehealthStatusLabel('CRITICAL_GAP')}</StatusBadge>
+                                    </div>
+                                    <p>{region.recommendation || 'Review connectivity, affordability, and nearby clinic access on the map.'}</p>
+                                    <Button
+                                        size="small"
+                                        variant="ghost"
+                                        onClick={() => onViewRegion ? onViewRegion(region.region_code) : viewMap('cat')}
+                                    >
+                                        View on map
+                                    </Button>
+                                </article>
+                            ))}
+                            {(telehealthStatus.summary.critical_gap ?? 0) > criticalRegions.length && (
+                                <div className="insights-list-note">
+                                    Showing 5 of {displayNumber(telehealthStatus.summary.critical_gap)} critical communities.
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </Panel>
+
+                <div className="insights-grid">
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Connectivity"
+                            title="Network performance summary"
+                            description="Observed Ookla measurements indicate whether current service can support reliable telehealth."
+                            action={<Button size="small" onClick={() => viewMap('gap')}>Open Gap Hunter</Button>}
+                        />
+                        {!performance || !performance.has_data ? (
+                            <SectionUnavailable message={sectionErrors.performance || 'No measured network-performance period is available.'} />
+                        ) : (
+                            <>
+                                <div className="insights-inline-metrics">
+                                    <MetricCard
+                                        label="Average download"
+                                        value={performance.speeds.avg_download_mbps === null
+                                            ? 'Data unavailable'
+                                            : `${displayNumber(performance.speeds.avg_download_mbps, 1)} Mbps`}
+                                        supportingText={performance.period.label}
+                                        tone="info"
+                                    />
+                                    <MetricCard
+                                        label="Telehealth-viable tiles"
+                                        value={percentage(performance.telehealth_viable_pct, 1)}
+                                        supportingText={`${displayNumber(performance.coverage.tiles_with_speed_data)} tiles with speed data`}
+                                        tone="success"
+                                    />
+                                </div>
+                                <div className="insights-distribution" aria-label="Speed distribution by measured tile">
+                                    <div className="insights-distribution__bar">
+                                        {speedDistribution && Object.entries(speedDistribution).map(([level, count]) => (
+                                            <span
+                                                key={level}
+                                                className={`is-${level}`}
+                                                style={{ flexGrow: count }}
+                                                title={`${level}: ${count} tiles`}
+                                            />
+                                        ))}
+                                    </div>
+                                    <div className="insights-distribution__legend">
+                                        {speedDistribution && Object.entries(speedDistribution).map(([level, count]) => (
+                                            <span key={level}><i className={`is-${level}`} />{level} {displayNumber(count)}</span>
+                                        ))}
+                                    </div>
+                                    <small>Distribution across {displayNumber(speedTileCount)} measured tiles.</small>
+                                </div>
+                            </>
+                        )}
+                    </Panel>
+
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Care access"
+                            title="Healthcare infrastructure"
+                            description="Facility inventory helps identify where telehealth must supplement limited physical access."
+                            action={<Button size="small" onClick={() => viewMap('cat')}>View communities</Button>}
+                        />
+                        {!healthcare ? (
+                            <SectionUnavailable message={sectionErrors.healthcare} />
+                        ) : (
+                            <div className="insights-summary-list">
+                                <SummaryRow label="Total facilities" value={displayNumber(healthcare.total_facilities)} strong />
+                                <SummaryRow label="Hospitals" value={displayNumber(healthcare.by_type.hospital)} />
+                                <SummaryRow label="Clinics" value={displayNumber(healthcare.by_type.clinic)} />
+                                <SummaryRow label="Health centers" value={displayNumber(healthcare.by_type.health_center)} />
+                                <SummaryRow label="Emergency services" value={displayNumber(healthcare.features.with_emergency)} />
+                                <SummaryRow label="Telehealth-capable facilities" value={displayNumber(healthcare.features.with_telehealth)} />
+                                <small>Source: {healthcare.data_source || 'Healthcare facility inventory'}</small>
+                            </div>
+                        )}
+                    </Panel>
+
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Evidence risk"
+                            title="Data quality risks"
+                            description="Incomplete or low-confidence evidence should trigger verification before funding or service decisions."
+                        />
+                        {!dataGaps ? (
+                            <SectionUnavailable message={sectionErrors.dataGaps} />
+                        ) : (
+                            <>
+                                <div className="insights-inline-metrics insights-inline-metrics--four">
+                                    <MetricCard label="Places with gaps" value={displayNumber(dataGaps.places_with_gaps)} tone="warning" />
+                                    <MetricCard label="Low confidence" value={displayNumber(dataGaps.confidence_distribution.LOW)} tone="danger" />
+                                    <MetricCard label="Viability uncertain" value={displayNumber(dataGaps.telehealth_viability.UNCERTAIN)} tone="warning" />
+                                    <MetricCard label="Stored data points" value={displayNumber(statistics?.total_data_points)} tone="neutral" />
+                                </div>
+                                <div className="insights-callout">
+                                    <div>
+                                        <strong>{displayNumber(dataGaps.primary_access.SATELLITE)}</strong>
+                                        <span>{SATELLITE_PRIMARY_METRIC.label}</span>
+                                    </div>
+                                    <p>{SATELLITE_PRIMARY_METRIC.description}</p>
+                                </div>
+                            </>
+                        )}
+                    </Panel>
+
+                    <Panel className="insights-panel">
+                        <SectionHeading
+                            eyebrow="Household burden"
+                            title="Affordability summary"
+                            description="Income-based burden estimates identify analyzed zones where the modeled monthly internet cost exceeds the configured threshold."
+                            action={<Button size="small" onClick={() => viewMap('affordability')}>Open telehealth access map</Button>}
+                        />
+                        {!affordability ? (
+                            <SectionUnavailable message={sectionErrors.affordability} />
+                        ) : (
+                            <>
+                                <div className="insights-inline-metrics">
+                                    <MetricCard
+                                        label="Unaffordable analyzed zones"
+                                        value={displayNumber(affordability.summary.unaffordable)}
+                                        supportingText={`of ${displayNumber(affordability.count)} analyzed ZCTAs`}
+                                        tone="danger"
+                                    />
+                                    <MetricCard
+                                        label="Affordable share"
+                                        value={percentage(affordability.summary.affordable_pct, 1)}
+                                        supportingText={`${displayNumber(affordability.summary.affordable)} analyzed zones`}
+                                        tone="success"
+                                    />
+                                </div>
+                                <div className="insights-method-note">
+                                    Modeled at {`$${displayNumber(affordability.monthly_cost)}`} per month with a {percentage(affordability.threshold_pct, 1)} income-burden threshold. Zones without usable income data may be excluded.
+                                </div>
+                            </>
+                        )}
+                    </Panel>
+                </div>
+            </main>
+        </div>
+    );
+}
+
+function SectionHeading({
+    eyebrow,
+    title,
+    description,
+    action,
+}: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    action?: ReactNode;
+}) {
+    return (
+        <div className="insights-panel__header">
+            <div>
+                <span className="insights-eyebrow">{eyebrow}</span>
+                <h2>{title}</h2>
+                <p>{description}</p>
+            </div>
+            {action && <div className="insights-panel__action">{action}</div>}
+        </div>
+    );
+}
+
+function SectionUnavailable({ message }: { message?: string }) {
+    return (
+        <div className="insights-unavailable" role="status">
+            <StatusBadge tone="neutral">Unavailable</StatusBadge>
+            <span>{message || 'This source did not return statewide data.'}</span>
+        </div>
+    );
+}
+
+function SummaryRow({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
+    return (
+        <div className={`insights-summary-row${strong ? ' is-strong' : ''}`}>
+            <span>{label}</span>
+            <strong>{value}</strong>
+        </div>
+    );
+}

--- a/frontend/src/components/layout/LayerSwitcher.css
+++ b/frontend/src/components/layout/LayerSwitcher.css
@@ -1,0 +1,96 @@
+.layer-switcher {
+  position: absolute;
+  top: var(--spacing-4);
+  left: 60px;
+  z-index: var(--z-overlay);
+  min-width: 278px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-2);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.layer-switcher__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  padding: 0 var(--spacing-1) var(--spacing-2);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.layer-switcher__header strong {
+  color: var(--color-status-limited);
+  font-size: 0.625rem;
+}
+
+.layer-switcher__options {
+  display: grid;
+  grid-template-columns: auto 1fr 1.25fr;
+  gap: 2px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+  padding: 2px;
+}
+
+.layer-switcher__option {
+  min-height: var(--control-height-sm);
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius-md) - 2px);
+  color: var(--color-text-secondary);
+  padding: 0 var(--spacing-3);
+  font-size: var(--font-xs);
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
+  transition: background-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.layer-switcher__option:hover:not(.is-active) {
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--color-text);
+}
+
+.layer-switcher__option.is-active {
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  box-shadow: var(--shadow-xs);
+}
+
+.layer-switcher__option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+@media (max-width: 1200px) {
+  .layer-switcher {
+    top: 90px;
+    right: var(--spacing-4);
+    left: auto;
+  }
+}
+
+@media (max-width: 700px) {
+  .layer-switcher {
+    top: 126px;
+    right: var(--spacing-3);
+    left: var(--spacing-3);
+    min-width: 0;
+  }
+
+  .layer-switcher__options {
+    grid-template-columns: auto 1fr 1.25fr;
+  }
+
+  .layer-switcher__option {
+    padding-inline: var(--spacing-2);
+  }
+}

--- a/frontend/src/components/layout/LayerSwitcher.tsx
+++ b/frontend/src/components/layout/LayerSwitcher.tsx
@@ -1,0 +1,48 @@
+import './LayerSwitcher.css';
+import type { BaseMapLayer } from '../../domain/mapMode';
+
+export type { BaseMapLayer } from '../../domain/mapMode';
+
+interface LayerSwitcherProps {
+    activeLayer: BaseMapLayer;
+    scenarioActive?: boolean;
+    onChange: (layer: BaseMapLayer) => void;
+}
+
+const LAYERS: Array<{ id: BaseMapLayer; label: string }> = [
+    { id: 'cat', label: 'CAT' },
+    { id: 'gap', label: 'Gap Hunter' },
+    { id: 'affordability', label: 'Affordability' },
+];
+
+export default function LayerSwitcher({
+    activeLayer,
+    scenarioActive = false,
+    onChange,
+}: LayerSwitcherProps) {
+    return (
+        <section className="layer-switcher" aria-label="Map layers">
+            <div className="layer-switcher__header">
+                <span>Layer</span>
+                {scenarioActive && <strong>Scenario active</strong>}
+            </div>
+            <div className="layer-switcher__options" role="group" aria-label="Select map layer">
+                {LAYERS.map(layer => {
+                    const active = !scenarioActive && activeLayer === layer.id;
+                    return (
+                        <button
+                            key={layer.id}
+                            type="button"
+                            className={`layer-switcher__option${active ? ' is-active' : ''}`}
+                            aria-pressed={active}
+                            aria-label={`Map layer: ${layer.label}`}
+                            onClick={() => onChange(layer.id)}
+                        >
+                            {layer.label}
+                        </button>
+                    );
+                })}
+            </div>
+        </section>
+    );
+}

--- a/frontend/src/components/layout/MapToolbar.css
+++ b/frontend/src/components/layout/MapToolbar.css
@@ -1,0 +1,117 @@
+.map-toolbar {
+  position: absolute;
+  top: var(--spacing-4);
+  right: var(--spacing-4);
+  z-index: var(--z-overlay);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  max-width: calc(100% - 390px);
+  min-height: 58px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-overlay);
+  padding: var(--spacing-2) var(--spacing-3);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.map-toolbar__brand {
+  display: flex;
+  min-width: 142px;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.map-toolbar__brand strong {
+  color: var(--color-text);
+  font-size: var(--font-base);
+  letter-spacing: -0.01em;
+}
+
+.map-toolbar__brand span {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+}
+
+.map-toolbar__divider {
+  align-self: stretch;
+  width: 1px;
+  background: var(--color-border-subtle);
+}
+
+.map-toolbar__controls {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+}
+
+.map-toolbar__season {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.map-toolbar__control-label {
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.map-toolbar__scenario-button.is-active {
+  border-color: var(--color-status-limited);
+  background: var(--color-status-limited);
+}
+
+.map-toolbar__scenario-button.is-active:hover:not(:disabled) {
+  border-color: #5b21b6;
+  background: #5b21b6;
+}
+
+@media (max-width: 1200px) {
+  .map-toolbar {
+    max-width: calc(100% - var(--spacing-8));
+  }
+}
+
+@media (max-width: 700px) {
+  .map-toolbar {
+    right: var(--spacing-3);
+    left: var(--spacing-3);
+    max-width: none;
+    flex-wrap: wrap;
+    gap: var(--spacing-2) var(--spacing-3);
+  }
+
+  .map-toolbar__brand {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .map-toolbar__brand span,
+  .map-toolbar__divider,
+  .map-toolbar__control-label {
+    display: none;
+  }
+
+  .map-toolbar__controls {
+    width: 100%;
+  }
+
+  .map-toolbar__season {
+    min-width: 0;
+    flex: 1;
+  }
+}
+
+@media (max-width: 430px) {
+  .map-toolbar__controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+}

--- a/frontend/src/components/layout/MapToolbar.tsx
+++ b/frontend/src/components/layout/MapToolbar.tsx
@@ -1,0 +1,65 @@
+import type { Season } from '../../api/catApi';
+import SeasonSelector from '../SeasonSelector';
+import Button from '../ui/Button';
+import './MapToolbar.css';
+
+interface MapToolbarProps {
+    season: Season;
+    scenarioActive: boolean;
+    scenarioDisabled?: boolean;
+    onSeasonChange: (season: Season) => void;
+    onOpenInsights: () => void;
+    onToggleScenario: () => void;
+}
+
+export default function MapToolbar({
+    season,
+    scenarioActive,
+    scenarioDisabled = false,
+    onSeasonChange,
+    onOpenInsights,
+    onToggleScenario,
+}: MapToolbarProps) {
+    return (
+        <header className="map-toolbar" aria-label="Map tools">
+            <div className="map-toolbar__brand">
+                <strong>TENeT</strong>
+                <span>Telehealth effectiveness and Necessity Tracker</span>
+            </div>
+
+            <div className="map-toolbar__divider" aria-hidden="true" />
+
+            <div className="map-toolbar__controls">
+                <div className="map-toolbar__season">
+                    <span className="map-toolbar__control-label">Season</span>
+                    <SeasonSelector season={season} onChange={onSeasonChange} />
+                </div>
+
+                <Button
+                    id="insights-toolbar-button"
+                    size="small"
+                    onClick={onOpenInsights}
+                    aria-label="Open Statewide Insights"
+                >
+                    Insights
+                </Button>
+
+                <Button
+                    id="scenario-toggle-button"
+                    data-testid="scenario-button"
+                    size="small"
+                    variant={scenarioActive ? 'primary' : 'secondary'}
+                    className={`map-toolbar__scenario-button${scenarioActive ? ' is-active' : ''}`}
+                    onClick={onToggleScenario}
+                    disabled={scenarioDisabled}
+                    aria-label={scenarioActive ? 'Exit scenario mode' : 'Open what-if scenario mode'}
+                    aria-pressed={scenarioActive}
+                    aria-expanded={scenarioActive}
+                    aria-controls="scenario-panel"
+                >
+                    {scenarioActive ? 'Scenario active' : 'Scenario'}
+                </Button>
+            </div>
+        </header>
+    );
+}

--- a/frontend/src/components/map/MapControllers.tsx
+++ b/frontend/src/components/map/MapControllers.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react';
+import { useMap, useMapEvents } from 'react-leaflet';
+import type { RegionSummary } from '../../api/catApi';
+import type { SelectableMapMarker } from '../../hooks/useMapSelection';
+
+interface MapViewportControllerProps {
+    center: [number, number];
+    zoom: number;
+    onViewportChange: (center: [number, number], zoom: number) => void;
+}
+
+export function MapViewportController({
+    center,
+    zoom,
+    onViewportChange,
+}: MapViewportControllerProps) {
+    const map = useMapEvents({
+        moveend: () => {
+            const nextCenter = map.getCenter();
+            onViewportChange(
+                [Number(nextCenter.lat.toFixed(5)), Number(nextCenter.lng.toFixed(5))],
+                map.getZoom(),
+            );
+        },
+        zoomend: () => {
+            const nextCenter = map.getCenter();
+            onViewportChange(
+                [Number(nextCenter.lat.toFixed(5)), Number(nextCenter.lng.toFixed(5))],
+                map.getZoom(),
+            );
+        },
+    });
+
+    useEffect(() => {
+        const current = map.getCenter();
+        if (
+            Math.abs(current.lat - center[0]) < 0.00001
+            && Math.abs(current.lng - center[1]) < 0.00001
+            && map.getZoom() === zoom
+        ) return;
+        map.setView(center, zoom, { animate: false });
+    }, [center, map, zoom]);
+
+    return null;
+}
+
+export function ComparisonMapController({ active }: { active: boolean }) {
+    const map = useMap();
+
+    useEffect(() => {
+        if (!active) return;
+        map.closePopup();
+        map.panBy([0, 96], { animate: true, duration: 0.25 });
+    }, [active, map]);
+
+    return null;
+}
+
+interface SelectionControllerProps {
+    selectedRegionCode: string | null;
+    regionSummaries: RegionSummary[];
+    markerRefs: React.MutableRefObject<Record<string, SelectableMapMarker>>;
+}
+
+export function SelectionController({
+    selectedRegionCode,
+    regionSummaries,
+    markerRefs,
+}: SelectionControllerProps) {
+    const map = useMap();
+
+    useEffect(() => {
+        if (!selectedRegionCode) return;
+        const selected = regionSummaries.find(region => region.region_code === selectedRegionCode);
+        if (!selected || selected.lat === null || selected.lon === null) return;
+
+        map.flyTo([selected.lat, selected.lon], Math.max(map.getZoom(), 8), { duration: 1.1 });
+        const timer = window.setTimeout(() => {
+            markerRefs.current[selectedRegionCode]?.openPopup();
+        }, 350);
+        return () => window.clearTimeout(timer);
+    }, [map, markerRefs, regionSummaries, selectedRegionCode]);
+
+    return null;
+}

--- a/frontend/src/components/map/MapLayers.css
+++ b/frontend/src/components/map/MapLayers.css
@@ -1,0 +1,111 @@
+.map-layer-state {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 1000;
+    max-width: 280px;
+    padding: 8px 12px;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    background: rgb(255 255 255 / 94%);
+    box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
+    color: #475569;
+    font-size: 12px;
+}
+
+.map-layer-state.is-error {
+    border-color: #fecaca;
+    color: #991b1b;
+}
+
+.region-marker-popup {
+    min-width: 210px;
+    max-width: 236px;
+    color: #172033;
+    font-size: 12px;
+}
+
+.region-marker-popup__title {
+    margin: 0 0 2px;
+    color: #111827;
+    font-size: 15px;
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+.region-marker-popup__code {
+    margin-bottom: 9px;
+    color: #64748b;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.region-marker-popup__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.region-marker-popup__button {
+    width: 100%;
+}
+
+.region-tooltip-content {
+    min-width: 200px;
+    font-family: system-ui, sans-serif;
+}
+
+.region-tooltip-title {
+    margin-bottom: 4px;
+    padding-bottom: 4px;
+    border-bottom: 2px solid var(--tooltip-color);
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.region-tooltip-metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+    margin-bottom: 6px;
+    font-size: 11px;
+}
+
+.region-tooltip-status {
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: var(--tooltip-color);
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+    text-align: center;
+}
+
+.region-tooltip-status.has-dark-text {
+    color: #1f2937;
+}
+
+.performance-popup {
+    min-width: 200px;
+    font-family: sans-serif;
+}
+
+.performance-popup__title {
+    margin-bottom: 8px;
+    color: var(--popup-color);
+    font-weight: 700;
+}
+
+.performance-popup__metrics {
+    margin-bottom: 8px;
+    padding: 6px;
+    border-radius: 4px;
+    background: #f3f4f6;
+    font-size: 11px;
+}
+
+.performance-popup__source {
+    color: #6b7280;
+    font-size: 10px;
+}

--- a/frontend/src/components/map/MapMarkers.css
+++ b/frontend/src/components/map/MapMarkers.css
@@ -1,0 +1,67 @@
+.custom-css-marker {
+    background: transparent;
+    border: 0;
+}
+
+.tenet-marker-shell {
+    width: var(--marker-shell-size);
+    height: var(--marker-shell-size);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+
+.tenet-marker-pin {
+    width: var(--marker-size);
+    height: var(--marker-size);
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    border: 1.5px solid #cbd5e1;
+    border-radius: 50% 50% 0 50%;
+    box-shadow: 1px 1px 2px rgb(0 0 0 / 15%);
+    transform: rotate(45deg);
+    transition: transform 0.15s ease-out;
+}
+
+.tenet-marker-pin:hover {
+    transform: rotate(45deg) scale(1.15);
+    z-index: 1000;
+}
+
+.tenet-marker-pin.is-selected {
+    border: 2px solid #475569;
+    box-shadow: 2px 2px 4px rgb(0 0 0 / 30%);
+}
+
+.tenet-marker-content {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: rotate(-45deg);
+}
+
+.tenet-marker-dot {
+    width: var(--marker-dot-size);
+    height: var(--marker-dot-size);
+    border-radius: 50%;
+    background: var(--marker-color);
+}
+
+.tenet-marker-pin.is-selected .tenet-marker-dot {
+    box-shadow: 0 0 0 2px white;
+}
+
+.tenet-marker-count {
+    position: absolute;
+    top: -14px;
+    color: #1e293b;
+    font-size: var(--marker-count-size);
+    font-weight: 800;
+}

--- a/frontend/src/components/scenario/ScenarioLayer.css
+++ b/frontend/src/components/scenario/ScenarioLayer.css
@@ -1,0 +1,165 @@
+.scenario-popup {
+    font-family: var(--font-family);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.scenario-popup__title {
+    margin-bottom: 8px;
+    color: var(--color-text);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.scenario-popup__grid,
+.scenario-sidebar-card__grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+}
+
+.scenario-popup__grid {
+    margin-bottom: 10px;
+}
+
+.scenario-popup__label,
+.scenario-sidebar-card__label {
+    color: var(--color-text-muted);
+}
+
+.scenario-popup__disclaimer {
+    padding-top: 8px;
+    border-top: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    font-size: 11px;
+    font-style: italic;
+    line-height: 1.4;
+}
+
+.scenario-popup__button {
+    width: 100%;
+    margin-top: 8px;
+}
+
+.scenario-sidebar-card {
+    margin: 12px 0;
+    padding: 14px;
+    border: 1px solid rgb(124 58 237 / 15%);
+    border-radius: var(--radius-lg);
+    background: var(--color-status-limited-subtle);
+}
+
+.scenario-sidebar-card__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.scenario-sidebar-card__title {
+    color: var(--color-status-limited);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.scenario-modeled-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    background: var(--color-status-limited);
+    color: var(--color-text-inverse);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.scenario-sidebar-card__grid {
+    font-size: 12px;
+}
+
+.scenario-sidebar-card__reasons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.scenario-sidebar-card__reason {
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-muted);
+    color: var(--color-text-muted);
+    font-family: monospace;
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.scenario-sidebar-card__explanation {
+    margin-top: 8px;
+    color: var(--color-text-muted);
+    font-size: 11px;
+    line-height: 1.4;
+}
+
+.scenario-legend {
+    max-width: 200px;
+    padding: 14px 16px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-overlay);
+    box-shadow: var(--shadow-md);
+    font-family: var(--font-family);
+    font-size: 12px;
+    backdrop-filter: blur(12px);
+}
+
+.scenario-legend__title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+    color: var(--color-text);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.scenario-legend__title .scenario-modeled-badge {
+    padding-inline: 5px;
+    background: var(--color-surface-muted);
+    color: var(--color-text-secondary);
+}
+
+.scenario-legend__items {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.scenario-legend__item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.scenario-legend__swatch {
+    width: 10px;
+    height: 10px;
+    flex-shrink: 0;
+    border-radius: var(--radius-full);
+}
+
+.scenario-legend__label {
+    color: var(--color-text-secondary);
+    font-size: 11px;
+}
+
+.scenario-legend__note {
+    margin-top: 8px;
+    color: var(--color-text-muted);
+    font-size: 10px;
+    font-style: italic;
+    line-height: 1.4;
+}

--- a/frontend/src/components/scenario/ScenarioLayer.tsx
+++ b/frontend/src/components/scenario/ScenarioLayer.tsx
@@ -9,10 +9,27 @@ import React, { memo } from 'react';
 import { Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import type { ScenarioPreviewResponse, ScenarioRegion } from '../../types/scenario';
-import { getScenarioStatusColor, getScenarioDeltaColor } from '../../types/scenario';
-import { formatStatus } from '../sidebar/sidebarUtils';
-import { createMarkerIcon } from '../../utils/markerUtils';
+import { getScenarioDeltaColor } from '../../types/scenario';
+import {
+    getTelehealthStatusColor,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+    isScenarioTelehealthStatus,
+    SCENARIO_TELEHEALTH_STATUSES,
+    type ScenarioTelehealthStatusName,
+} from '../../domain/statusPresentation';
+import {
+    createMarkerIcon,
+    getClusterMarkerSize,
+    getMarkerMetadata,
+    setMarkerMetadata,
+    type MarkerClusterLike,
+} from '../../utils/markerUtils';
 import MarkerClusterGroup from 'react-leaflet-cluster';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
+import '../MapModeLegends.css';
+import './ScenarioLayer.css';
 
 interface ScenarioLayerProps {
     data: ScenarioPreviewResponse | null;
@@ -48,95 +65,70 @@ const ScenarioMarker = memo(function ScenarioMarker({
 }: ScenarioMarkerProps) {
     if (region.lat === null || region.lon === null) return null;
 
-    const color = getScenarioStatusColor(region.scenario_status);
+    const color = getTelehealthStatusColor(region.scenario_status, 'scenario');
     return (
         <Marker
             position={[region.lat, region.lon]}
+            alt={`${region.name} scenario marker`}
+            title={region.name}
             icon={createMarkerIcon(color, selected)}
             eventHandlers={{
                 click: () => onSelect(region.region_code),
             }}
             ref={(marker) => {
                 if (marker) {
-                    (marker.options as any).scenarioStatus = region.scenario_status;
+                    setMarkerMetadata(marker, { scenarioStatus: region.scenario_status });
                 }
                 onMarkerReady?.(region.region_code, marker);
             }}
         >
             <Popup maxWidth={280}>
-                <div style={{
-                    fontFamily: "'Inter', sans-serif",
-                    fontSize: '13px',
-                    lineHeight: 1.5,
-                }}>
-                    <div style={{
-                        fontWeight: 700,
-                        fontSize: '14px',
-                        marginBottom: '8px',
-                        color: '#0f172a',
-                    }}>
+                <div className="scenario-popup">
+                    <div className="scenario-popup__title">
                         {region.name}
                     </div>
 
-                    <div style={{
-                        display: 'grid',
-                        gridTemplateColumns: 'auto 1fr',
-                        gap: '4px 12px',
-                        marginBottom: '10px',
-                    }}>
-                        <span style={{ color: '#64748b' }}>Baseline Status</span>
-                        <strong style={{ color: getScenarioStatusColor(region.baseline_status) }}>
-                            {formatStatus(region.baseline_status)}
-                        </strong>
+                    <div className="scenario-popup__grid">
+                        <span className="scenario-popup__label">Baseline Status</span>
+                        <StatusBadge tone={getTelehealthStatusTone(region.baseline_status)}>
+                            {getTelehealthStatusLabel(region.baseline_status)}
+                        </StatusBadge>
 
-                        <span style={{ color: '#64748b' }}>Scenario Status</span>
-                        <strong style={{ color: getScenarioStatusColor(region.scenario_status) }}>
-                            {formatStatus(region.scenario_status)}
-                        </strong>
+                        <span className="scenario-popup__label">Scenario Status</span>
+                        <StatusBadge tone={getTelehealthStatusTone(region.scenario_status)}>
+                            {getTelehealthStatusLabel(region.scenario_status)}
+                        </StatusBadge>
 
                         {region.changed && (
                             <>
-                                <span style={{ color: '#64748b' }}>Change</span>
+                                <span className="scenario-popup__label">Change</span>
                                 <strong style={{ color: getScenarioDeltaColor(region.status_delta) }}>
                                     {deltaSymbol(region.status_delta)} {region.status_delta}
                                 </strong>
                             </>
                         )}
 
-                        <span style={{ color: '#64748b' }}>Need Score</span>
-                        <strong>{region.scenario_need_score}</strong>
+                        <span className="scenario-popup__label">Need Score</span>
+                        <strong>
+                            {Number.isFinite(region.scenario_need_score)
+                                ? region.scenario_need_score
+                                : 'Data unavailable'}
+                        </strong>
                     </div>
 
-                    <div style={{
-                        fontSize: '11px',
-                        color: '#64748b',
-                        fontStyle: 'italic',
-                        borderTop: '1px solid #e2e8f0',
-                        paddingTop: '8px',
-                        lineHeight: 1.4,
-                    }}>
+                    <div className="scenario-popup__disclaimer">
                         This scenario result is modeled from selected thresholds
                         and should not be interpreted as observed field data.
                     </div>
 
-                    <button
-                        type="button"
+                    <Button
+                        size="small"
+                        variant="secondary"
                         onClick={() => onViewDetails(region.region_code)}
-                        style={{
-                            marginTop: '8px',
-                            padding: '5px 12px',
-                            border: '1px solid #e2e8f0',
-                            borderRadius: '6px',
-                            background: 'white',
-                            color: '#475569',
-                            fontSize: '12px',
-                            fontWeight: 600,
-                            cursor: 'pointer',
-                            width: '100%',
-                        }}
+                        className="scenario-popup__button"
                     >
                         View Details →
-                    </button>
+                    </Button>
                 </div>
             </Popup>
         </Marker>
@@ -144,34 +136,31 @@ const ScenarioMarker = memo(function ScenarioMarker({
 });
 
 // Custom cluster icon for Scenario mode
-const createScenarioClusterIcon = function (cluster: any) {
+const createScenarioClusterIcon = function (cluster: MarkerClusterLike) {
   const pointCount = cluster.getChildCount();
   const markers = cluster.getAllChildMarkers();
 
   // Find the most frequent scenario status in the cluster
-  const statusCounts: Record<string, number> = {};
-  markers.forEach((marker: any) => {
-    const status = marker.options.scenarioStatus || 'DATA_UNAVAILABLE';
-    statusCounts[status] = (statusCounts[status] || 0) + 1;
+  const statusCounts: Partial<Record<ScenarioTelehealthStatusName, number>> = {};
+  markers.forEach(marker => {
+    const candidate: unknown = getMarkerMetadata(marker).scenarioStatus;
+    const status = isScenarioTelehealthStatus(candidate) ? candidate : 'DATA_UNAVAILABLE';
+    statusCounts[status] = (statusCounts[status] ?? 0) + 1;
   });
 
-  let dominantStatus = 'DATA_UNAVAILABLE';
+  let dominantStatus: ScenarioTelehealthStatusName = 'DATA_UNAVAILABLE';
   let maxCount = 0;
-  Object.entries(statusCounts).forEach(([status, count]) => {
+  SCENARIO_TELEHEALTH_STATUSES.forEach(status => {
+    const count = statusCounts[status] ?? 0;
     if (count > maxCount) {
       dominantStatus = status;
       maxCount = count;
     }
   });
 
-  const clusterColor = getScenarioStatusColor(dominantStatus as any);
+  const clusterColor = getTelehealthStatusColor(dominantStatus, 'scenario');
 
-  let scale = 1.0;
-  if (pointCount >= 200) scale = 1.5;
-  else if (pointCount >= 50) scale = 1.35;
-  else if (pointCount >= 10) scale = 1.2;
-
-  const size = 24 * scale;
+  const size = getClusterMarkerSize(pointCount);
   return createMarkerIcon(clusterColor, false, size, pointCount.toString());
 };
 
@@ -219,90 +208,50 @@ export function ScenarioSidebarCard({ region }: ScenarioSidebarCardProps) {
     if (!region) return null;
 
     return (
-        <section style={{
-            margin: '12px 0',
-            padding: '14px',
-            borderRadius: '10px',
-            background: 'linear-gradient(135deg, rgba(124,58,237,0.06) 0%, rgba(124,58,237,0.02) 100%)',
-            border: '1px solid rgba(124,58,237,0.15)',
-        }}>
-            <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                marginBottom: '10px',
-            }}>
-                <span style={{
-                    fontSize: '11px',
-                    fontWeight: 700,
-                    color: '#7c3aed',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.06em',
-                }}>
+        <section className="scenario-sidebar-card">
+            <div className="scenario-sidebar-card__header">
+                <span className="scenario-sidebar-card__title">
                     Scenario Estimate
                 </span>
-                <span style={{
-                    display: 'inline-block',
-                    background: 'linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%)',
-                    color: 'white',
-                    fontSize: '9px',
-                    fontWeight: 700,
-                    padding: '1px 6px',
-                    borderRadius: '3px',
-                    letterSpacing: '0.04em',
-                }}>
+                <span className="scenario-modeled-badge">
                     MODELED
                 </span>
             </div>
 
-            <div style={{
-                display: 'grid',
-                gridTemplateColumns: 'auto 1fr',
-                gap: '4px 12px',
-                fontSize: '12px',
-            }}>
-                <span style={{ color: '#64748b' }}>Baseline Status</span>
-                <strong style={{ color: getScenarioStatusColor(region.baseline_status) }}>
-                    {formatStatus(region.baseline_status)}
+            <div className="scenario-sidebar-card__grid">
+                <span className="scenario-sidebar-card__label">Baseline Status</span>
+                <strong style={{ color: getTelehealthStatusColor(region.baseline_status) }}>
+                    {getTelehealthStatusLabel(region.baseline_status)}
                 </strong>
 
-                <span style={{ color: '#64748b' }}>Scenario Status</span>
-                <strong style={{ color: getScenarioStatusColor(region.scenario_status) }}>
-                    {formatStatus(region.scenario_status)}
+                <span className="scenario-sidebar-card__label">Scenario Status</span>
+                <strong style={{ color: getTelehealthStatusColor(region.scenario_status, 'scenario') }}>
+                    {getTelehealthStatusLabel(region.scenario_status)}
                 </strong>
 
-                <span style={{ color: '#64748b' }}>Need Score Delta</span>
+                <span className="scenario-sidebar-card__label">Need Score Delta</span>
                 <strong style={{
-                    color: region.need_score_delta < 0
-                        ? '#22c55e'
-                        : region.need_score_delta > 0
-                            ? '#ef4444'
-                            : '#94a3b8',
+                    color: !Number.isFinite(region.need_score_delta)
+                        ? '#94a3b8'
+                        : region.need_score_delta < 0
+                            ? '#22c55e'
+                            : region.need_score_delta > 0
+                                ? '#ef4444'
+                                : '#94a3b8',
                 }}>
-                    {region.need_score_delta > 0 ? '+' : ''}{region.need_score_delta}
+                    {Number.isFinite(region.need_score_delta)
+                        ? `${region.need_score_delta > 0 ? '+' : ''}${region.need_score_delta}`
+                        : 'Data unavailable'}
                 </strong>
             </div>
 
             {/* Reason codes */}
             {region.reason_codes.length > 0 && (
-                <div style={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: '4px',
-                    marginTop: '8px',
-                }}>
+                <div className="scenario-sidebar-card__reasons">
                     {region.reason_codes.map(code => (
                         <span
                             key={code}
-                            style={{
-                                fontSize: '10px',
-                                fontWeight: 600,
-                                color: '#64748b',
-                                background: 'rgba(0,0,0,0.04)',
-                                padding: '2px 6px',
-                                borderRadius: '3px',
-                                fontFamily: 'monospace',
-                            }}
+                            className="scenario-sidebar-card__reason"
                         >
                             {code}
                         </span>
@@ -311,12 +260,7 @@ export function ScenarioSidebarCard({ region }: ScenarioSidebarCardProps) {
             )}
 
             {region.explanation && (
-                <div style={{
-                    fontSize: '11px',
-                    color: '#64748b',
-                    marginTop: '8px',
-                    lineHeight: 1.4,
-                }}>
+                <div className="scenario-sidebar-card__explanation">
                     {region.explanation}
                 </div>
             )}
@@ -327,89 +271,38 @@ export function ScenarioSidebarCard({ region }: ScenarioSidebarCardProps) {
 /* ─── Scenario Legend ──────────────────────────────────────────────────── */
 
 export function ScenarioLegend() {
-    const STATUS_ITEMS = [
-        { status: 'TELEHEALTH_READY', label: 'Telehealth Ready' },
-        { status: 'COMMUNITY_ANCHOR', label: 'Community Anchor' },
-        { status: 'LIMITED_TELEHEALTH', label: 'Limited Telehealth' },
-        { status: 'CRITICAL_GAP', label: 'Critical Gap' },
-        { status: 'DATA_UNAVAILABLE', label: 'Data Unavailable' },
-    ];
+    const statusItems = SCENARIO_TELEHEALTH_STATUSES.map(status => ({
+        status,
+        label: getTelehealthStatusLabel(status),
+    }));
 
     return (
-        <div style={{
-            position: 'absolute',
-            bottom: '30px',
-            left: '20px',
-            zIndex: 1000,
-            background: 'rgba(255, 255, 255, 0.95)',
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            padding: '14px 16px',
-            borderRadius: '10px',
-            boxShadow: '0 4px 16px rgba(31, 38, 135, 0.1)',
-            border: '1px solid rgba(255, 255, 255, 0.3)',
-            fontSize: '12px',
-            fontFamily: "'Inter', sans-serif",
-            maxWidth: '200px',
-        }}>
-            <div style={{
-                fontWeight: 700,
-                fontSize: '12px',
-                color: '#0f172a',
-                marginBottom: '4px',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-            }}>
+        <div className="scenario-legend">
+            <div className="scenario-legend__title">
                 What-If Scenario
-                <span style={{
-                    fontSize: '9px',
-                    fontWeight: 700,
-                    color: '#334155',
-                    background: '#e2e8f0',
-                    padding: '1px 5px',
-                    borderRadius: '3px',
-                }}>
+                <span className="scenario-modeled-badge">
                     MODELED
                 </span>
             </div>
 
-            <div style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '4px',
-                marginTop: '8px',
-            }}>
-                {STATUS_ITEMS.map(item => (
+            <div className="scenario-legend__items">
+                {statusItems.map(item => (
                     <div
                         key={item.status}
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '8px',
-                        }}
+                        className="scenario-legend__item"
                     >
-                        <span style={{
-                            width: '10px',
-                            height: '10px',
-                            borderRadius: '50%',
-                            background: getScenarioStatusColor(item.status),
-                            flexShrink: 0,
-                        }} />
-                        <span style={{ color: '#475569', fontSize: '11px' }}>
+                        <span
+                            className="scenario-legend__swatch"
+                            style={{ backgroundColor: getTelehealthStatusColor(item.status, 'scenario') }}
+                        />
+                        <span className="scenario-legend__label">
                             {item.label}
                         </span>
                     </div>
                 ))}
             </div>
 
-            <div style={{
-                fontSize: '10px',
-                color: '#94a3b8',
-                marginTop: '8px',
-                lineHeight: 1.4,
-                fontStyle: 'italic',
-            }}>
+            <div className="scenario-legend__note">
                 Scenario colors represent modeled telehealth readiness under the selected thresholds.
                 Baseline data remains unchanged.
             </div>

--- a/frontend/src/components/scenario/ScenarioPanel.css
+++ b/frontend/src/components/scenario/ScenarioPanel.css
@@ -1,0 +1,234 @@
+.scenario-panel {
+  position: relative;
+  z-index: 1;
+  width: 340px;
+  max-height: calc(100vh - 170px);
+  overflow-y: auto;
+  background: var(--color-surface-overlay);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 20px;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.scenario-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 14px;
+}
+
+.scenario-panel__title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.scenario-panel__badge {
+  display: inline-block;
+  margin-top: 4px;
+  background: var(--color-status-limited);
+  color: var(--color-text-inverse);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.scenario-panel__disclaimer {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  line-height: 1.4;
+  margin-bottom: 16px;
+  padding: 8px 10px;
+  background: var(--color-status-limited-subtle);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-status-limited);
+}
+
+.scenario-panel__section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+  margin-top: 16px;
+}
+
+.scenario-panel__select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+}
+
+.scenario-panel__slider-group {
+  margin-bottom: 12px;
+}
+
+.scenario-panel__slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.scenario-panel__slider-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.scenario-panel__slider-value {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-status-limited);
+  font-variant-numeric: tabular-nums;
+}
+
+.scenario-panel__impact-row {
+  display: flex;
+  gap: 6px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.scenario-panel__impact-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.scenario-panel__status-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 12px;
+  margin-top: 10px;
+  font-size: 12px;
+}
+
+.scenario-panel__status-grid > span {
+  color: var(--color-text-muted);
+}
+
+.scenario-panel__status-grid > strong {
+  text-align: right;
+}
+
+.scenario-panel__impact-note {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-top: 8px;
+  line-height: 1.4;
+}
+
+.scenario-panel__loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: rgba(124, 58, 237, 0.1);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  color: var(--color-status-limited);
+  margin-top: 12px;
+}
+
+.scenario-panel__spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(124, 58, 237, 0.3);
+  border-top-color: var(--color-status-limited);
+  border-radius: var(--radius-full);
+  animation: scenario-spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+.scenario-panel__error {
+  padding: 8px 10px;
+  background: var(--color-danger-subtle);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  color: var(--color-danger);
+  margin-top: 8px;
+}
+
+.scenario-panel__use-baseline {
+  color: var(--color-status-limited);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+@keyframes scenario-spin {
+  to { transform: rotate(360deg); }
+}
+
+.scenario-panel::-webkit-scrollbar {
+  width: 5px;
+}
+
+.scenario-panel::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scenario-panel::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.scenario-panel input[type="range"] {
+  height: 4px;
+  border-radius: 2px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--color-surface-muted);
+  outline: none;
+}
+
+.scenario-panel input[type="range"]:focus-visible {
+  box-shadow: var(--focus-ring);
+}
+
+.scenario-panel select:focus-visible {
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
+}
+
+.scenario-panel input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: var(--color-status-limited);
+  border: 2px solid var(--color-surface);
+  cursor: pointer;
+  transition: transform var(--transition-fast);
+}
+
+.scenario-panel input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}

--- a/frontend/src/components/scenario/ScenarioPanel.tsx
+++ b/frontend/src/components/scenario/ScenarioPanel.tsx
@@ -5,267 +5,71 @@
  * Contains threshold sliders, preset selector, impact summary,
  * and a "Modeled Output" label.
  */
-import React, { useCallback, useMemo, useState } from 'react';
 import type { ScenarioState } from '../../hooks/useScenarioState';
 import type { ScenarioPreviewState } from '../../hooks/useScenarioPreview';
-import {
-    BASELINE_THRESHOLDS,
-    SCENARIO_PRESETS,
-    type ScenarioThresholds,
-} from '../../types/scenario';
-
-/* ─── Styling ──────────────────────────────────────────────────────────── */
-
-const PANEL_STYLE: React.CSSProperties = {
-    position: 'relative',
-    zIndex: 1,
-    width: 340,
-    maxHeight: 'calc(100vh - 170px)',
-    overflowY: 'auto',
-    background: 'rgba(15, 23, 42, 0.94)',
-    backdropFilter: 'blur(16px)',
-    WebkitBackdropFilter: 'blur(16px)',
-    borderRadius: '14px',
-    boxShadow: '0 8px 40px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255,255,255,0.06)',
-    padding: '20px',
-    color: '#e2e8f0',
-    fontFamily: "'Inter', -apple-system, sans-serif",
-    fontSize: '13px',
-    lineHeight: '1.5',
-};
-
-const HEADER_STYLE: React.CSSProperties = {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginBottom: '14px',
-};
-
-const TITLE_STYLE: React.CSSProperties = {
-    fontSize: '15px',
-    fontWeight: 700,
-    color: '#f1f5f9',
-    letterSpacing: '-0.01em',
-    margin: 0,
-};
-
-const BADGE_STYLE: React.CSSProperties = {
-    display: 'inline-block',
-    background: 'linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%)',
-    color: 'white',
-    fontSize: '10px',
-    fontWeight: 700,
-    padding: '2px 7px',
-    borderRadius: '4px',
-    letterSpacing: '0.04em',
-    textTransform: 'uppercase' as const,
-};
-
-const CLOSE_BTN_STYLE: React.CSSProperties = {
-    appearance: 'none',
-    border: 'none',
-    background: 'rgba(255,255,255,0.08)',
-    color: '#94a3b8',
-    width: '28px',
-    height: '28px',
-    borderRadius: '6px',
-    cursor: 'pointer',
-    fontSize: '16px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    transition: 'background 0.15s',
-};
-
-const DISCLAIMER_STYLE: React.CSSProperties = {
-    fontSize: '11px',
-    color: '#94a3b8',
-    fontStyle: 'italic',
-    lineHeight: 1.4,
-    marginBottom: '16px',
-    padding: '8px 10px',
-    background: 'rgba(255,255,255,0.04)',
-    borderRadius: '6px',
-    borderLeft: '3px solid #7c3aed',
-};
-
-const SECTION_TITLE: React.CSSProperties = {
-    fontSize: '11px',
-    fontWeight: 600,
-    color: '#94a3b8',
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.06em',
-    marginBottom: '8px',
-    marginTop: '16px',
-};
-
-const SELECT_STYLE: React.CSSProperties = {
-    width: '100%',
-    padding: '8px 10px',
-    borderRadius: '8px',
-    border: '1px solid rgba(255,255,255,0.1)',
-    background: 'rgba(255,255,255,0.06)',
-    color: '#e2e8f0',
-    fontSize: '13px',
-    fontWeight: 500,
-    cursor: 'pointer',
-    outline: 'none',
-};
-
-const SLIDER_CONTAINER: React.CSSProperties = {
-    marginBottom: '12px',
-};
-
-const SLIDER_LABEL: React.CSSProperties = {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: '4px',
-};
-
-const SLIDER_NAME: React.CSSProperties = {
-    fontSize: '12px',
-    fontWeight: 500,
-    color: '#cbd5e1',
-};
-
-const SLIDER_VALUE: React.CSSProperties = {
-    fontSize: '12px',
-    fontWeight: 700,
-    color: '#7c3aed',
-    fontVariantNumeric: 'tabular-nums',
-};
-
-const IMPACT_ROW: React.CSSProperties = {
-    display: 'flex',
-    gap: '6px',
-    marginTop: '12px',
-    flexWrap: 'wrap',
-};
-
-const IMPACT_CHIP: (color: string) => React.CSSProperties = (color) => ({
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '4px',
-    padding: '4px 10px',
-    borderRadius: '20px',
-    background: `${color}18`,
-    border: `1px solid ${color}40`,
-    fontSize: '12px',
-    fontWeight: 600,
-    color,
-    fontVariantNumeric: 'tabular-nums',
-});
-
-const RESET_BTN: React.CSSProperties = {
-    width: '100%',
-    marginTop: '16px',
-    padding: '9px 0',
-    border: '1px solid rgba(255,255,255,0.12)',
-    borderRadius: '8px',
-    background: 'rgba(255,255,255,0.05)',
-    color: '#94a3b8',
-    fontSize: '12px',
-    fontWeight: 600,
-    cursor: 'pointer',
-    transition: 'all 0.15s',
-};
-
-const IMPACT_NOTE: React.CSSProperties = {
-    fontSize: '10px',
-    color: '#64748b',
-    fontStyle: 'italic',
-    marginTop: '8px',
-    lineHeight: 1.4,
-};
-
-const LOADING_STYLE: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    padding: '8px 10px',
-    background: 'rgba(124, 58, 237, 0.1)',
-    borderRadius: '6px',
-    fontSize: '12px',
-    color: '#a78bfa',
-    marginTop: '12px',
-};
-
-const ERROR_STYLE: React.CSSProperties = {
-    padding: '8px 10px',
-    background: 'rgba(239, 68, 68, 0.1)',
-    borderRadius: '6px',
-    fontSize: '12px',
-    color: '#fca5a5',
-    marginTop: '8px',
-};
+import { SCENARIO_PRESETS } from '../../types/scenario';
+import { getTelehealthStatusLabel } from '../../domain/statusPresentation';
+import Button from '../ui/Button';
+import IconButton from '../ui/IconButton';
+import './ScenarioPanel.css';
 
 /* ─── Component ────────────────────────────────────────────────────────── */
 
 interface ScenarioPanelProps {
     scenario: ScenarioState;
     preview: ScenarioPreviewState;
-    gapModeActive?: boolean;
-    onClose?: () => void;
+    onClose: () => void;
 }
 
 export default function ScenarioPanel({
     scenario,
     preview,
-    gapModeActive = false,
     onClose,
 }: ScenarioPanelProps) {
-    const { mode, thresholds, activePreset, setThreshold, applyPreset, resetToBaseline, deactivate } = scenario;
+    const { mode, thresholds, activePreset, setThreshold, applyPreset, resetToBaseline } = scenario;
     const { data, loading, error } = preview;
-    const closePanel = onClose ?? deactivate;
+    const closePanel = () => {
+        onClose();
+        window.requestAnimationFrame(() => {
+            document.getElementById('scenario-toggle-button')?.focus();
+        });
+    };
 
     if (mode === 'off') return null;
 
     return (
-        <div style={PANEL_STYLE} id="scenario-panel" data-testid="scenario-panel">
+        <div className="scenario-panel" id="scenario-panel" data-testid="scenario-panel">
             {/* Header */}
-            <div style={HEADER_STYLE}>
+            <div className="scenario-panel__header">
                 <div>
-                    <h3 style={TITLE_STYLE}>What-If Scenarios</h3>
-                    <span style={{ ...BADGE_STYLE, marginTop: '4px' }}>Modeled Output</span>
+                    <h3 className="scenario-panel__title">What-If Scenarios</h3>
+                    <span className="scenario-panel__badge">Modeled Output</span>
                 </div>
-                <button
-                    type="button"
-                    style={CLOSE_BTN_STYLE}
+                <IconButton
+                    icon="×"
+                    size="small"
                     onClick={closePanel}
                     aria-label="Close scenario panel"
                     title="Close scenario mode"
-                >
-                    ✕
-                </button>
+                />
             </div>
 
             {/* Disclaimer */}
-            <div style={DISCLAIMER_STYLE}>
+            <div className="scenario-panel__disclaimer">
                 Scenario Mode shows modeled estimates based on selected thresholds.
                 It does not represent observed ground truth and does not modify TENeT's baseline data.
             </div>
 
-            {/* Gap Hunter note */}
-            {gapModeActive && (
-                <div style={{
-                    ...DISCLAIMER_STYLE,
-                    borderLeftColor: '#f59e0b',
-                    background: 'rgba(245, 158, 11, 0.06)',
-                }}>
-                    Gap Hunter displays observed measurement data and is not affected by scenario thresholds.
-                </div>
-            )}
-
             {/* Preset */}
             <label
-                style={{ ...SECTION_TITLE, display: 'block' }}
+                className="scenario-panel__section-title"
+                style={{ display: 'block' }}
                 htmlFor="scenario-preset-select"
             >
                 Preset
             </label>
             <select
-                style={SELECT_STYLE}
+                className="scenario-panel__select"
                 value={activePreset ?? ''}
                 onChange={e => {
                     const value = e.target.value;
@@ -285,7 +89,7 @@ export default function ScenarioPanel({
             </select>
 
             {/* Broadband */}
-            <div style={SECTION_TITLE}>Broadband</div>
+            <div className="scenario-panel__section-title">Broadband</div>
             <ThresholdSlider
                 label="Download"
                 unit="Mbps"
@@ -306,37 +110,30 @@ export default function ScenarioPanel({
             />
 
             {/* Clinic Proximity */}
-            <div style={SECTION_TITLE}>Clinic Proximity</div>
-            <div style={SLIDER_CONTAINER}>
-                <div style={SLIDER_LABEL}>
-                    <span style={SLIDER_NAME}>
+            <div className="scenario-panel__section-title">Clinic Proximity</div>
+            <div className="scenario-panel__slider-group">
+                <div className="scenario-panel__slider-header">
+                    <span className="scenario-panel__slider-name">
                         {thresholds.clinic_proximity_km === null
                             ? 'Baseline road/water/air rules'
                             : `Override: ${thresholds.clinic_proximity_km} km`
                         }
                     </span>
                     {thresholds.clinic_proximity_km !== null && (
-                        <button
-                            type="button"
+                        <Button
+                            variant="ghost"
+                            size="small"
+                            className="scenario-panel__use-baseline"
                             onClick={() => setThreshold('clinic_proximity_km', null)}
-                            style={{
-                                appearance: 'none',
-                                border: 'none',
-                                background: 'none',
-                                color: '#7c3aed',
-                                cursor: 'pointer',
-                                fontSize: '11px',
-                                fontWeight: 600,
-                                padding: 0,
-                            }}
                         >
                             Use baseline
-                        </button>
+                        </Button>
                     )}
                 </div>
                 {thresholds.clinic_proximity_km !== null ? (
                     <input
                         type="range"
+                        aria-label="Clinic proximity threshold"
                         min={5}
                         max={200}
                         step={5}
@@ -346,23 +143,19 @@ export default function ScenarioPanel({
                         id="scenario-clinic-slider"
                     />
                 ) : (
-                    <button
-                        type="button"
+                    <Button
+                        variant="secondary"
+                        size="small"
+                        style={{ width: '100%', marginTop: '4px' }}
                         onClick={() => setThreshold('clinic_proximity_km', 25)}
-                        style={{
-                            ...RESET_BTN,
-                            marginTop: '4px',
-                            padding: '6px 0',
-                            fontSize: '11px',
-                        }}
                     >
                         Override with custom distance
-                    </button>
+                    </Button>
                 )}
             </div>
 
             {/* Affordability */}
-            <div style={SECTION_TITLE}>Affordability</div>
+            <div className="scenario-panel__section-title">Affordability</div>
             <ThresholdSlider
                 label="Burden threshold"
                 unit="%"
@@ -375,61 +168,56 @@ export default function ScenarioPanel({
 
             {/* Loading */}
             {loading && (
-                <div style={LOADING_STYLE}>
-                    <span style={{
-                        width: '14px',
-                        height: '14px',
-                        border: '2px solid rgba(124,58,237,0.3)',
-                        borderTopColor: '#7c3aed',
-                        borderRadius: '50%',
-                        animation: 'scenario-spin 0.6s linear infinite',
-                        flexShrink: 0,
-                    }} />
+                <div className="scenario-panel__loading" role="status">
+                    <span className="scenario-panel__spinner" aria-hidden="true" />
                     Calculating scenario…
                 </div>
             )}
 
             {/* Error */}
-            {error && <div style={ERROR_STYLE}>{error}</div>}
+            {error && <div className="scenario-panel__error" role="alert">{error}</div>}
 
             {/* Impact Summary */}
             {data && !loading && (
                 <>
-                    <div style={SECTION_TITLE}>Impact Summary</div>
+                    <div className="scenario-panel__section-title">Impact Summary</div>
                     <div data-testid="scenario-summary">
-                    <div style={IMPACT_ROW}>
-                        <span style={IMPACT_CHIP('#f59e0b')}>
+                    <div className="scenario-panel__impact-row">
+                        <span
+                            className="scenario-panel__impact-chip"
+                            style={{ background: '#f59e0b18', border: '1px solid #f59e0b40', color: '#f59e0b' }}
+                        >
                             Changed {data.summary.status_changed_regions}
                         </span>
-                        <span style={IMPACT_CHIP('#22c55e')}>
-                            ▲ {data.summary.improved_count}
+                        <span
+                            className="scenario-panel__impact-chip"
+                            style={{ background: '#15803d18', border: '1px solid #15803d40', color: '#15803d' }}
+                        >
+                            Improved ▲ {data.summary.improved_count}
                         </span>
-                        <span style={IMPACT_CHIP('#ef4444')}>
-                            ▼ {data.summary.worsened_count}
+                        <span
+                            className="scenario-panel__impact-chip"
+                            style={{ background: '#b4231818', border: '1px solid #b4231840', color: '#b42318' }}
+                        >
+                            Worsened ▼ {data.summary.worsened_count}
                         </span>
                     </div>
 
                     {/* Status distribution */}
-                    <div style={{
-                        display: 'grid',
-                        gridTemplateColumns: '1fr 1fr',
-                        gap: '4px 12px',
-                        marginTop: '10px',
-                        fontSize: '12px',
-                    }}>
-                        <span style={{ color: '#94a3b8' }}>Telehealth Ready</span>
-                        <strong style={{ color: '#22c55e', textAlign: 'right' }}>{data.summary.telehealth_ready}</strong>
-                        <span style={{ color: '#94a3b8' }}>Community Anchor</span>
-                        <strong style={{ color: '#f59e0b', textAlign: 'right' }}>{data.summary.community_anchor}</strong>
-                        <span style={{ color: '#94a3b8' }}>Limited Telehealth</span>
-                        <strong style={{ color: '#8b5cf6', textAlign: 'right' }}>{data.summary.limited_telehealth}</strong>
-                        <span style={{ color: '#94a3b8' }}>Critical Gap</span>
-                        <strong style={{ color: '#ef4444', textAlign: 'right' }}>{data.summary.critical_gap}</strong>
-                        <span style={{ color: '#94a3b8' }}>Data Unavailable</span>
-                        <strong style={{ color: '#6b7280', textAlign: 'right' }}>{data.summary.data_unavailable}</strong>
+                    <div className="scenario-panel__status-grid">
+                        <span>{getTelehealthStatusLabel('TELEHEALTH_READY')}</span>
+                        <strong style={{ color: 'var(--color-status-ready)' }}>{data.summary.telehealth_ready}</strong>
+                        <span>{getTelehealthStatusLabel('COMMUNITY_ANCHOR')}</span>
+                        <strong style={{ color: 'var(--color-status-anchor)' }}>{data.summary.community_anchor}</strong>
+                        <span>{getTelehealthStatusLabel('LIMITED_TELEHEALTH')}</span>
+                        <strong style={{ color: 'var(--color-status-limited)' }}>{data.summary.limited_telehealth}</strong>
+                        <span>{getTelehealthStatusLabel('CRITICAL_GAP')}</span>
+                        <strong style={{ color: 'var(--color-status-gap)' }}>{data.summary.critical_gap}</strong>
+                        <span>{getTelehealthStatusLabel('DATA_UNAVAILABLE')}</span>
+                        <strong style={{ color: 'var(--color-status-unknown)' }}>{data.summary.data_unavailable}</strong>
                     </div>
 
-                    <div style={IMPACT_NOTE}>
+                    <div className="scenario-panel__impact-note">
                         These counts show how classifications would change under the selected assumptions.
                         They do not indicate actual measured changes in infrastructure or healthcare access.
                     </div>
@@ -438,56 +226,15 @@ export default function ScenarioPanel({
             )}
 
             {/* Reset */}
-            <button
-                type="button"
-                style={RESET_BTN}
+            <Button
+                variant="secondary"
+                size="small"
+                style={{ width: '100%', marginTop: '16px' }}
                 onClick={resetToBaseline}
                 id="scenario-reset-button"
             >
                 Reset to Baseline
-            </button>
-
-            {/* Spinner keyframes */}
-            <style>{`
-                @keyframes scenario-spin {
-                    to { transform: rotate(360deg); }
-                }
-                #scenario-panel::-webkit-scrollbar {
-                    width: 5px;
-                }
-                #scenario-panel::-webkit-scrollbar-track {
-                    background: transparent;
-                }
-                #scenario-panel::-webkit-scrollbar-thumb {
-                    background: rgba(255,255,255,0.1);
-                    border-radius: 4px;
-                }
-                #scenario-panel input[type="range"] {
-                    height: 4px;
-                    border-radius: 2px;
-                    -webkit-appearance: none;
-                    appearance: none;
-                    background: rgba(255,255,255,0.12);
-                    outline: none;
-                }
-                #scenario-panel input[type="range"]::-webkit-slider-thumb {
-                    -webkit-appearance: none;
-                    width: 16px;
-                    height: 16px;
-                    border-radius: 50%;
-                    background: #7c3aed;
-                    border: 2px solid rgba(255,255,255,0.2);
-                    cursor: pointer;
-                    transition: transform 0.15s;
-                }
-                #scenario-panel input[type="range"]::-webkit-slider-thumb:hover {
-                    transform: scale(1.15);
-                }
-                #scenario-reset-button:hover {
-                    background: rgba(255,255,255,0.1) !important;
-                    color: #e2e8f0 !important;
-                }
-            `}</style>
+            </Button>
         </div>
     );
 }
@@ -506,10 +253,10 @@ interface ThresholdSliderProps {
 
 function ThresholdSlider({ label, unit, value, min, max, step, onChange }: ThresholdSliderProps) {
     return (
-        <div style={SLIDER_CONTAINER}>
-            <div style={SLIDER_LABEL}>
-                <span style={SLIDER_NAME}>{label}</span>
-                <span style={SLIDER_VALUE}>{value} {unit}</span>
+        <div className="scenario-panel__slider-group">
+            <div className="scenario-panel__slider-header">
+                <span className="scenario-panel__slider-name">{label}</span>
+                <span className="scenario-panel__slider-value">{value} {unit}</span>
             </div>
             <input
                 type="range"

--- a/frontend/src/components/scenario/ScenarioPanel.tsx
+++ b/frontend/src/components/scenario/ScenarioPanel.tsx
@@ -205,16 +205,19 @@ const ERROR_STYLE: React.CSSProperties = {
 interface ScenarioPanelProps {
     scenario: ScenarioState;
     preview: ScenarioPreviewState;
-    gapModeActive: boolean;
+    gapModeActive?: boolean;
+    onClose?: () => void;
 }
 
 export default function ScenarioPanel({
     scenario,
     preview,
-    gapModeActive,
+    gapModeActive = false,
+    onClose,
 }: ScenarioPanelProps) {
     const { mode, thresholds, activePreset, setThreshold, applyPreset, resetToBaseline, deactivate } = scenario;
     const { data, loading, error } = preview;
+    const closePanel = onClose ?? deactivate;
 
     if (mode === 'off') return null;
 
@@ -229,7 +232,7 @@ export default function ScenarioPanel({
                 <button
                     type="button"
                     style={CLOSE_BTN_STYLE}
-                    onClick={deactivate}
+                    onClick={closePanel}
                     aria-label="Close scenario panel"
                     title="Close scenario mode"
                 >

--- a/frontend/src/components/sidebar/FilterControls.tsx
+++ b/frontend/src/components/sidebar/FilterControls.tsx
@@ -1,3 +1,5 @@
+import { BASE_TELEHEALTH_STATUSES, getTelehealthStatusLabel } from '../../domain/statusPresentation';
+import { CAT_TIERS, DESERT_SCORE_FILTER_OPTIONS } from '../../domain/metrics';
 import { DataGapFilter, SidebarFilters } from './sidebarUtils';
 
 interface FilterControlsProps {
@@ -7,10 +9,10 @@ interface FilterControlsProps {
 
 const STATUS_OPTIONS = [
     { value: '', label: 'All statuses' },
-    { value: 'TELEHEALTH_READY', label: 'Ready' },
-    { value: 'COMMUNITY_ANCHOR', label: 'Anchor' },
-    { value: 'CRITICAL_GAP', label: 'Critical' },
-    { value: 'DATA_UNAVAILABLE', label: 'Unknown' },
+    ...BASE_TELEHEALTH_STATUSES.map(value => ({
+        value,
+        label: getTelehealthStatusLabel(value),
+    })),
 ];
 
 export default function FilterControls({ filters, onChange }: FilterControlsProps) {
@@ -20,13 +22,13 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 CAT tier
                 <select
                     value={filters.tier}
-                    onChange={(event) => onChange({ ...filters, tier: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        tier: event.target.value as SidebarFilters['tier'],
+                    })}
                 >
                     <option value="">All tiers</option>
-                    <option value="1">Tier 1</option>
-                    <option value="2">Tier 2</option>
-                    <option value="3">Tier 3</option>
-                    <option value="4">Tier 4</option>
+                    {CAT_TIERS.map(tier => <option key={tier} value={tier}>Tier {tier}</option>)}
                 </select>
             </label>
 
@@ -34,7 +36,10 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 Status
                 <select
                     value={filters.status}
-                    onChange={(event) => onChange({ ...filters, status: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        status: event.target.value as SidebarFilters['status'],
+                    })}
                 >
                     {STATUS_OPTIONS.map(option => (
                         <option key={option.value} value={option.value}>{option.label}</option>
@@ -46,13 +51,14 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
                 Desert score
                 <select
                     value={filters.desert}
-                    onChange={(event) => onChange({ ...filters, desert: event.target.value })}
+                    onChange={(event) => onChange({
+                        ...filters,
+                        desert: event.target.value as SidebarFilters['desert'],
+                    })}
                 >
-                    <option value="">All scores</option>
-                    <option value="70-plus">70+ severe need</option>
-                    <option value="50-plus">50+ high need</option>
-                    <option value="below-50">Below 50</option>
-                    <option value="unknown">Unknown score</option>
+                    {DESERT_SCORE_FILTER_OPTIONS.map(option => (
+                        <option key={option.value || 'all'} value={option.value}>{option.label}</option>
+                    ))}
                 </select>
             </label>
 

--- a/frontend/src/components/sidebar/QuickFilterChips.tsx
+++ b/frontend/src/components/sidebar/QuickFilterChips.tsx
@@ -1,0 +1,73 @@
+import type { SidebarFilters } from './sidebarUtils';
+
+interface QuickFilterChipsProps {
+    filters: SidebarFilters;
+    onChange: (filters: SidebarFilters) => void;
+}
+
+interface QuickFilter {
+    id: string;
+    label: string;
+    isActive: (filters: SidebarFilters) => boolean;
+    toggle: (filters: SidebarFilters) => SidebarFilters;
+}
+
+const QUICK_FILTERS: QuickFilter[] = [
+    {
+        id: 'critical',
+        label: 'Critical gaps',
+        isActive: filters => filters.status === 'CRITICAL_GAP',
+        toggle: filters => ({
+            ...filters,
+            status: filters.status === 'CRITICAL_GAP' ? '' : 'CRITICAL_GAP',
+        }),
+    },
+    {
+        id: 'desert',
+        label: 'High desert score',
+        isActive: filters => filters.desert === '75-plus',
+        toggle: filters => ({
+            ...filters,
+            desert: filters.desert === '75-plus' ? '' : '75-plus',
+        }),
+    },
+    {
+        id: 'incomplete',
+        label: 'Data incomplete',
+        isActive: filters => filters.dataGap === 'missing',
+        toggle: filters => ({
+            ...filters,
+            dataGap: filters.dataGap === 'missing' ? 'all' : 'missing',
+        }),
+    },
+    {
+        id: 'ready',
+        label: 'Telehealth ready',
+        isActive: filters => filters.status === 'TELEHEALTH_READY',
+        toggle: filters => ({
+            ...filters,
+            status: filters.status === 'TELEHEALTH_READY' ? '' : 'TELEHEALTH_READY',
+        }),
+    },
+];
+
+export default function QuickFilterChips({ filters, onChange }: QuickFilterChipsProps) {
+    return (
+        <div className="sidebar-quick-filters" aria-label="Quick filters">
+            {QUICK_FILTERS.map(filter => {
+                const active = filter.isActive(filters);
+                return (
+                    <button
+                        key={filter.id}
+                        type="button"
+                        className={`sidebar-filter-chip${active ? ' is-active' : ''}`}
+                        aria-pressed={active}
+                        onClick={() => onChange(filter.toggle(filters))}
+                    >
+                        {filter.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/sidebar/RegionCard.tsx
+++ b/frontend/src/components/sidebar/RegionCard.tsx
@@ -1,5 +1,12 @@
 import { RegionSummary } from '../../api/catApi';
-import { formatMissing, formatStatus, statusClassName } from './sidebarUtils';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
+import { getRegionSeverityClassName } from '../../domain/metrics';
+import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
+import {
+    formatMissing,
+    formatStatus,
+} from './sidebarUtils';
 
 interface RegionCardProps {
     region: RegionSummary;
@@ -28,7 +35,7 @@ export default function RegionCard({
 
     return (
         <article
-            className={`region-card ${selected ? 'selected' : ''}`}
+            className={`region-card ${getRegionSeverityClassName(region)} ${selected ? 'selected' : ''}`}
             data-testid="sidebar-result"
             data-region-code={region.region_code}
         >
@@ -41,30 +48,45 @@ export default function RegionCard({
                     <strong>{region.name}</strong>
                     <small>{region.region_code}</small>
                 </span>
-                <span className={`status-badge ${statusClassName(region.telehealth_status)}`}>
-                    {formatStatus(region.telehealth_status)}
-                </span>
+                <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)}>
+                    {getTelehealthStatusLabel(region.telehealth_status)}
+                </StatusBadge>
             </button>
 
             {showCatDetails && (
-                <div className="region-card-meta">
-                    <span>CAT {formatMissing(region.cat_tier)}</span>
-                    <span>Desert {desertScore}</span>
-                    <span>Confidence {formatStatus(region.data_confidence)}</span>
-                    <span>{region.has_data_gap ? 'Data incomplete' : 'Data complete'}</span>
+                <div className="region-card-metrics">
+                    <span className="region-card-metric" aria-label={`Desert score ${desertScore}`}>
+                        <small>Desert</small>
+                        <strong>{desertScore}</strong>
+                    </span>
+                    <span className="region-card-metric">
+                        <small>CAT tier</small>
+                        <strong>{formatMissing(region.cat_tier)}</strong>
+                    </span>
+                    <span
+                        className={`region-card-data-state${region.has_data_gap ? ' is-incomplete' : ''}`}
+                        aria-label={`${region.has_data_gap ? 'Data incomplete' : 'Data complete'}. ${formatStatus(region.data_confidence)} confidence`}
+                    >
+                        <i aria-hidden="true" />
+                        <span>
+                            {region.has_data_gap ? 'Incomplete' : 'Complete'}
+                            <small>{formatStatus(region.data_confidence)} confidence</small>
+                        </span>
+                    </span>
                 </div>
             )}
 
             {showPin && (
-                <button
-                    type="button"
+                <Button
+                    variant={pinned ? 'primary' : 'ghost'}
+                    size="small"
                     className={`pin-button ${pinned ? 'pinned' : ''}`}
                     aria-label={`${pinned ? 'Unpin' : 'Pin'} ${region.name}`}
                     disabled={!pinned && pinDisabled}
                     onClick={() => onTogglePin(region.region_code)}
                 >
                     {pinned ? 'Pinned' : 'Pin'}
-                </button>
+                </Button>
             )}
         </article>
     );

--- a/frontend/src/components/sidebar/SearchBar.tsx
+++ b/frontend/src/components/sidebar/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { KeyboardEvent, useMemo, useState } from 'react';
+import { KeyboardEvent, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { useRegionSearch } from '../../hooks/useRegionSearch';
-import { formatStatus, statusClassName } from './sidebarUtils';
+import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
+import StatusBadge from '../ui/StatusBadge';
 
 interface SearchBarProps {
     value: string;
@@ -11,9 +12,21 @@ interface SearchBarProps {
 
 export default function SearchBar({ value, onChange, onSelectRegion }: SearchBarProps) {
     const [isOpen, setIsOpen] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const listboxId = useId();
     const searchParams = useMemo(() => ({ q: value }), [value]);
     const { results } = useRegionSearch(searchParams);
     const dropdownResults = value.trim() ? results.slice(0, 8) : [];
+    const listboxOpen = isOpen && dropdownResults.length > 0;
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handlePointerDown = (event: PointerEvent) => {
+            if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false);
+        };
+        document.addEventListener('pointerdown', handlePointerDown);
+        return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, [isOpen]);
 
     function selectRegion(region: RegionSummary) {
         onSelectRegion(region.region_code);
@@ -31,9 +44,13 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
     }
 
     return (
-        <div className="sidebar-search">
+        <div className="sidebar-search" ref={rootRef}>
             <input
+                role="combobox"
                 aria-label="Search communities"
+                aria-autocomplete="list"
+                aria-expanded={listboxOpen}
+                aria-controls={listboxId}
                 data-testid="community-search"
                 value={value}
                 onChange={(event) => {
@@ -45,13 +62,15 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
                 placeholder="Search communities"
                 className="sidebar-search-input"
             />
-            {isOpen && dropdownResults.length > 0 && (
-                <div className="sidebar-autocomplete" role="listbox">
+            {listboxOpen && (
+                <div className="sidebar-autocomplete" role="listbox" id={listboxId} aria-label="Community suggestions">
                     {dropdownResults.map(region => (
                         <button
                             key={region.region_code}
                             className="sidebar-autocomplete-row"
                             data-testid="sidebar-search-result"
+                            role="option"
+                            aria-selected="false"
                             onClick={() => selectRegion(region)}
                             type="button"
                         >
@@ -59,9 +78,9 @@ export default function SearchBar({ value, onChange, onSelectRegion }: SearchBar
                                 <strong>{region.name}</strong>
                                 <small>CAT {region.cat_tier ?? 'Unknown'}</small>
                             </span>
-                            <span className={`status-badge ${statusClassName(region.telehealth_status)}`}>
-                                {formatStatus(region.telehealth_status)}
-                            </span>
+                            <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)}>
+                                {getTelehealthStatusLabel(region.telehealth_status)}
+                            </StatusBadge>
                         </button>
                     ))}
                 </div>

--- a/frontend/src/components/sidebar/SelectedRegionPanel.test.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RegionSummary } from '../../api/catApi';
+import SelectedRegionPanel from './SelectedRegionPanel';
+
+vi.mock('../../hooks/useResearchProfile', () => ({
+    useResearchProfile: () => ({
+        profile: null,
+        loading: false,
+        error: null,
+    }),
+}));
+
+const region: RegionSummary = {
+    id: 1,
+    region_code: 'AK-BETHEL',
+    name: 'Bethel',
+    lat: 60.7922,
+    lon: -161.7558,
+    cat_tier: 3,
+    telehealth_status: 'COMMUNITY_ANCHOR',
+    desert_score: 55,
+    affordability_status: 'unaffordable',
+    data_confidence: 'medium',
+    has_data_gap: true,
+    region: 'Yukon-Kuskokwim',
+};
+
+function renderPanel(activeLayer: 'cat' | 'affordability') {
+    render(
+        <SelectedRegionPanel
+            region={region}
+            season="year_round"
+            activeLayer={activeLayer}
+            pinned={false}
+            pinDisabled={false}
+            onTogglePin={vi.fn()}
+        />,
+    );
+}
+
+describe('SelectedRegionPanel layer details', () => {
+    it('shows CAT-first details on the CAT layer', () => {
+        renderPanel('cat');
+
+        expect(screen.getByRole('heading', { name: 'CAT access' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Transport evidence' })).toBeInTheDocument();
+        expect(screen.getByText(/CAT details/)).toBeInTheDocument();
+        expect(screen.getByTestId('cat-region-summary')).toBeInTheDocument();
+        expect(screen.queryByTestId('affordability-region-summary')).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Affordability' })).not.toBeInTheDocument();
+        expect(screen.queryByText('Cost burden')).not.toBeInTheDocument();
+    });
+
+    it('shows affordability details on the affordability layer', () => {
+        renderPanel('affordability');
+
+        expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Connectivity' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Affordability' })).toBeInTheDocument();
+        expect(screen.getAllByText('Cost burden')).toHaveLength(2);
+        expect(screen.getByText(/Affordability details/)).toBeInTheDocument();
+        expect(screen.getByTestId('affordability-region-summary')).toBeInTheDocument();
+        expect(screen.queryByTestId('cat-region-summary')).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'CAT access' })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/sidebar/SelectedRegionPanel.tsx
+++ b/frontend/src/components/sidebar/SelectedRegionPanel.tsx
@@ -1,17 +1,30 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { RegionSummary, Season } from '../../api/catApi';
+import type { BaseMapLayer } from '../../domain/mapMode';
 import type { ScenarioRegion } from '../../types/scenario';
 import { useResearchProfile } from '../../hooks/useResearchProfile';
 import { exportResearchProfileReport } from '../../utils/reportExport';
-import { formatMissing, formatStatus, statusClassName, telehealthNeedLabel } from './sidebarUtils';
+import {
+    getTelehealthStatusClassName,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+} from '../../domain/statusPresentation';
+import {
+    formatMissing,
+    formatStatus,
+    telehealthNeedLabel,
+} from './sidebarUtils';
 import { DATA_UNAVAILABLE, formatResearchValue } from '../../utils/formatResearchValue';
 import { ScenarioSidebarCard } from '../scenario/ScenarioLayer';
 import MetricTooltip from '../MetricTooltip';
+import Button from '../ui/Button';
+import StatusBadge from '../ui/StatusBadge';
 
 interface SelectedRegionPanelProps {
     region: RegionSummary | null;
     season: Season;
     focusKey?: number;
+    activeLayer?: BaseMapLayer;
     pinned: boolean;
     pinDisabled: boolean;
     onTogglePin: (regionCode: string) => void;
@@ -22,6 +35,7 @@ export default function SelectedRegionPanel({
     region,
     season,
     focusKey = 0,
+    activeLayer = 'cat',
     pinned,
     pinDisabled,
     onTogglePin,
@@ -30,6 +44,7 @@ export default function SelectedRegionPanel({
     const { profile, loading, error } = useResearchProfile(region?.region_code ?? null, season);
     const panelRef = useRef<HTMLElement | null>(null);
     const [highlight, setHighlight] = useState(false);
+    const [actionStatus, setActionStatus] = useState<{ message: string; error: boolean } | null>(null);
 
     useEffect(() => {
         if (!region || focusKey === 0) return;
@@ -40,20 +55,135 @@ export default function SelectedRegionPanel({
     }, [focusKey, region]);
 
     if (!region) {
-        return null;
+        return (
+            <section className="selected-region-panel selected-region-empty">
+                <strong>Select a community</strong>
+                <span>Choose a result to inspect access, connectivity, and data quality.</span>
+            </section>
+        );
     }
 
     const handleDownloadReport = async () => {
         if (!profile) return;
-        await exportResearchProfileReport(
-            profile,
-            document.querySelector<HTMLElement>('.leaflet-container'),
-        );
+        try {
+            await exportResearchProfileReport(
+                profile,
+                document.querySelector<HTMLElement>('.leaflet-container'),
+            );
+            setActionStatus({ message: 'Report download started.', error: false });
+        } catch {
+            setActionStatus({ message: 'Report could not be generated.', error: true });
+        }
     };
 
     const handleCopyShareLink = async () => {
-        await navigator.clipboard?.writeText(window.location.href);
+        try {
+            if (!navigator.clipboard) throw new Error('Clipboard unavailable');
+            await navigator.clipboard.writeText(window.location.href);
+            setActionStatus({ message: 'Share link copied.', error: false });
+        } catch {
+            setActionStatus({ message: 'Share link could not be copied.', error: true });
+        }
     };
+
+    const profileFallback = loading
+        ? 'Loading…'
+        : error
+            ? 'Details unavailable'
+            : DATA_UNAVAILABLE;
+    const catDetailSections = (
+        <>
+            <DetailSection title="CAT access">
+                <DetailRow
+                    label={<>CAT tier<MetricTooltip term="CAT Tier">Transport access category. Higher tiers indicate more limited or fragile access.</MetricTooltip></>}
+                    value={formatMissing(region.cat_tier)}
+                />
+                <DetailRow
+                    label={<>Healthcare desert score<MetricTooltip term="Healthcare Desert Score">Higher scores mean greater need for telehealth due to healthcare access barriers.</MetricTooltip></>}
+                    value={formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}
+                />
+                <DetailRow
+                    label={<>Telehealth need<MetricTooltip term="Telehealth Need">Interprets healthcare desert score: below 25 adequate, 25-49 moderate, 50-74 high, and 75-100 critical.</MetricTooltip></>}
+                    value={telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}
+                />
+                <DetailRow label="Region" value={formatMissing(region.region)} />
+                <DetailRow label="Season" value={profile?.telehealth.season_note ?? formatStatus(season)} />
+            </DetailSection>
+
+            <DetailSection title="Transport evidence">
+                <DetailRow
+                    label={<>Telehealth status<MetricTooltip term="Telehealth Status">Combines affordability and clinic access into a practical access label.</MetricTooltip></>}
+                    value={<span className={`status-text ${getTelehealthStatusClassName(region.telehealth_status)}`}>{getTelehealthStatusLabel(region.telehealth_status)}</span>}
+                />
+                <DetailRow label="Nearest care" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_name) : profileFallback} />
+                <DetailRow label="Facility distance" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Data confidence">
+                <DetailRow
+                    label={<>Confidence<MetricTooltip term="Data Confidence">Confidence describes whether supporting coverage data is strong, weak, or missing.</MetricTooltip></>}
+                    value={formatStatus(region.data_confidence)}
+                />
+                <DetailRow
+                    label={<>Coverage<MetricTooltip term="Data Incomplete">Some required coverage, speed, affordability, or access evidence is missing.</MetricTooltip></>}
+                    value={region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}
+                />
+            </DetailSection>
+        </>
+    );
+    const telehealthDetailSections = (
+        <>
+            <DetailSection title="Access">
+                <DetailRow
+                    label={<>CAT tier<MetricTooltip term="CAT Tier">Transport access category. Higher tiers indicate more limited or fragile access.</MetricTooltip></>}
+                    value={formatMissing(region.cat_tier)}
+                />
+                <DetailRow
+                    label={<>Telehealth<MetricTooltip term="Telehealth Status">Combines affordability and clinic access into a practical access label.</MetricTooltip></>}
+                    value={<span className={`status-text ${getTelehealthStatusClassName(region.telehealth_status)}`}>{getTelehealthStatusLabel(region.telehealth_status)}</span>}
+                />
+                <DetailRow
+                    label={<>Telehealth need<MetricTooltip term="Telehealth Need">Interprets healthcare desert score: below 25 adequate, 25-49 moderate, 50-74 high, and 75-100 critical.</MetricTooltip></>}
+                    value={telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}
+                />
+                <DetailRow label="Region" value={formatMissing(region.region)} />
+            </DetailSection>
+
+            <DetailSection title="Connectivity">
+                <DetailRow label="Download speed" value={profile ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 }) : profileFallback} />
+                <DetailRow label="Upload speed" value={profile ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 }) : profileFallback} />
+                <DetailRow label="Latency" value={profile ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Affordability">
+                <DetailRow
+                    label={<>Status<MetricTooltip term="Affordability Burden">Whether monthly internet cost is affordable relative to income data.</MetricTooltip></>}
+                    value={formatStatus(profile?.affordability.status ?? region.affordability_status)}
+                />
+                <DetailRow label="Cost burden" value={profile ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Healthcare">
+                <DetailRow
+                    label={<>Desert score<MetricTooltip term="Healthcare Desert Score">Higher scores mean greater need for telehealth due to healthcare access barriers.</MetricTooltip></>}
+                    value={formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}
+                />
+                <DetailRow label="Nearest care" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_name) : profileFallback} />
+                <DetailRow label="Facility distance" value={profile ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 }) : profileFallback} />
+            </DetailSection>
+
+            <DetailSection title="Data confidence">
+                <DetailRow
+                    label={<>Confidence<MetricTooltip term="Data Confidence">Confidence describes whether supporting coverage data is strong, weak, or missing.</MetricTooltip></>}
+                    value={formatStatus(region.data_confidence)}
+                />
+                <DetailRow
+                    label={<>Coverage<MetricTooltip term="Data Incomplete">Some required coverage, speed, affordability, or access evidence is missing.</MetricTooltip></>}
+                    value={region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}
+                />
+            </DetailSection>
+        </>
+    );
 
     return (
         <section
@@ -63,155 +193,101 @@ export default function SelectedRegionPanel({
             <div className="selected-region-header">
                 <div>
                     <h2>{region.name}</h2>
-                    <small>{region.region_code}</small>
+                    <small>{region.region_code} · {activeLayer === 'cat' ? 'CAT details' : activeLayer === 'affordability' ? 'Affordability details' : 'Gap Hunter details'}</small>
                 </div>
-                <button
-                    type="button"
-                    className={`pin-button ${pinned ? 'pinned' : ''}`}
+                <Button
+                    variant={pinned ? 'primary' : 'secondary'}
+                    size="small"
+                    className="selected-region-pin"
                     aria-label={`${pinned ? 'Unpin' : 'Pin'} ${region.name}`}
                     disabled={!pinned && pinDisabled}
                     onClick={() => onTogglePin(region.region_code)}
                 >
                     {pinned ? 'Pinned' : 'Pin'}
-                </button>
+                </Button>
             </div>
 
+            {activeLayer !== 'affordability' ? (
+                <div className="selected-region-summary" data-testid="cat-region-summary">
+                    <StatusBadge tone="neutral" showDot>
+                        CAT tier {formatMissing(region.cat_tier)}
+                    </StatusBadge>
+                    <span><small>Desert score</small><strong>{formatResearchValue(region.desert_score, { digits: 1 })}</strong></span>
+                    <span><small>Region</small><strong>{formatMissing(region.region)}</strong></span>
+                </div>
+            ) : (
+                <div className="selected-region-summary" data-testid="affordability-region-summary">
+                    <StatusBadge tone={getTelehealthStatusTone(region.telehealth_status)} showDot>
+                        {getTelehealthStatusLabel(region.telehealth_status)}
+                    </StatusBadge>
+                    <span><small>Affordability</small><strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong></span>
+                    <span><small>Cost burden</small><strong>{profile ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 }) : profileFallback}</strong></span>
+                </div>
+            )}
+
             <div className="selected-region-actions">
-                <button
-                    type="button"
-                    className="sidebar-action-button"
+                <Button
+                    variant="primary"
+                    size="small"
                     data-testid="download-report"
                     disabled={loading || !profile}
                     onClick={handleDownloadReport}
                     aria-label={`Download report for ${region.name}`}
                 >
                     Download Report
-                </button>
-                <button
-                    type="button"
-                    className="sidebar-action-button"
+                </Button>
+                <Button
+                    variant="secondary"
+                    size="small"
                     data-testid="copy-share-link"
                     onClick={handleCopyShareLink}
                     aria-label={`Copy share link for ${region.name}`}
                 >
                     Copy Share Link
-                </button>
+                </Button>
             </div>
 
-            {error && <div className="selected-region-note error">{error}</div>}
+            {actionStatus && (
+                <div
+                    className={`selected-region-action-status${actionStatus.error ? ' is-error' : ''}`}
+                    role={actionStatus.error ? 'alert' : 'status'}
+                >
+                    {actionStatus.message}
+                </div>
+            )}
+
+            {loading && <div className="selected-region-note" role="status">Loading community details…</div>}
+            {error && <div className="selected-region-note error" role="alert">Community details unavailable: {error}</div>}
             {profile?.region?.has_data_gap && (
-                <div className="selected-region-note">
+                <div className="selected-region-note" role="status">
                     {profile.region?.data_confidence ?? DATA_UNAVAILABLE} confidence · {profile.region?.missing_fields?.length ?? 0} data gaps
                 </div>
             )}
 
-            <div className="selected-detail-grid">
-                <span>
-                    CAT tier
-                    <MetricTooltip term="CAT Tier">
-                        Transport access category. Higher tiers indicate more limited or fragile access.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatMissing(region.cat_tier)}</strong>
-
-                <span>
-                    Telehealth
-                    <MetricTooltip term="Telehealth Status">
-                        Combines affordability and clinic access into a practical access label.
-                    </MetricTooltip>
-                </span>
-                <strong className={`status-text ${statusClassName(region.telehealth_status)}`}>
-                    {formatStatus(region.telehealth_status)}
-                </strong>
-
-                <span>
-                    Desert score
-                    <MetricTooltip term="Healthcare Desert Score">
-                        Higher scores mean greater need for telehealth due to healthcare access barriers.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatResearchValue(profile?.healthcare.desert_score ?? region.desert_score, { digits: 1 })}</strong>
-
-                <span>
-                    Telehealth need
-                    <MetricTooltip term="Telehealth Need">
-                        Interprets healthcare desert score: 0-30 low, 31-60 moderate, 61-80 high, and 81-100 critical.
-                    </MetricTooltip>
-                </span>
-                <strong>{telehealthNeedLabel(profile?.healthcare.desert_score ?? region.desert_score)}</strong>
-
-                <span>
-                    Affordability
-                    <MetricTooltip term="Affordability Burden">
-                        Whether monthly internet cost is affordable relative to income data.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatStatus(profile?.affordability.status ?? region.affordability_status)}</strong>
-
-                <span>
-                    Data confidence
-                    <MetricTooltip term="Data Confidence">
-                        Confidence describes whether supporting coverage data is strong, weak, or missing.
-                    </MetricTooltip>
-                </span>
-                <strong>{formatStatus(region.data_confidence)}</strong>
-
-                <span>
-                    Data gap
-                    <MetricTooltip term="Data Incomplete">
-                        Some required coverage, speed, affordability, or access evidence is missing.
-                    </MetricTooltip>
-                </span>
-                <strong>{region.has_data_gap ? 'Data incomplete' : 'No gap flagged'}</strong>
-
-                <span>Region</span>
-                <strong>{formatMissing(region.region)}</strong>
-
-                <span>Download speed</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.ookla_download_mbps, { suffix: ' Mbps', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Upload speed</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.ookla_upload_mbps, { suffix: ' Mbps', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Latency</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.connectivity.latency_ms, { suffix: ' ms', digits: 0 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Cost burden</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.affordability.burden_pct, { suffix: '%', digits: 2 })
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Nearest care</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.healthcare.nearest_facility_name)
-                        : DATA_UNAVAILABLE}
-                </strong>
-
-                <span>Facility distance</span>
-                <strong>
-                    {profile
-                        ? formatResearchValue(profile.healthcare.nearest_facility_distance_km, { suffix: ' km', digits: 1 })
-                        : DATA_UNAVAILABLE}
-                </strong>
+            <div className="selected-region-detail-sections">
+                {activeLayer === 'affordability' ? telehealthDetailSections : catDetailSections}
             </div>
 
             {/* Scenario Sidebar Card */}
             <ScenarioSidebarCard region={scenarioRegion} />
         </section>
+    );
+}
+
+function DetailSection({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <section className="selected-detail-section">
+            <h3>{title}</h3>
+            <div className="selected-detail-grid">{children}</div>
+        </section>
+    );
+}
+
+function DetailRow({ label, value }: { label: ReactNode; value: ReactNode }) {
+    return (
+        <>
+            <span>{label}</span>
+            <strong>{value}</strong>
+        </>
     );
 }

--- a/frontend/src/components/sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/sidebar/Sidebar.test.tsx
@@ -132,8 +132,27 @@ describe('Sidebar discovery', () => {
         expect(screen.getByText('Eareckson')).toBeInTheDocument();
         expect(screen.getByText('Missing Data')).toBeInTheDocument();
         expect(screen.getAllByText('Data incomplete').length).toBeGreaterThan(0);
-        expect(screen.getAllByText('Confidence Missing').length).toBeGreaterThan(0);
-        expect(screen.getByText('Desert Unknown')).toBeInTheDocument();
+        expect(screen.getAllByLabelText(/Data incomplete\. Missing confidence/i).length).toBeGreaterThan(0);
+        expect(screen.getByLabelText('Desert score Unknown')).toBeInTheDocument();
+    });
+
+    it('keeps quick filters synchronized with the existing filter controls', () => {
+        renderSidebar();
+
+        const critical = screen.getByRole('button', { name: 'Critical gaps' });
+        fireEvent.click(critical);
+
+        expect(critical).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByLabelText(/^Status$/i)).toHaveValue('CRITICAL_GAP');
+        expect(resultCodes()).toEqual(['AK-EARECKSON']);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Data incomplete' }));
+        expect(screen.getByLabelText(/^Data gaps$/i)).toHaveValue('missing');
+        expect(resultCodes()).toEqual(['AK-EARECKSON']);
+
+        fireEvent.click(critical);
+        expect(screen.getByLabelText(/^Status$/i)).toHaveValue('');
+        expect(resultCodes()).toEqual(['AK-BETHEL', 'AK-EARECKSON', 'AK-MISSING']);
     });
 
     it('filters by CAT tier', async () => {
@@ -167,7 +186,7 @@ describe('Sidebar discovery', () => {
     it('filters by healthcare desert score', async () => {
         renderSidebar();
 
-        fireEvent.change(screen.getByLabelText(/Desert score/i), { target: { value: '70-plus' } });
+        fireEvent.change(screen.getByLabelText(/^Desert score$/i), { target: { value: '75-plus' } });
 
         expect(screen.getByText('Eareckson')).toBeInTheDocument();
         expect(screen.queryByText('Bethel')).not.toBeInTheDocument();

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,12 +1,22 @@
-import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { RegionSummary } from '../../api/catApi';
 import { Season } from '../../api/catApi';
+import type { BaseMapLayer } from '../../domain/mapMode';
 import type { ScenarioRegion } from '../../types/scenario';
 import FilterControls from './FilterControls';
 import RegionList from './RegionList';
 import SearchBar from './SearchBar';
 import SelectedRegionPanel from './SelectedRegionPanel';
 import SortControls from './SortControls';
+import QuickFilterChips from './QuickFilterChips';
+import Button from '../ui/Button';
 import {
     filterRegions,
     RegionSortMode,
@@ -22,7 +32,7 @@ interface SidebarProps {
     selectedRegionCode: string | null;
     detailsFocusKey?: number;
     season?: Season;
-    activeLayer?: 'cat' | 'affordability' | 'gap';
+    activeLayer?: BaseMapLayer;
     pinnedRegionCodes?: string[];
     maxPinnedRegions?: number;
     scenarioRegion?: ScenarioRegion;
@@ -61,6 +71,7 @@ export default function Sidebar({
     const [query, setQuery] = useState('');
     const [filters, setFilters] = useState<SidebarFilters>(DEFAULT_FILTERS);
     const [sortMode, setSortMode] = useState<RegionSortMode>('name');
+    const [filtersOpen, setFiltersOpen] = useState(false);
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(360);
     const activePinnedRegionCodes = pinnedRegionCodes ?? [];
@@ -68,6 +79,9 @@ export default function Sidebar({
     const activeTogglePin = onTogglePin ?? (() => {});
     const activeIsPinned = isPinned ?? (() => false);
     const showCatTools = activeLayer === 'cat';
+    const activeFilterCount = [filters.tier, filters.status, filters.desert]
+        .filter(Boolean).length + (filters.dataGap === 'all' ? 0 : 1);
+    const hasActiveControls = Boolean(query) || activeFilterCount > 0 || sortMode !== 'name';
 
     const selectedRegion = useMemo(
         () => regions.find(region => region.region_code === selectedRegionCode) ?? null,
@@ -118,6 +132,21 @@ export default function Sidebar({
         document.addEventListener('mouseup', handleUp);
     }, [sidebarWidth]);
 
+    const resizeWithKeyboard = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+        event.preventDefault();
+        if (event.key === 'Home') {
+            setSidebarWidth(MIN_SIDEBAR_WIDTH);
+            return;
+        }
+        if (event.key === 'End') {
+            setSidebarWidth(MAX_SIDEBAR_WIDTH);
+            return;
+        }
+        const delta = event.key === 'ArrowRight' ? 16 : -16;
+        setSidebarWidth(width => Math.min(Math.max(width + delta, MIN_SIDEBAR_WIDTH), MAX_SIDEBAR_WIDTH));
+    }, []);
+
     if (isCollapsed) {
         return (
             <aside
@@ -125,14 +154,13 @@ export default function Sidebar({
                 style={{ width: 56, minWidth: 56 }}
                 aria-label="Collapsed community sidebar"
             >
-                <button
-                    type="button"
-                    className="sidebar-collapse-button"
+                <Button
+                    size="small"
                     onClick={() => setIsCollapsed(false)}
                     aria-label="Expand community sidebar"
                 >
                     Open
-                </button>
+                </Button>
                 <div className="sidebar-collapsed-label">Communities</div>
             </aside>
         );
@@ -149,22 +177,14 @@ export default function Sidebar({
                     <p>{loading ? 'Loading...' : `${visibleRegions.length} of ${regions.length}`}</p>
                 </div>
                 <div className="sidebar-header-actions">
-                    <button
-                        type="button"
-                        className="sidebar-action-button"
-                        onClick={resetSidebarControls}
-                        aria-label="Reset sidebar filters"
-                    >
-                        Reset
-                    </button>
-                    <button
-                        type="button"
-                        className="sidebar-collapse-button"
+                    <Button
+                        variant="ghost"
+                        size="small"
                         onClick={() => setIsCollapsed(true)}
                         aria-label="Collapse community sidebar"
                     >
                         Hide
-                    </button>
+                    </Button>
                 </div>
             </header>
 
@@ -176,8 +196,40 @@ export default function Sidebar({
 
             {showCatTools && (
                 <>
-                    <FilterControls filters={filters} onChange={setFilters} />
-                    <SortControls value={sortMode} onChange={setSortMode} />
+                    <QuickFilterChips filters={filters} onChange={setFilters} />
+                    <section className="sidebar-control-panel" aria-label="Community controls">
+                        <div className="sidebar-control-panel__header">
+                            <button
+                                type="button"
+                                className="sidebar-control-panel__toggle"
+                                aria-expanded={filtersOpen}
+                                aria-controls="sidebar-filter-controls"
+                                onClick={() => setFiltersOpen(value => !value)}
+                            >
+                                Filters &amp; sort
+                                {activeFilterCount > 0 && (
+                                    <span>{activeFilterCount} active</span>
+                                )}
+                            </button>
+                            <Button
+                                variant="ghost"
+                                size="small"
+                                onClick={resetSidebarControls}
+                                disabled={!hasActiveControls}
+                                aria-label="Reset sidebar filters"
+                            >
+                                Reset
+                            </Button>
+                        </div>
+                        <div
+                            id="sidebar-filter-controls"
+                            className="sidebar-control-panel__body"
+                            hidden={!filtersOpen}
+                        >
+                            <FilterControls filters={filters} onChange={setFilters} />
+                            <SortControls value={sortMode} onChange={setSortMode} />
+                        </div>
+                    </section>
                 </>
             )}
 
@@ -205,6 +257,7 @@ export default function Sidebar({
                 region={selectedRegion}
                 season={season}
                 focusKey={detailsFocusKey}
+                activeLayer={activeLayer}
                 pinned={selectedRegion ? activeIsPinned(selectedRegion.region_code) : false}
                 pinDisabled={activePinnedRegionCodes.length >= activeMaxPinnedRegions}
                 onTogglePin={activeTogglePin}
@@ -231,9 +284,15 @@ export default function Sidebar({
             <div
                 className="sidebar-resize-handle"
                 role="separator"
+                tabIndex={0}
                 aria-orientation="vertical"
                 aria-label="Resize community sidebar"
+                aria-valuemin={MIN_SIDEBAR_WIDTH}
+                aria-valuemax={MAX_SIDEBAR_WIDTH}
+                aria-valuenow={sidebarWidth}
+                aria-valuetext={`${sidebarWidth} pixels`}
                 onMouseDown={startResize}
+                onKeyDown={resizeWithKeyboard}
             />
         </aside>
     );

--- a/frontend/src/components/sidebar/sidebar.css
+++ b/frontend/src/components/sidebar/sidebar.css
@@ -1,517 +1,778 @@
 .tenet-sidebar {
-    position: relative;
-    z-index: 1200;
-    width: 360px;
-    min-width: 360px;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 16px;
-    box-sizing: border-box;
-    background: #f8fafc;
-    border-right: 1px solid #dbe3ea;
-    box-shadow: 6px 0 18px rgba(15, 23, 42, 0.08);
-    color: #172033;
-    overflow: hidden;
+  position: relative;
+  z-index: var(--z-sidebar);
+  display: flex;
+  width: 360px;
+  min-width: 360px;
+  height: 100vh;
+  height: 100dvh;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  overflow: hidden;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-4);
+  box-shadow: 6px 0 18px rgba(15, 23, 42, 0.08);
+  color: var(--color-text);
 }
 
 .tenet-sidebar.collapsed {
-    align-items: center;
-    gap: 14px;
-    padding: 12px 8px;
-    overflow: hidden;
-}
-
-.sidebar-collapse-button {
-    border: 1px solid #c7d0da;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #334155;
-    padding: 6px 8px;
-    font-size: 11px;
-    font-weight: 800;
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.sidebar-collapse-button:hover {
-    background: #eef6ff;
-    border-color: #93c5fd;
-}
-
-.sidebar-header-actions {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-}
-
-.sidebar-action-button {
-    border: 1px solid #c7d0da;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #334155;
-    padding: 6px 8px;
-    font-size: 11px;
-    font-weight: 800;
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.sidebar-action-button:hover {
-    background: #f8fbff;
-    border-color: #93c5fd;
+  align-items: center;
+  gap: var(--spacing-3);
+  overflow: hidden;
+  padding: var(--spacing-3) var(--spacing-2);
 }
 
 .sidebar-collapsed-label {
-    writing-mode: vertical-rl;
-    text-orientation: mixed;
-    color: #536176;
-    font-size: 12px;
-    font-weight: 800;
-    letter-spacing: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-orientation: mixed;
+  writing-mode: vertical-rl;
 }
 
 .sidebar-resize-handle {
-    position: absolute;
-    top: 0;
-    right: -4px;
-    width: 8px;
-    height: 100%;
-    cursor: col-resize;
-    z-index: 2;
+  position: absolute;
+  top: 0;
+  right: -4px;
+  z-index: 2;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
 }
 
 .sidebar-resize-handle::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 3px;
-    width: 1px;
-    background: transparent;
-    transition: background 0.15s;
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: transparent;
+  transition: background-color var(--transition-fast);
 }
 
 .sidebar-resize-handle:hover::after {
-    background: #2563eb;
+  background: var(--color-primary);
 }
 
 .sidebar-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
 }
 
 .sidebar-header h1 {
-    margin: 0;
-    font-size: 20px;
-    line-height: 1.2;
-    color: #111827;
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  line-height: 1.2;
 }
 
 .sidebar-header p {
-    margin: 3px 0 0;
-    font-size: 12px;
-    color: #607089;
+  margin: 2px 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+}
+
+.sidebar-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
 }
 
 .sidebar-search {
-    position: relative;
+  position: relative;
 }
 
 .sidebar-search-input,
 .sidebar-filter-grid select,
 .sidebar-sort select {
-    width: 100%;
-    min-height: 36px;
-    box-sizing: border-box;
-    border: 1px solid #c7d0da;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #172033;
-    font-size: 13px;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--font-xs);
 }
 
 .sidebar-search-input {
-    padding: 0 12px;
+  padding: 0 var(--spacing-3);
+}
+
+.sidebar-search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.sidebar-search-input:focus,
+.sidebar-filter-grid select:focus,
+.sidebar-sort select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
 }
 
 .sidebar-autocomplete {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    right: 0;
-    z-index: 1500;
-    overflow: hidden;
-    border: 1px solid #c7d0da;
-    border-radius: 6px;
-    background: #ffffff;
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  position: absolute;
+  top: calc(100% + var(--spacing-1));
+  right: 0;
+  left: 0;
+  z-index: var(--z-popover);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
 }
 
 .sidebar-autocomplete-row {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    border: 0;
-    border-bottom: 1px solid #eef2f6;
-    background: #ffffff;
-    padding: 9px 10px;
-    text-align: left;
-    cursor: pointer;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
+  padding: var(--spacing-2) var(--spacing-3);
+  color: var(--color-text);
+  text-align: left;
 }
 
 .sidebar-autocomplete-row:hover {
-    background: #f1f7f4;
+  background: var(--color-primary-subtle);
 }
 
 .sidebar-autocomplete-row small,
 .region-card-title small {
-    display: block;
-    color: #64748b;
-    font-size: 11px;
-    margin-top: 2px;
+  display: block;
+  margin-top: 2px;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.sidebar-quick-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1);
+}
+
+.sidebar-filter-chip {
+  min-height: 27px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  padding: 0 var(--spacing-2);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.sidebar-filter-chip:hover {
+  border-color: #94a3b8;
+  background: var(--color-surface-muted);
+}
+
+.sidebar-filter-chip.is-active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+  color: var(--color-primary);
+}
+
+.sidebar-filter-chip:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.sidebar-control-panel {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.sidebar-control-panel__header {
+  display: flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  padding: 2px var(--spacing-1) 2px var(--spacing-3);
+}
+
+.sidebar-control-panel__toggle {
+  display: inline-flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-align: left;
+}
+
+.sidebar-control-panel__toggle::after {
+  content: "";
+  width: 6px;
+  height: 6px;
+  margin-left: auto;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform var(--transition-fast);
+}
+
+.sidebar-control-panel__toggle[aria-expanded="true"]::after {
+  transform: rotate(225deg) translate(-1px, -1px);
+}
+
+.sidebar-control-panel__toggle span {
+  border-radius: var(--radius-full);
+  background: var(--color-primary-subtle);
+  color: var(--color-primary);
+  padding: 2px 6px;
+  font-size: 0.625rem;
+}
+
+.sidebar-control-panel__body {
+  display: grid;
+  gap: var(--spacing-2);
+  border-top: 1px solid var(--color-border-subtle);
+  padding: var(--spacing-3);
+}
+
+.sidebar-control-panel__body[hidden] {
+  display: none;
 }
 
 .sidebar-filter-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 8px;
-}
-
-.sidebar-filter-grid label:last-child {
-    grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
 }
 
 .sidebar-filter-grid label,
 .sidebar-sort {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    color: #536176;
-    font-size: 11px;
-    font-weight: 700;
-    text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .sidebar-filter-grid select,
 .sidebar-sort select {
-    padding: 0 8px;
-    text-transform: none;
-    font-weight: 500;
+  padding: 0 var(--spacing-2);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .sidebar-error {
-    border: 1px solid #fecaca;
-    border-radius: 6px;
-    background: #fef2f2;
-    color: #b91c1c;
-    padding: 10px;
-    font-size: 12px;
+  border: 1px solid #fecaca;
+  border-radius: var(--radius-md);
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+  padding: var(--spacing-2);
+  font-size: var(--font-xs);
 }
 
 .sidebar-section-title {
-    color: #536176;
-    font-size: 11px;
-    font-weight: 800;
-    letter-spacing: 0;
-    text-transform: uppercase;
-    margin-bottom: 6px;
+  margin-bottom: var(--spacing-1);
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .pinned-section {
-    flex: 0 0 auto;
-    max-height: min(22vh, 170px);
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 2px;
+  display: flex;
+  min-height: 0;
+  max-height: min(20vh, 154px);
+  flex: 0 0 auto;
+  flex-direction: column;
 }
 
 .pinned-section .region-list {
-    flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .selected-region-panel {
-    flex: 0 1 auto;
-    max-height: min(34vh, 320px);
-    overflow: auto;
-    border: 1px solid #c7d0da;
-    border-radius: 8px;
-    background: #ffffff;
-    padding: 12px;
-    transition: border-color 0.18s, box-shadow 0.18s, background 0.18s;
-    scroll-margin-block: 12px;
+  min-height: 0;
+  max-height: min(38vh, 390px);
+  flex: 0 1 auto;
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: var(--spacing-3);
+  box-shadow: var(--shadow-xs);
+  scroll-margin-block: var(--spacing-3);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
 }
 
 .selected-region-panel.focused {
-    border-color: #2563eb;
-    background: #eff6ff;
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+  box-shadow: var(--focus-ring);
 }
 
-.selected-region-panel.muted {
-    color: #64748b;
-    font-size: 13px;
+.selected-region-empty {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  border-style: dashed;
+  padding: var(--spacing-3);
+}
+
+.selected-region-empty strong {
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+}
+
+.selected-region-empty span {
+  color: var(--color-text-muted);
+  font-size: 0.6875rem;
+  line-height: 1.35;
 }
 
 .selected-region-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 10px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .selected-region-header h2 {
-    margin: 0;
-    color: #111827;
-    font-size: 17px;
-    line-height: 1.2;
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-lg);
+  line-height: 1.2;
 }
 
 .selected-region-header small {
-    color: #64748b;
-    font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: 0.625rem;
+}
+
+.selected-region-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  padding: var(--spacing-2);
+}
+
+.selected-region-summary > span:not(.ui-status-badge) {
+  display: flex;
+  min-width: 42px;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.selected-region-summary small {
+  color: var(--color-text-muted);
+  font-size: 0.5625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.selected-region-summary strong {
+  color: var(--color-text);
+  font-size: var(--font-xs);
+  font-variant-numeric: tabular-nums;
 }
 
 .selected-region-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin-bottom: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
 }
 
-.selected-region-actions .sidebar-action-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.55;
+.selected-region-actions .ui-button {
+  width: 100%;
+}
+
+.selected-region-action-status {
+  margin: calc(var(--spacing-2) * -1) 0 var(--spacing-2);
+  color: var(--color-status-ready);
+  font-size: 0.6875rem;
+}
+
+.selected-region-action-status.is-error {
+  color: var(--color-danger);
 }
 
 .selected-region-note {
-    margin-bottom: 10px;
-    border: 1px solid #fde68a;
-    border-radius: 6px;
-    background: #fffbeb;
-    color: #92400e;
-    padding: 7px 8px;
-    font-size: 11px;
-    line-height: 1.35;
+  margin-bottom: var(--spacing-2);
+  border: 1px solid #fde68a;
+  border-radius: var(--radius-md);
+  background: var(--color-status-anchor-subtle);
+  color: #92400e;
+  padding: var(--spacing-2);
+  font-size: 0.6875rem;
+  line-height: 1.35;
 }
 
 .selected-region-note.error {
-    border-color: #fecaca;
-    background: #fef2f2;
-    color: #b91c1c;
+  border-color: #fecaca;
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+}
+
+.selected-region-detail-sections {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.selected-detail-section {
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--spacing-2);
+}
+
+.selected-detail-section h3 {
+  margin: 0 0 var(--spacing-2);
+  color: var(--color-text-secondary);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .selected-detail-grid {
-    display: grid;
-    grid-template-columns: minmax(92px, 1fr) minmax(0, 1.2fr);
-    gap: 6px 10px;
-    font-size: 12px;
+  display: grid;
+  grid-template-columns: minmax(92px, 1fr) minmax(0, 1.15fr);
+  gap: 6px var(--spacing-3);
+  font-size: 0.6875rem;
 }
 
-.selected-detail-grid span {
-    color: #64748b;
+.selected-detail-grid > span {
+  color: var(--color-text-muted);
 }
 
-.selected-detail-grid strong {
-    color: #172033;
-    word-break: break-word;
+.selected-detail-grid > strong {
+  color: var(--color-text);
+  font-weight: 650;
+  text-align: right;
+  word-break: break-word;
 }
 
 .sidebar-results {
-    min-height: 170px;
-    flex: 1 1 220px;
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  min-height: 120px;
+  flex: 1 1 220px;
+  flex-direction: column;
 }
 
 .region-list {
-    min-height: 0;
-    overflow: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding-right: 2px;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  overflow: auto;
+  padding-right: 2px;
 }
 
 .region-list-empty {
-    border: 1px dashed #c7d0da;
-    border-radius: 8px;
-    padding: 16px;
-    color: #64748b;
-    font-size: 13px;
-    text-align: center;
-    background: #ffffff;
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: var(--spacing-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  text-align: center;
 }
 
 .region-card {
-    position: relative;
-    border: 1px solid #d8e0e8;
-    border-radius: 8px;
-    background: #ffffff;
-    padding: 10px;
-    transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+  position: relative;
+  overflow: hidden;
+  flex: 0 0 auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: var(--spacing-2) var(--spacing-2) var(--spacing-3) var(--spacing-3);
+  box-shadow: var(--shadow-xs);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
+}
+
+.region-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--color-status-unknown);
+}
+
+.region-card.severity-critical::before {
+  background: var(--color-status-gap);
+}
+
+.region-card.severity-warning::before {
+  background: var(--color-status-anchor);
+}
+
+.region-card.severity-ready::before {
+  background: var(--color-status-ready);
+}
+
+.region-card:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 .region-card.selected {
-    border-color: #2563eb;
-    background: #eff6ff;
-    box-shadow: inset 3px 0 0 #2563eb;
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+  box-shadow: 0 0 0 1px var(--color-primary);
 }
 
 .region-card-main {
-    width: 100%;
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 8px;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: inherit;
-    text-align: left;
-    cursor: pointer;
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  color: inherit;
+  text-align: left;
+}
+
+.region-card-main:focus-visible {
+  outline: none;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--focus-ring);
 }
 
 .region-card-title {
-    min-width: 0;
+  min-width: 0;
 }
 
 .region-card-title strong {
-    display: block;
-    color: #172033;
-    font-size: 14px;
-    line-height: 1.25;
+  display: block;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--font-sm);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.region-card-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
-    margin-top: 8px;
-    padding-right: 50px;
+.region-card-metrics {
+  display: grid;
+  grid-template-columns: auto auto minmax(88px, 1fr);
+  gap: var(--spacing-2);
+  align-items: end;
+  margin-top: var(--spacing-2);
+  padding-right: 48px;
 }
 
-.region-card-meta span {
-    border-radius: 999px;
-    background: #edf2f7;
-    color: #475569;
-    padding: 3px 7px;
-    font-size: 11px;
+.region-card-metric {
+  display: flex;
+  flex-direction: column;
 }
 
-.pin-button {
-    border: 1px solid #c7d0da;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #334155;
-    padding: 5px 8px;
-    font-size: 11px;
-    font-weight: 700;
-    cursor: pointer;
+.region-card-metric small,
+.region-card-data-state small {
+  color: var(--color-text-muted);
+  font-size: 0.5625rem;
+  line-height: 1.2;
 }
 
-.pin-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.55;
+.region-card-metric strong {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
 }
 
-.pin-button.pinned {
-    border-color: #0f766e;
-    background: #ccfbf1;
-    color: #115e59;
+.region-card-data-state {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  color: var(--color-status-ready);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1.1;
+}
+
+.region-card-data-state > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.region-card-data-state i {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: var(--radius-full);
+  background: currentColor;
+}
+
+.region-card-data-state.is-incomplete {
+  color: var(--color-status-anchor);
 }
 
 .region-card > .pin-button {
-    position: absolute;
-    right: 10px;
-    bottom: 9px;
-}
-
-.status-badge {
-    flex-shrink: 0;
-    border-radius: 999px;
-    padding: 3px 7px;
-    color: #ffffff;
-    font-size: 10px;
-    font-weight: 800;
-    white-space: nowrap;
-}
-
-.status-badge.status-ready {
-    background: #16a34a;
-}
-
-.status-badge.status-anchor {
-    background: #d97706;
-}
-
-.status-badge.status-critical {
-    background: #dc2626;
-}
-
-.status-badge.status-unknown {
-    background: #64748b;
-}
-
-.status-text.status-ready {
-    color: #166534;
-}
-
-.status-text.status-anchor {
-    color: #92400e;
-}
-
-.status-text.status-critical {
-    color: #b91c1c;
-}
-
-.status-text.status-unknown {
-    color: #475569;
+  position: absolute;
+  right: var(--spacing-2);
+  bottom: var(--spacing-2);
+  min-height: 25px;
+  padding-inline: var(--spacing-2);
 }
 
 .status-text {
-    background: transparent;
+  background: transparent;
+}
+
+.status-text.status-ready {
+  color: var(--color-status-ready);
+}
+
+.status-text.status-anchor {
+  color: #92400e;
+}
+
+.status-text.status-critical {
+  color: var(--color-status-gap);
+}
+
+.status-text.status-unknown {
+  color: var(--color-text-secondary);
+}
+
+.sidebar-resize-handle:focus-visible {
+  outline: none;
+}
+
+.sidebar-resize-handle:focus-visible::after {
+  width: 2px;
+  background: var(--color-primary);
 }
 
 @media (max-width: 900px) {
-    .tenet-sidebar {
-        position: absolute;
-        left: 10px;
-        right: 10px;
-        bottom: 10px;
-        width: auto !important;
-        min-width: 0 !important;
-        height: 46vh;
-        border: 1px solid #dbe3ea;
-        border-radius: 8px;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
-    }
+  .tenet-sidebar {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    width: auto !important;
+    min-width: 0 !important;
+    height: 46vh;
+    height: 46dvh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-3);
+    box-shadow: var(--shadow-lg);
+  }
 
-    .tenet-sidebar.collapsed {
-        width: 48px !important;
-        min-width: 48px !important;
-        height: 148px;
-        right: auto;
-        bottom: 16px;
-        left: 12px;
-    }
+  .tenet-sidebar.collapsed {
+    right: auto;
+    bottom: 16px;
+    left: 12px;
+    width: 48px !important;
+    min-width: 48px !important;
+    height: 148px;
+  }
 
-    .sidebar-resize-handle {
-        display: none;
-    }
+  .sidebar-resize-handle {
+    display: none;
+  }
 
-    .sidebar-header h1 {
-        font-size: 17px;
-    }
+  .sidebar-header h1 {
+    font-size: var(--font-base);
+  }
 
-    .selected-region-panel {
-        display: none;
-    }
+  .sidebar-quick-filters {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 2px;
+  }
+
+  .sidebar-filter-chip {
+    flex: 0 0 auto;
+  }
+
+  .selected-region-panel {
+    display: block;
+    max-height: none;
+    flex: 0 0 auto;
+    overflow: visible;
+    padding: var(--spacing-2);
+  }
+
+  .selected-region-empty {
+    display: none;
+  }
+
+  .selected-region-header {
+    margin-bottom: var(--spacing-1);
+  }
+
+  .selected-region-header h2 {
+    font-size: var(--font-sm);
+  }
+
+  .selected-region-summary {
+    margin-bottom: var(--spacing-1);
+    padding: var(--spacing-1) var(--spacing-2);
+  }
+
+  .selected-region-actions {
+    margin-bottom: 0;
+  }
+
+  .selected-region-detail-sections,
+  .selected-region-note,
+  .selected-region-panel > section:not(.selected-detail-section) {
+    display: none;
+  }
+
+  .pinned-section {
+    max-height: 96px;
+  }
+
+  .sidebar-results {
+    min-height: 180px;
+    flex: 0 0 auto;
+  }
+
+  .sidebar-results .region-list {
+    max-height: 180px;
+  }
+}
+
+@media (max-width: 430px) {
+  .selected-region-summary {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .selected-region-actions {
+    gap: var(--spacing-1);
+  }
+
+  .selected-region-actions .ui-button {
+    padding-inline: var(--spacing-2);
+    font-size: 0.6875rem;
+  }
 }

--- a/frontend/src/components/sidebar/sidebarUtils.ts
+++ b/frontend/src/components/sidebar/sidebarUtils.ts
@@ -1,12 +1,18 @@
-import { RegionSummary } from '../../api/catApi';
+import type { RegionSummary, TelehealthStatusName } from '../../api/catApi';
+import {
+    getDesertScorePresentation,
+    matchesDesertScoreFilter,
+    type CatTier,
+    type DesertScoreFilter,
+} from '../../domain/metrics';
 
 export type RegionSortMode = 'name' | 'tier' | 'desert';
 export type DataGapFilter = 'all' | 'missing' | 'complete';
 
 export interface SidebarFilters {
-    tier: string;
-    status: string;
-    desert: string;
+    tier: '' | `${CatTier}`;
+    status: '' | TelehealthStatusName;
+    desert: DesertScoreFilter;
     dataGap: DataGapFilter;
 }
 
@@ -28,22 +34,11 @@ export function formatStatus(status: string | null | undefined, fallback = 'Unkn
         .join(' ');
 }
 
-export function statusClassName(status: string | null | undefined) {
-    const normalized = (status || '').toLowerCase();
-    if (normalized.includes('ready')) return 'status-ready';
-    if (normalized.includes('anchor')) return 'status-anchor';
-    if (normalized.includes('critical')) return 'status-critical';
-    return 'status-unknown';
-}
-
 export function telehealthNeedLabel(score: number | null | undefined): string {
     if (score === null || score === undefined || !Number.isFinite(score)) {
         return 'Data unavailable';
     }
-    if (score <= 30) return `Low Need (${score.toFixed(1)})`;
-    if (score <= 60) return `Moderate Need (${score.toFixed(1)})`;
-    if (score <= 80) return `High Need (${score.toFixed(1)})`;
-    return `Critical Need (${score.toFixed(1)})`;
+    return `${getDesertScorePresentation(score).label} (${score.toFixed(1)})`;
 }
 
 export function sortRegions(regions: RegionSummary[], sortMode: RegionSortMode) {
@@ -85,19 +80,7 @@ export function filterRegions(
             return false;
         }
 
-        if (filters.desert === '70-plus' && (region.desert_score ?? -1) < 70) {
-            return false;
-        }
-
-        if (filters.desert === '50-plus' && (region.desert_score ?? -1) < 50) {
-            return false;
-        }
-
-        if (filters.desert === 'below-50' && (region.desert_score === null || region.desert_score === undefined || region.desert_score >= 50)) {
-            return false;
-        }
-
-        if (filters.desert === 'unknown' && region.desert_score !== null && region.desert_score !== undefined) {
+        if (!matchesDesertScoreFilter(region.desert_score, filters.desert)) {
             return false;
         }
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'small' | 'default';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    leadingIcon?: ReactNode;
+    trailingIcon?: ReactNode;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
+    variant = 'secondary',
+    size = 'default',
+    leadingIcon,
+    trailingIcon,
+    className = '',
+    children,
+    type = 'button',
+    ...props
+}, ref) {
+    const classes = ['ui-button', `ui-button--${variant}`, `ui-button--${size}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button ref={ref} type={type} className={classes} {...props}>
+            {leadingIcon && <span className="ui-button__icon" aria-hidden="true">{leadingIcon}</span>}
+            <span className="ui-button__label">{children}</span>
+            {trailingIcon && <span className="ui-button__icon" aria-hidden="true">{trailingIcon}</span>}
+        </button>
+    );
+});
+
+export default Button;

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import type { ButtonSize, ButtonVariant } from './Button';
+import './ui.css';
+
+export interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
+    'aria-label': string;
+    icon: ReactNode;
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+}
+
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
+    'aria-label': ariaLabel,
+    icon,
+    variant = 'ghost',
+    size = 'default',
+    className = '',
+    type = 'button',
+    ...props
+}, ref) {
+    const classes = ['ui-icon-button', `ui-button--${variant}`, `ui-icon-button--${size}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button
+            ref={ref}
+            type={type}
+            className={classes}
+            aria-label={ariaLabel}
+            {...props}
+        >
+            <span className="ui-icon-button__icon" aria-hidden="true">{icon}</span>
+        </button>
+    );
+});
+
+export default IconButton;

--- a/frontend/src/components/ui/MetricCard.tsx
+++ b/frontend/src/components/ui/MetricCard.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type MetricTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+
+export interface MetricCardProps extends HTMLAttributes<HTMLElement> {
+    label: string;
+    value: ReactNode;
+    supportingText?: ReactNode;
+    tone?: MetricTone;
+}
+
+const MetricCard = forwardRef<HTMLElement, MetricCardProps>(function MetricCard({
+    label,
+    value,
+    supportingText,
+    tone = 'neutral',
+    className = '',
+    ...props
+}, ref) {
+    const classes = ['ui-metric-card', `ui-metric-card--${tone}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <article ref={ref} className={classes} {...props}>
+            <span className="ui-metric-card__label">{label}</span>
+            <strong className="ui-metric-card__value">{value}</strong>
+            {supportingText && (
+                <span className="ui-metric-card__supporting-text">{supportingText}</span>
+            )}
+        </article>
+    );
+});
+
+export default MetricCard;

--- a/frontend/src/components/ui/Panel.tsx
+++ b/frontend/src/components/ui/Panel.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import './ui.css';
+
+export type PanelPadding = 'none' | 'small' | 'default';
+
+export interface PanelProps extends HTMLAttributes<HTMLDivElement> {
+    padding?: PanelPadding;
+    elevated?: boolean;
+}
+
+const Panel = forwardRef<HTMLDivElement, PanelProps>(function Panel({
+    padding = 'default',
+    elevated = false,
+    className = '',
+    ...props
+}, ref) {
+    const classes = [
+        'ui-panel',
+        `ui-panel--padding-${padding}`,
+        elevated ? 'ui-panel--elevated' : '',
+        className,
+    ].filter(Boolean).join(' ');
+
+    return <div ref={ref} className={classes} {...props} />;
+});
+
+export default Panel;

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import './ui.css';
+
+export type StatusTone = 'neutral' | 'ready' | 'anchor' | 'limited' | 'critical' | 'info';
+
+export interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+    children: ReactNode;
+    tone?: StatusTone;
+    showDot?: boolean;
+}
+
+const StatusBadge = forwardRef<HTMLSpanElement, StatusBadgeProps>(function StatusBadge({
+    children,
+    tone = 'neutral',
+    showDot = false,
+    className = '',
+    ...props
+}, ref) {
+    const classes = ['ui-status-badge', `ui-status-badge--${tone}`, className]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <span ref={ref} className={classes} {...props}>
+            {showDot && <span className="ui-status-badge__dot" aria-hidden="true" />}
+            {children}
+        </span>
+    );
+});
+
+export default StatusBadge;

--- a/frontend/src/components/ui/ui.css
+++ b/frontend/src/components/ui/ui.css
@@ -1,0 +1,263 @@
+.ui-button,
+.ui-icon-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow: var(--shadow-xs);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.ui-button:hover:not(:disabled),
+.ui-icon-button:hover:not(:disabled) {
+  box-shadow: var(--shadow-sm);
+}
+
+.ui-button:focus-visible,
+.ui-icon-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring), var(--shadow-xs);
+}
+
+.ui-button:disabled,
+.ui-icon-button:disabled {
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.ui-button--primary {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+}
+
+.ui-button--primary:hover:not(:disabled) {
+  border-color: var(--color-primary-hover);
+  background: var(--color-primary-hover);
+}
+
+.ui-button--primary:active:not(:disabled) {
+  border-color: var(--color-primary-active);
+  background: var(--color-primary-active);
+}
+
+.ui-button--secondary {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.ui-button--secondary:hover:not(:disabled) {
+  border-color: #94a3b8;
+  background: var(--color-surface-subtle);
+}
+
+.ui-button--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  box-shadow: none;
+}
+
+.ui-button--ghost:hover:not(:disabled) {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+.ui-button--danger {
+  border-color: var(--color-danger);
+  background: var(--color-danger);
+  color: var(--color-text-inverse);
+}
+
+.ui-button--danger:hover:not(:disabled) {
+  border-color: var(--color-danger-hover);
+  background: var(--color-danger-hover);
+}
+
+.ui-button {
+  gap: var(--spacing-2);
+  min-width: max-content;
+}
+
+.ui-button--small {
+  min-height: var(--control-height-sm);
+  padding: 0 var(--spacing-3);
+  font-size: var(--font-xs);
+}
+
+.ui-button--default {
+  min-height: var(--control-height);
+  padding: 0 var(--spacing-4);
+  font-size: var(--font-sm);
+}
+
+.ui-button__icon,
+.ui-icon-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+}
+
+.ui-button__icon > svg,
+.ui-icon-button__icon > svg {
+  width: 100%;
+  height: 100%;
+  stroke-width: 2;
+}
+
+.ui-icon-button {
+  padding: 0;
+}
+
+.ui-icon-button--small {
+  width: var(--control-icon-size-sm);
+  height: var(--control-icon-size-sm);
+  font-size: var(--font-sm);
+}
+
+.ui-icon-button--default {
+  width: var(--control-icon-size);
+  height: var(--control-icon-size);
+  font-size: var(--font-base);
+}
+
+.ui-panel {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-xs);
+}
+
+.ui-panel--padding-none {
+  padding: 0;
+}
+
+.ui-panel--padding-small {
+  padding: var(--spacing-3);
+}
+
+.ui-panel--padding-default {
+  padding: var(--spacing-4);
+}
+
+.ui-panel--elevated {
+  box-shadow: var(--shadow-md);
+}
+
+.ui-metric-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  border: 1px solid var(--color-border);
+  border-top: 3px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-xs);
+}
+
+.ui-metric-card--success {
+  border-top-color: var(--color-status-ready);
+}
+
+.ui-metric-card--warning {
+  border-top-color: var(--color-status-anchor);
+}
+
+.ui-metric-card--danger {
+  border-top-color: var(--color-status-gap);
+}
+
+.ui-metric-card--info {
+  border-top-color: var(--color-status-info);
+}
+
+.ui-metric-card__label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.ui-metric-card__value {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--font-xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+}
+
+.ui-metric-card__supporting-text {
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+}
+
+.ui-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  width: fit-content;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-status-unknown-subtle);
+  color: var(--color-status-unknown);
+  padding: 0.1875rem var(--spacing-2);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.ui-status-badge--ready {
+  border-color: #bbf7d0;
+  background: var(--color-status-ready-subtle);
+  color: var(--color-status-ready);
+}
+
+.ui-status-badge--anchor {
+  border-color: #fde68a;
+  background: var(--color-status-anchor-subtle);
+  color: var(--color-status-anchor);
+}
+
+.ui-status-badge--limited {
+  border-color: #ddd6fe;
+  background: var(--color-status-limited-subtle);
+  color: var(--color-status-limited);
+}
+
+.ui-status-badge--critical {
+  border-color: #fecaca;
+  background: var(--color-status-gap-subtle);
+  color: var(--color-status-gap);
+}
+
+.ui-status-badge--info {
+  border-color: #bae6fd;
+  background: var(--color-status-info-subtle);
+  color: var(--color-status-info);
+}
+
+.ui-status-badge__dot {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: var(--radius-full);
+  background: currentColor;
+}

--- a/frontend/src/domain/domainPresentation.test.ts
+++ b/frontend/src/domain/domainPresentation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DESERT_SCORE_THRESHOLDS,
+    getDataGapPresentation,
+    getDesertScorePresentation,
+    matchesDesertScoreFilter,
+} from './metrics';
+import {
+    getTelehealthStatusColor,
+    getTelehealthStatusLabel,
+    getTelehealthStatusTone,
+} from './statusPresentation';
+
+describe('desert score presentation', () => {
+    it.each([
+        [0, 'adequate', 'Adequate Need'],
+        [DESERT_SCORE_THRESHOLDS.moderate - 0.1, 'adequate', 'Adequate Need'],
+        [DESERT_SCORE_THRESHOLDS.moderate, 'moderate', 'Moderate Need'],
+        [DESERT_SCORE_THRESHOLDS.high, 'high', 'High Need'],
+        [DESERT_SCORE_THRESHOLDS.critical, 'critical', 'Critical Need'],
+        [100, 'critical', 'Critical Need'],
+    ])('classifies %s as %s', (score, level, label) => {
+        expect(getDesertScorePresentation(score)).toMatchObject({ level, label });
+    });
+
+    it('uses the same thresholds for sidebar score filters', () => {
+        expect(matchesDesertScoreFilter(75, '75-plus')).toBe(true);
+        expect(matchesDesertScoreFilter(74.9, '75-plus')).toBe(false);
+        expect(matchesDesertScoreFilter(50, '50-plus')).toBe(true);
+        expect(matchesDesertScoreFilter(49.9, 'below-50')).toBe(true);
+        expect(matchesDesertScoreFilter(null, 'unknown')).toBe(true);
+    });
+});
+
+describe('status presentation', () => {
+    it('provides one label, color, and tone for each shared status', () => {
+        expect(getTelehealthStatusLabel('COMMUNITY_ANCHOR')).toBe('Community Anchor');
+        expect(getTelehealthStatusColor('CRITICAL_GAP')).toBe('#ef4444');
+        expect(getTelehealthStatusColor('COMMUNITY_ANCHOR', 'scenario')).toBe('#f97316');
+        expect(getTelehealthStatusTone('LIMITED_TELEHEALTH')).toBe('limited');
+    });
+
+    it('names satellite dependency as connectivity, not affordability', () => {
+        expect(getDataGapPresentation('SATELLITE_DEPENDENT').label).toBe('Satellite-dependent access');
+    });
+});

--- a/frontend/src/domain/mapMode.ts
+++ b/frontend/src/domain/mapMode.ts
@@ -1,0 +1,27 @@
+export type BaseMapLayer = 'cat' | 'gap' | 'affordability';
+
+export type MapMode =
+    | { type: 'cat' }
+    | { type: 'gapHunter' }
+    | { type: 'telehealthAccess' }
+    | { type: 'scenario' };
+
+export const CAT_MAP_MODE: MapMode = { type: 'cat' };
+
+export function mapModeFromLayer(layer: BaseMapLayer): MapMode {
+    switch (layer) {
+        case 'gap': return { type: 'gapHunter' };
+        case 'affordability': return { type: 'telehealthAccess' };
+        case 'cat': return CAT_MAP_MODE;
+    }
+}
+
+export function baseLayerForMapMode(mode: MapMode): BaseMapLayer {
+    switch (mode.type) {
+        case 'gapHunter': return 'gap';
+        case 'telehealthAccess': return 'affordability';
+        case 'cat':
+        case 'scenario':
+            return 'cat';
+    }
+}

--- a/frontend/src/domain/mapUrlState.test.ts
+++ b/frontend/src/domain/mapUrlState.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { BASELINE_THRESHOLDS } from '../types/scenario';
+import {
+    ALASKA_CENTER,
+    ALASKA_ZOOM,
+    parseMapUrlState,
+    serializeMapUrlState,
+} from './mapUrlState';
+
+describe('map URL state', () => {
+    it('parses selection, viewport, layer, pins, and season', () => {
+        const state = parseMapUrlState(
+            '?region=AK-1&season=winter&layer=gap&pins=AK-1,AK-2&lat=64.5&lng=-151.25&zoom=7',
+        );
+
+        expect(state).toMatchObject({
+            selectedRegionCode: 'AK-1',
+            season: 'winter',
+            mapMode: { type: 'gapHunter' },
+            pinnedRegionCodes: ['AK-1', 'AK-2'],
+            center: [64.5, -151.25],
+            zoom: 7,
+        });
+    });
+
+    it('falls back for invalid or stale viewport values', () => {
+        expect(parseMapUrlState('?season=invalid&layer=unknown&lat=200&lng=nope&zoom=99')).toMatchObject({
+            season: 'year_round',
+            mapMode: { type: 'cat' },
+            center: ALASKA_CENTER,
+            zoom: ALASKA_ZOOM,
+        });
+        expect(parseMapUrlState('?lat=62.9752&lng=-154.95117&zoom=4')).toMatchObject({
+            center: ALASKA_CENTER,
+            zoom: ALASKA_ZOOM,
+        });
+    });
+
+    it('round-trips scenario mode and threshold parameters', () => {
+        const search = serializeMapUrlState('?unrelated=kept', {
+            selectedRegionCode: 'AK-9',
+            season: 'summer',
+            mapMode: { type: 'scenario' },
+            pinnedRegionCodes: [],
+            center: ALASKA_CENTER,
+            zoom: ALASKA_ZOOM,
+            scenario: {
+                thresholds: { ...BASELINE_THRESHOLDS, min_download_mbps: 100, max_latency_ms: null },
+                preset: 'equity',
+            },
+        });
+        const parsed = parseMapUrlState(`?${search}`);
+
+        expect(new URLSearchParams(search).get('unrelated')).toBe('kept');
+        expect(parsed.mapMode).toEqual({ type: 'scenario' });
+        expect(parsed.scenario).toEqual({
+            thresholds: {
+                min_download_mbps: 100,
+                min_upload_mbps: 3,
+                max_latency_ms: null,
+                affordability_burden_pct: 2,
+                clinic_proximity_km: null,
+            },
+            preset: 'equity',
+        });
+    });
+
+    it('removes stale owned parameters when returning to CAT mode', () => {
+        const search = serializeMapUrlState(
+            '?layer=gap&scenario=1&bd=100&preset=equity&external=1',
+            {
+                selectedRegionCode: null,
+                season: 'year_round',
+                mapMode: { type: 'cat' },
+                pinnedRegionCodes: [],
+                center: ALASKA_CENTER,
+                zoom: ALASKA_ZOOM,
+                scenario: { thresholds: BASELINE_THRESHOLDS, preset: null },
+            },
+        );
+
+        expect(search).toBe('external=1');
+    });
+});

--- a/frontend/src/domain/mapUrlState.ts
+++ b/frontend/src/domain/mapUrlState.ts
@@ -1,0 +1,157 @@
+import type { Season } from '../api/catApi';
+import type { ScenarioThresholds } from '../types/scenario';
+import type { MapMode } from './mapMode';
+
+export const ALASKA_CENTER: [number, number] = [64.2, -152.0];
+export const ALASKA_ZOOM = 4;
+export const ALASKA_BOUNDS: [[number, number], [number, number]] = [
+    [51.0, -188.0],
+    [72.0, -129.0],
+];
+
+const STALE_DEFAULT_CENTERS: Array<[number, number]> = [
+    [62.9752, -154.95117],
+    [62.35, -146.75],
+    [62.2, -141.8],
+    [62.2, -170.8],
+    [62.35, -136.5],
+];
+
+const OWNED_PARAMS = [
+    'region', 'layer', 'season', 'pins', 'lat', 'lng', 'zoom',
+    'scenario', 'bd', 'up', 'latency', 'aff', 'clinic', 'preset',
+] as const;
+
+export interface ParsedScenarioUrlState {
+    thresholds: Partial<ScenarioThresholds>;
+    preset: string | null;
+}
+
+export interface ParsedMapUrlState {
+    selectedRegionCode: string | null;
+    season: Season;
+    mapMode: MapMode;
+    pinnedRegionCodes: string[];
+    center: [number, number];
+    zoom: number;
+    scenario: ParsedScenarioUrlState;
+}
+
+export interface SerializableMapUrlState {
+    selectedRegionCode: string | null;
+    season: Season;
+    mapMode: MapMode;
+    pinnedRegionCodes: string[];
+    center: [number, number];
+    zoom: number;
+    scenario: {
+        thresholds: ScenarioThresholds;
+        preset: string | null;
+    };
+}
+
+function validNumber(value: string | null): number | null {
+    if (value === null || value.trim() === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseScenarioParams(params: URLSearchParams): ParsedScenarioUrlState {
+    if (params.get('scenario') !== '1') return { thresholds: {}, preset: null };
+
+    const thresholds: Partial<ScenarioThresholds> = {};
+    const download = validNumber(params.get('bd'));
+    const upload = validNumber(params.get('up'));
+    const affordability = validNumber(params.get('aff'));
+    const latencyParam = params.get('latency');
+    const clinicParam = params.get('clinic');
+
+    if (download !== null) thresholds.min_download_mbps = download;
+    if (upload !== null) thresholds.min_upload_mbps = upload;
+    if (affordability !== null) thresholds.affordability_burden_pct = affordability;
+    if (latencyParam === 'baseline') thresholds.max_latency_ms = null;
+    else {
+        const latency = validNumber(latencyParam);
+        if (latency !== null) thresholds.max_latency_ms = latency;
+    }
+    if (clinicParam === 'baseline') thresholds.clinic_proximity_km = null;
+    else {
+        const clinic = validNumber(clinicParam);
+        if (clinic !== null) thresholds.clinic_proximity_km = clinic;
+    }
+
+    return { thresholds, preset: params.get('preset') };
+}
+
+export function parseMapUrlState(search: string): ParsedMapUrlState {
+    const params = new URLSearchParams(search);
+    const seasonParam = params.get('season');
+    const layerParam = params.get('layer');
+    const lat = validNumber(params.get('lat'));
+    const lng = validNumber(params.get('lng'));
+    const zoom = validNumber(params.get('zoom'));
+    const hasSafeCenter = lat !== null && lng !== null
+        && lat >= ALASKA_BOUNDS[0][0] && lat <= ALASKA_BOUNDS[1][0]
+        && lng >= ALASKA_BOUNDS[0][1] && lng <= ALASKA_BOUNDS[1][1];
+    const hasSafeZoom = zoom !== null && zoom >= 4 && zoom <= 18;
+    const hasStaleDefaultViewport = hasSafeCenter && hasSafeZoom
+        && STALE_DEFAULT_CENTERS.some(([staleLat, staleLng]) => (
+            Math.abs(lat - staleLat) < 0.0001 && Math.abs(lng - staleLng) < 0.0001
+        ))
+        && zoom === ALASKA_ZOOM;
+
+    let mapMode: MapMode = { type: 'cat' };
+    if (params.get('scenario') === '1') mapMode = { type: 'scenario' };
+    else if (layerParam === 'gap') mapMode = { type: 'gapHunter' };
+    else if (layerParam === 'affordability') mapMode = { type: 'telehealthAccess' };
+
+    return {
+        selectedRegionCode: params.get('region'),
+        season: seasonParam === 'summer' || seasonParam === 'winter' || seasonParam === 'year_round'
+            ? seasonParam
+            : 'year_round',
+        mapMode,
+        pinnedRegionCodes: (params.get('pins') ?? '')
+            .split(',')
+            .map(code => code.trim())
+            .filter(Boolean)
+            .slice(0, 3),
+        center: hasSafeCenter && !hasStaleDefaultViewport ? [lat, lng] : ALASKA_CENTER,
+        zoom: hasSafeZoom && !hasStaleDefaultViewport ? zoom : ALASKA_ZOOM,
+        scenario: parseScenarioParams(params),
+    };
+}
+
+export function serializeMapUrlState(
+    currentSearch: string,
+    state: SerializableMapUrlState,
+): string {
+    const params = new URLSearchParams(currentSearch);
+    OWNED_PARAMS.forEach(param => params.delete(param));
+
+    if (state.selectedRegionCode) params.set('region', state.selectedRegionCode);
+    if (state.mapMode.type === 'gapHunter') params.set('layer', 'gap');
+    if (state.mapMode.type === 'telehealthAccess') params.set('layer', 'affordability');
+    if (state.season !== 'year_round') params.set('season', state.season);
+    if (state.pinnedRegionCodes.length) params.set('pins', state.pinnedRegionCodes.slice(0, 3).join(','));
+    if (state.center[0] !== ALASKA_CENTER[0]) params.set('lat', state.center[0].toFixed(5));
+    if (state.center[1] !== ALASKA_CENTER[1]) params.set('lng', state.center[1].toFixed(5));
+    if (state.zoom !== ALASKA_ZOOM) params.set('zoom', String(state.zoom));
+
+    if (state.mapMode.type === 'scenario') {
+        const { thresholds, preset } = state.scenario;
+        params.set('scenario', '1');
+        params.set('bd', String(thresholds.min_download_mbps));
+        params.set('up', String(thresholds.min_upload_mbps));
+        params.set('latency', thresholds.max_latency_ms === null
+            ? 'baseline'
+            : String(thresholds.max_latency_ms));
+        params.set('aff', String(thresholds.affordability_burden_pct));
+        params.set('clinic', thresholds.clinic_proximity_km === null
+            ? 'baseline'
+            : String(thresholds.clinic_proximity_km));
+        if (preset) params.set('preset', preset);
+    }
+
+    return params.toString();
+}

--- a/frontend/src/domain/metrics.ts
+++ b/frontend/src/domain/metrics.ts
@@ -1,0 +1,171 @@
+import type { StatusTone } from '../components/ui/StatusBadge';
+import type { TelehealthStatusName } from './statusPresentation';
+
+export type CatTier = 1 | 2 | 3 | 4;
+
+interface CatTierPresentation {
+    label: string;
+    shortDescription: string;
+    color: string;
+    tone: StatusTone;
+}
+
+export const CAT_TIER_PRESENTATION: Record<CatTier, CatTierPresentation> = {
+    1: {
+        label: 'Full Multimodal Access',
+        shortDescription: 'strongest access; road-connected or easier service reach.',
+        color: '#22c55e',
+        tone: 'ready',
+    },
+    2: {
+        label: 'Dual Mode Access',
+        shortDescription: 'moderate access; some travel or logistics constraints.',
+        color: '#eab308',
+        tone: 'info',
+    },
+    3: {
+        label: 'Limited Access',
+        shortDescription: 'limited access; remote travel makes care harder to reach.',
+        color: '#f97316',
+        tone: 'anchor',
+    },
+    4: {
+        label: 'Extreme/No Direct Access',
+        shortDescription: 'most isolated; highest transport and service-access barriers.',
+        color: '#ef4444',
+        tone: 'critical',
+    },
+};
+
+export const CAT_TIERS = [1, 2, 3, 4] as const;
+
+export interface DesertScorePresentation {
+    level: 'adequate' | 'moderate' | 'high' | 'critical';
+    label: string;
+    color: string;
+    tone: StatusTone;
+    description: string;
+}
+
+export const DESERT_SCORE_THRESHOLDS = {
+    moderate: 25,
+    high: 50,
+    critical: 75,
+} as const;
+
+const REGION_CARD_SEVERITY_THRESHOLDS = {
+    warning: 60,
+    critical: 80,
+} as const;
+
+export function getDesertScorePresentation(score: number): DesertScorePresentation {
+    if (score >= DESERT_SCORE_THRESHOLDS.critical) {
+        return {
+            level: 'critical',
+            label: 'Critical Need',
+            color: '#f43f5e',
+            tone: 'critical',
+            description: 'Severe lack of nearby healthcare facilities',
+        };
+    }
+    if (score >= DESERT_SCORE_THRESHOLDS.high) {
+        return {
+            level: 'high',
+            label: 'High Need',
+            color: '#fb923c',
+            tone: 'anchor',
+            description: 'Limited access to clinics or hospitals',
+        };
+    }
+    if (score >= DESERT_SCORE_THRESHOLDS.moderate) {
+        return {
+            level: 'moderate',
+            label: 'Moderate Need',
+            color: '#fbbf24',
+            tone: 'info',
+            description: 'Adequate access with some travel distance',
+        };
+    }
+    return {
+        level: 'adequate',
+        label: 'Adequate Need',
+        color: '#34d399',
+        tone: 'ready',
+        description: 'Good access to nearby healthcare facilities',
+    };
+}
+
+export type DesertScoreFilter = '' | '75-plus' | '50-plus' | 'below-50' | 'unknown';
+
+export const DESERT_SCORE_FILTER_OPTIONS: Array<{ value: DesertScoreFilter; label: string }> = [
+    { value: '', label: 'All scores' },
+    { value: '75-plus', label: `${DESERT_SCORE_THRESHOLDS.critical}+ critical need` },
+    { value: '50-plus', label: `${DESERT_SCORE_THRESHOLDS.high}+ high need` },
+    { value: 'below-50', label: `Below ${DESERT_SCORE_THRESHOLDS.high}` },
+    { value: 'unknown', label: 'Unknown score' },
+];
+
+export function matchesDesertScoreFilter(
+    score: number | null | undefined,
+    filter: DesertScoreFilter,
+): boolean {
+    if (!filter) return true;
+    if (filter === 'unknown') return score === null || score === undefined;
+    if (score === null || score === undefined) return false;
+    if (filter === '75-plus') return score >= DESERT_SCORE_THRESHOLDS.critical;
+    if (filter === '50-plus') return score >= DESERT_SCORE_THRESHOLDS.high;
+    return score < DESERT_SCORE_THRESHOLDS.high;
+}
+
+export function getRegionSeverityClassName(region: {
+    telehealth_status: TelehealthStatusName;
+    desert_score: number | null;
+}): string {
+    const status: TelehealthStatusName = region.telehealth_status;
+    const score = region.desert_score ?? -1;
+    // These existing card-emphasis cutoffs are intentionally distinct from the
+    // canonical 25/50/75 desert-score meaning bands above.
+    if (status === 'CRITICAL_GAP' || score >= REGION_CARD_SEVERITY_THRESHOLDS.critical) return 'severity-critical';
+    if (status === 'COMMUNITY_ANCHOR' || score >= REGION_CARD_SEVERITY_THRESHOLDS.warning) return 'severity-warning';
+    if (status === 'TELEHEALTH_READY') return 'severity-ready';
+    return 'severity-unknown';
+}
+
+export type DataGapSeverity = 'warning' | 'error' | 'info';
+
+export type DataConfidenceLevel = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export const DATA_CONFIDENCE_PRESENTATION: Record<DataConfidenceLevel, {
+    label: string;
+    className: string;
+}> = {
+    HIGH: { label: 'High', className: 'is-high' },
+    MEDIUM: { label: 'Medium', className: 'is-medium' },
+    LOW: { label: 'Low', className: 'is-low' },
+};
+
+export const DATA_CONFIDENCE_LEVELS: DataConfidenceLevel[] = ['HIGH', 'MEDIUM', 'LOW'];
+
+export function getDataGapPresentation(gap: string): { label: string; severity: DataGapSeverity } {
+    switch (gap) {
+        case 'SATELLITE_DEPENDENT':
+            return { label: 'Satellite-dependent access', severity: 'warning' };
+        case 'LOW_TERRESTRIAL':
+            return { label: 'Low wired coverage', severity: 'warning' };
+        case 'LOW_CONFIDENCE':
+            return { label: 'Low data confidence', severity: 'info' };
+        case 'INTERNET_DESERT':
+            return { label: 'No internet coverage', severity: 'error' };
+        case 'MISSING_WIRED_DATA':
+            return { label: 'Missing wired data', severity: 'info' };
+        case 'MISSING_SATELLITE_DATA':
+            return { label: 'Missing satellite data', severity: 'info' };
+        default:
+            return { label: gap, severity: 'info' };
+    }
+}
+
+export const SATELLITE_PRIMARY_METRIC = {
+    label: 'Satellite-primary places',
+    description: 'This is a connectivity access type, not a measure of affordability.',
+} as const;

--- a/frontend/src/domain/statusPresentation.ts
+++ b/frontend/src/domain/statusPresentation.ts
@@ -1,0 +1,101 @@
+import type { StatusTone } from '../components/ui/StatusBadge';
+
+export type TelehealthStatusName =
+    | 'TELEHEALTH_READY'
+    | 'COMMUNITY_ANCHOR'
+    | 'CRITICAL_GAP'
+    | 'DATA_UNAVAILABLE';
+
+export type ScenarioTelehealthStatusName = TelehealthStatusName | 'LIMITED_TELEHEALTH';
+
+interface TelehealthStatusPresentation {
+    label: string;
+    color: string;
+    scenarioColor?: string;
+    tone: StatusTone;
+    className: string;
+    description: string;
+}
+
+export const TELEHEALTH_STATUS_PRESENTATION: Record<ScenarioTelehealthStatusName, TelehealthStatusPresentation> = {
+    TELEHEALTH_READY: {
+        label: 'Telehealth Ready',
+        color: '#22c55e',
+        tone: 'ready',
+        className: 'status-ready',
+        description: 'Affordable home access',
+    },
+    COMMUNITY_ANCHOR: {
+        label: 'Community Anchor',
+        color: '#f59e0b',
+        scenarioColor: '#f97316',
+        tone: 'anchor',
+        className: 'status-anchor',
+        description: 'Nearby clinic safety net',
+    },
+    LIMITED_TELEHEALTH: {
+        label: 'Limited Telehealth',
+        color: '#eab308',
+        tone: 'limited',
+        className: 'status-limited',
+        description: 'Some access requirements are not met',
+    },
+    CRITICAL_GAP: {
+        label: 'Critical Gap',
+        color: '#ef4444',
+        tone: 'critical',
+        className: 'status-critical',
+        description: 'Unaffordable access and no nearby clinic',
+    },
+    DATA_UNAVAILABLE: {
+        label: 'Data Unavailable',
+        color: '#6b7280',
+        tone: 'neutral',
+        className: 'status-unknown',
+        description: 'Required classification data is missing',
+    },
+};
+
+export const BASE_TELEHEALTH_STATUSES: TelehealthStatusName[] = [
+    'TELEHEALTH_READY',
+    'COMMUNITY_ANCHOR',
+    'CRITICAL_GAP',
+    'DATA_UNAVAILABLE',
+];
+
+export const SCENARIO_TELEHEALTH_STATUSES: ScenarioTelehealthStatusName[] = [
+    'TELEHEALTH_READY',
+    'COMMUNITY_ANCHOR',
+    'LIMITED_TELEHEALTH',
+    'CRITICAL_GAP',
+    'DATA_UNAVAILABLE',
+];
+
+export function isScenarioTelehealthStatus(value: unknown): value is ScenarioTelehealthStatusName {
+    return typeof value === 'string'
+        && SCENARIO_TELEHEALTH_STATUSES.includes(value as ScenarioTelehealthStatusName);
+}
+
+export function getTelehealthStatusPresentation(status: ScenarioTelehealthStatusName) {
+    return TELEHEALTH_STATUS_PRESENTATION[status];
+}
+
+export function getTelehealthStatusLabel(status: ScenarioTelehealthStatusName): string {
+    return getTelehealthStatusPresentation(status).label;
+}
+
+export function getTelehealthStatusColor(
+    status: ScenarioTelehealthStatusName,
+    context: 'baseline' | 'scenario' = 'baseline',
+): string {
+    const presentation = getTelehealthStatusPresentation(status);
+    return context === 'scenario' ? presentation.scenarioColor ?? presentation.color : presentation.color;
+}
+
+export function getTelehealthStatusTone(status: ScenarioTelehealthStatusName): StatusTone {
+    return getTelehealthStatusPresentation(status).tone;
+}
+
+export function getTelehealthStatusClassName(status: ScenarioTelehealthStatusName): string {
+    return getTelehealthStatusPresentation(status).className;
+}

--- a/frontend/src/hooks/useComparisonProfiles.ts
+++ b/frontend/src/hooks/useComparisonProfiles.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Season } from '../api/catApi';
 import { fetchResearchProfiles } from '../api/researchApi';
 import { ResearchProfile } from '../types/research';
+import { errorMessage, isAbortError } from '../api/http';
 
 export function useComparisonProfiles(regionCodes: string[], season: Season) {
     const codesKey = regionCodes.slice(0, 3).join(',');
@@ -20,30 +21,30 @@ export function useComparisonProfiles(regionCodes: string[], season: Season) {
             return;
         }
 
-        let active = true;
+        const controller = new AbortController();
         setLoading(true);
         setError(null);
 
-        fetchResearchProfiles(codes, season)
+        fetchResearchProfiles(codes, season, controller.signal)
             .then(data => {
-                if (active) {
+                if (!controller.signal.aborted) {
                     setProfiles(data.profiles);
                     setMissingCodes(data.missing_codes);
                 }
             })
-            .catch(err => {
-                if (active) {
+            .catch((caught: unknown) => {
+                if (!isAbortError(caught)) {
                     setProfiles([]);
                     setMissingCodes([]);
-                    setError(err instanceof Error ? err.message : 'Failed to load comparison');
+                    setError(errorMessage(caught, 'Failed to load comparison'));
                 }
             })
             .finally(() => {
-                if (active) setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             });
 
         return () => {
-            active = false;
+            controller.abort();
         };
     }, [codesKey, season]);
 

--- a/frontend/src/hooks/useDashboardData.test.tsx
+++ b/frontend/src/hooks/useDashboardData.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    fetchAffordability,
+    fetchAllTelehealthStatus,
+    fetchDataGapsSummary,
+    fetchHealthcareSummary,
+    fetchPerformanceSummary,
+    fetchStatistics,
+} from '../api/catApi';
+import { useDashboardData } from './useDashboardData';
+
+vi.mock('../api/catApi', () => ({
+    fetchAffordability: vi.fn(),
+    fetchAllTelehealthStatus: vi.fn(),
+    fetchDataGapsSummary: vi.fn(),
+    fetchHealthcareSummary: vi.fn(),
+    fetchPerformanceSummary: vi.fn(),
+    fetchStatistics: vi.fn(),
+}));
+
+const mockedFetchStatistics = vi.mocked(fetchStatistics);
+const mockedFetchTelehealth = vi.mocked(fetchAllTelehealthStatus);
+const mockedFetchHealthcare = vi.mocked(fetchHealthcareSummary);
+const mockedFetchPerformance = vi.mocked(fetchPerformanceSummary);
+const mockedFetchDataGaps = vi.mocked(fetchDataGapsSummary);
+const mockedFetchAffordability = vi.mocked(fetchAffordability);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFetchStatistics.mockResolvedValue({
+        total_regions: 4,
+        total_data_points: 10,
+        total_uploads: 1,
+        completed_uploads: 1,
+        total_gating_rules: 0,
+        active_gating_rules: 0,
+        total_healthcare_sites: 2,
+        hospitals: 1,
+        clinics: 1,
+    });
+    mockedFetchTelehealth.mockResolvedValue({
+        regions: [],
+        count: 4,
+        summary: {
+            telehealth_ready: 1,
+            community_anchor: 1,
+            critical_gap: 1,
+            data_unavailable: 1,
+        },
+    });
+    mockedFetchHealthcare.mockResolvedValue({
+        total_facilities: 2,
+        by_type: { hospital: 1, clinic: 1, pharmacy: 0, health_center: 0 },
+        features: { with_emergency: 1, with_specialists: 0, with_telehealth: 1 },
+        data_source: 'test',
+    });
+    mockedFetchPerformance.mockResolvedValue({
+        has_data: true,
+        period: { year: 2025, quarter: 1, label: '2025 Q1' },
+        coverage: { total_tiles: 1, tiles_with_speed_data: 1, total_tests: 1, total_devices: 1 },
+        speeds: { avg_download_mbps: 25, max_download_mbps: 25, min_download_mbps: 25, median_download_mbps: 25 },
+        distribution: { excellent: 0, good: 1, moderate: 0, poor: 0, critical: 0 },
+        telehealth_viable_pct: 100,
+    });
+    mockedFetchDataGaps.mockResolvedValue({
+        total_places: 1,
+        places_with_gaps: 0,
+        gap_breakdown: {},
+        confidence_distribution: { HIGH: 1, MEDIUM: 0, LOW: 0 },
+        telehealth_viability: { YES: 1, NO: 0, UNCERTAIN: 0 },
+        primary_access: { WIRED: 1, SATELLITE: 0, LIMITED: 0 },
+    });
+    mockedFetchAffordability.mockResolvedValue({
+        zones: [],
+        count: 1,
+        monthly_cost: 120,
+        threshold_pct: 2,
+        summary: { affordable: 1, unaffordable: 0, affordable_pct: 100 },
+    });
+});
+
+describe('useDashboardData', () => {
+    it('keeps fulfilled sections and identifies a rejected section', async () => {
+        mockedFetchPerformance.mockRejectedValue(new Error('Performance period unavailable'));
+
+        const { result } = renderHook(() => useDashboardData());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.data.statistics?.total_regions).toBe(4);
+        expect(result.current.data.performance).toBeNull();
+        expect(result.current.sectionErrors).toEqual({
+            performance: 'Performance period unavailable',
+        });
+        expect(result.current.availableSectionCount).toBe(5);
+        expect(result.current.hasPartialData).toBe(true);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('passes one request signal to every dashboard source and aborts on unmount', async () => {
+        const { result, unmount } = renderHook(() => useDashboardData());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const signal = mockedFetchStatistics.mock.calls[0][0];
+        expect(signal).toBeInstanceOf(AbortSignal);
+        expect(mockedFetchTelehealth).toHaveBeenCalledWith(signal);
+        expect(mockedFetchHealthcare).toHaveBeenCalledWith(signal);
+        expect(mockedFetchPerformance).toHaveBeenCalledWith(signal);
+        expect(mockedFetchDataGaps).toHaveBeenCalledWith(signal);
+        expect(mockedFetchAffordability).toHaveBeenCalledWith(120, 2, signal);
+
+        unmount();
+        expect(signal?.aborted).toBe(true);
+    });
+});

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    fetchAffordability,
+    fetchAllTelehealthStatus,
+    fetchDataGapsSummary,
+    fetchHealthcareSummary,
+    fetchPerformanceSummary,
+    fetchStatistics,
+    type AffordabilityResponse,
+    type AllTelehealthStatusResponse,
+    type DataGapsSummary,
+    type HealthcareSummary,
+    type PerformanceSummary,
+    type StatisticsResponse,
+} from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
+
+export interface DashboardData {
+    statistics: StatisticsResponse | null;
+    telehealthStatus: AllTelehealthStatusResponse | null;
+    healthcare: HealthcareSummary | null;
+    performance: PerformanceSummary | null;
+    dataGaps: DataGapsSummary | null;
+    affordability: AffordabilityResponse | null;
+}
+
+export type DashboardSection = keyof DashboardData;
+export type DashboardSectionErrors = Partial<Record<DashboardSection, string>>;
+
+const EMPTY_DATA: DashboardData = {
+    statistics: null,
+    telehealthStatus: null,
+    healthcare: null,
+    performance: null,
+    dataGaps: null,
+    affordability: null,
+};
+
+function rejectedMessage(result: PromiseSettledResult<unknown>): string | undefined {
+    return result.status === 'rejected' ? errorMessage(result.reason) : undefined;
+}
+
+export function useDashboardData() {
+    const [data, setData] = useState<DashboardData>(EMPTY_DATA);
+    const [sectionErrors, setSectionErrors] = useState<DashboardSectionErrors>({});
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+        const controller = new AbortController();
+
+        async function loadData() {
+            setLoading(true);
+            setError(null);
+            setSectionErrors({});
+
+            try {
+                const results = await Promise.allSettled([
+                    fetchStatistics(controller.signal),
+                    fetchAllTelehealthStatus(controller.signal),
+                    fetchHealthcareSummary(controller.signal),
+                    fetchPerformanceSummary(controller.signal),
+                    fetchDataGapsSummary(controller.signal),
+                    fetchAffordability(120, 2, controller.signal),
+                ] as const);
+
+                if (!isMounted || controller.signal.aborted) return;
+
+                const [
+                    statisticsResult,
+                    telehealthResult,
+                    healthcareResult,
+                    performanceResult,
+                    dataGapsResult,
+                    affordabilityResult,
+                ] = results;
+
+                const nextData: DashboardData = {
+                    statistics: statisticsResult.status === 'fulfilled' ? statisticsResult.value : null,
+                    telehealthStatus: telehealthResult.status === 'fulfilled' ? telehealthResult.value : null,
+                    healthcare: healthcareResult.status === 'fulfilled' ? healthcareResult.value : null,
+                    performance: performanceResult.status === 'fulfilled' ? performanceResult.value : null,
+                    dataGaps: dataGapsResult.status === 'fulfilled' ? dataGapsResult.value : null,
+                    affordability: affordabilityResult.status === 'fulfilled' ? affordabilityResult.value : null,
+                };
+
+                const nextSectionErrors: DashboardSectionErrors = {};
+                const resultBySection: Record<DashboardSection, PromiseSettledResult<unknown>> = {
+                    statistics: statisticsResult,
+                    telehealthStatus: telehealthResult,
+                    healthcare: healthcareResult,
+                    performance: performanceResult,
+                    dataGaps: dataGapsResult,
+                    affordability: affordabilityResult,
+                };
+
+                (Object.keys(resultBySection) as DashboardSection[]).forEach(section => {
+                    const message = rejectedMessage(resultBySection[section]);
+                    if (message) nextSectionErrors[section] = message;
+                });
+
+                const failedCount = Object.keys(nextSectionErrors).length;
+                setData(nextData);
+                setSectionErrors(nextSectionErrors);
+                setError(failedCount === results.length
+                    ? 'Statewide insight sources are currently unavailable. Return to the map and try again later.'
+                    : null);
+            } catch (caught: unknown) {
+                if (!isMounted || isAbortError(caught)) return;
+                setData(EMPTY_DATA);
+                setError(errorMessage(caught));
+            } finally {
+                if (isMounted) setLoading(false);
+            }
+        }
+
+        loadData();
+        return () => {
+            isMounted = false;
+            controller.abort();
+        };
+    }, []);
+
+    const availableSectionCount = useMemo(
+        () => Object.values(data).filter(Boolean).length,
+        [data],
+    );
+    const unavailableSectionCount = Object.keys(sectionErrors).length;
+
+    return {
+        data,
+        sectionErrors,
+        availableSectionCount,
+        hasPartialData: availableSectionCount > 0 && unavailableSectionCount > 0,
+        loading,
+        error,
+    };
+}

--- a/frontend/src/hooks/useMapSelection.test.tsx
+++ b/frontend/src/hooks/useMapSelection.test.tsx
@@ -1,0 +1,17 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useMapSelection } from './useMapSelection';
+
+describe('useMapSelection', () => {
+    it('requests selected-panel visibility for selections and detail actions', () => {
+        const { result } = renderHook(() => useMapSelection(null));
+
+        act(() => result.current.selectRegion('AK-ANCHORAGE'));
+        expect(result.current.selectedRegionCode).toBe('AK-ANCHORAGE');
+        expect(result.current.detailsFocusKey).toBe(1);
+
+        act(() => result.current.viewRegionDetails('AK-BETHEL'));
+        expect(result.current.selectedRegionCode).toBe('AK-BETHEL');
+        expect(result.current.detailsFocusKey).toBe(2);
+    });
+});

--- a/frontend/src/hooks/useMapSelection.ts
+++ b/frontend/src/hooks/useMapSelection.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from 'react';
+import type L from 'leaflet';
+
+export type SelectableMapMarker = L.Marker | L.CircleMarker;
+
+export function useMapSelection(initialRegionCode: string | null) {
+    const [selectedRegionCode, setSelectedRegionCode] = useState(initialRegionCode);
+    const [detailsFocusKey, setDetailsFocusKey] = useState(0);
+    const markerRefs = useRef<Record<string, SelectableMapMarker>>({});
+
+    const registerMarker = useCallback((regionCode: string, marker: SelectableMapMarker | null) => {
+        if (marker) markerRefs.current[regionCode] = marker;
+        else delete markerRefs.current[regionCode];
+    }, []);
+
+    const selectRegion = useCallback((regionCode: string) => {
+        setSelectedRegionCode(regionCode);
+        setDetailsFocusKey(key => key + 1);
+    }, []);
+
+    const viewRegionDetails = useCallback((regionCode: string) => {
+        setSelectedRegionCode(regionCode);
+        setDetailsFocusKey(key => key + 1);
+        markerRefs.current[regionCode]?.closePopup();
+    }, []);
+
+    return {
+        selectedRegionCode,
+        setSelectedRegionCode,
+        detailsFocusKey,
+        markerRefs,
+        registerMarker,
+        selectRegion,
+        viewRegionDetails,
+    };
+}

--- a/frontend/src/hooks/useMapUrlSync.test.tsx
+++ b/frontend/src/hooks/useMapUrlSync.test.tsx
@@ -1,0 +1,35 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ALASKA_CENTER, ALASKA_ZOOM } from '../domain/mapUrlState';
+import { BASELINE_THRESHOLDS } from '../types/scenario';
+import { useMapUrlSync } from './useMapUrlSync';
+
+const currentState = {
+    selectedRegionCode: null,
+    season: 'year_round' as const,
+    mapMode: { type: 'cat' as const },
+    pinnedRegionCodes: [],
+    center: ALASKA_CENTER,
+    zoom: ALASKA_ZOOM,
+    scenario: { thresholds: BASELINE_THRESHOLDS, preset: null },
+};
+
+describe('useMapUrlSync', () => {
+    it('restores the complete URL state on browser navigation', () => {
+        window.history.replaceState(null, '', '/');
+        const restoreState = vi.fn();
+        renderHook(() => useMapUrlSync(currentState, restoreState));
+
+        act(() => {
+            window.history.pushState(null, '', '/?region=AK-2&season=winter&layer=gap&zoom=6');
+            window.dispatchEvent(new PopStateEvent('popstate'));
+        });
+
+        expect(restoreState).toHaveBeenCalledWith(expect.objectContaining({
+            selectedRegionCode: 'AK-2',
+            season: 'winter',
+            mapMode: { type: 'gapHunter' },
+            zoom: 6,
+        }));
+    });
+});

--- a/frontend/src/hooks/useMapUrlSync.ts
+++ b/frontend/src/hooks/useMapUrlSync.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import {
+    parseMapUrlState,
+    serializeMapUrlState,
+    type ParsedMapUrlState,
+    type SerializableMapUrlState,
+} from '../domain/mapUrlState';
+
+export function useMapUrlSync(
+    state: SerializableMapUrlState,
+    restoreState: (state: ParsedMapUrlState) => void,
+): void {
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const search = serializeMapUrlState(window.location.search, state);
+        const nextUrl = `${window.location.pathname}${search ? `?${search}` : ''}`;
+        window.history.replaceState(null, '', nextUrl);
+    }, [state]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const handlePopState = () => restoreState(parseMapUrlState(window.location.search));
+        window.addEventListener('popstate', handlePopState);
+        return () => window.removeEventListener('popstate', handlePopState);
+    }, [restoreState]);
+}

--- a/frontend/src/hooks/useRegionSearch.ts
+++ b/frontend/src/hooks/useRegionSearch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RegionSearchParams, RegionSummary, searchRegions } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
 
 const SEARCH_DEBOUNCE_MS = 250;
 
@@ -12,7 +13,7 @@ export function useRegionSearch(params: RegionSearchParams) {
     const stableParams = useMemo(() => JSON.stringify(params), [params]);
 
     useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
         const parsedParams = JSON.parse(stableParams) as RegionSearchParams;
         const hasActiveParams = Object.values(parsedParams).some(
             value => value !== undefined && value !== null && value !== '',
@@ -26,7 +27,7 @@ export function useRegionSearch(params: RegionSearchParams) {
                 hasSearched.current = false;
             }
             return () => {
-                cancelled = true;
+                controller.abort();
             };
         }
         hasSearched.current = true;
@@ -34,24 +35,24 @@ export function useRegionSearch(params: RegionSearchParams) {
         const timeoutId = window.setTimeout(async () => {
             try {
                 setLoading(true);
-                const data = await searchRegions(parsedParams);
-                if (!cancelled) {
+                const data = await searchRegions(parsedParams, controller.signal);
+                if (!controller.signal.aborted) {
                     setResults(data);
                     setError(null);
                 }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : 'Failed to search regions');
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to search regions'));
                 }
             } finally {
-                if (!cancelled) {
+                if (!controller.signal.aborted) {
                     setLoading(false);
                 }
             }
         }, SEARCH_DEBOUNCE_MS);
 
         return () => {
-            cancelled = true;
+            controller.abort();
             window.clearTimeout(timeoutId);
         };
     }, [stableParams]);

--- a/frontend/src/hooks/useRegionSummary.ts
+++ b/frontend/src/hooks/useRegionSummary.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchRegionSummary, RegionSummary } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
 
 export function useRegionSummary() {
     const [regions, setRegions] = useState<RegionSummary[]>([]);
@@ -7,22 +8,22 @@ export function useRegionSummary() {
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
 
         async function loadSummary() {
             try {
                 setLoading(true);
-                const data = await fetchRegionSummary();
-                if (!cancelled) {
+                const data = await fetchRegionSummary(controller.signal);
+                if (!controller.signal.aborted) {
                     setRegions(data);
                     setError(null);
                 }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : 'Failed to load region summary');
+            } catch (caught: unknown) {
+                if (!isAbortError(caught)) {
+                    setError(errorMessage(caught, 'Failed to load region summary'));
                 }
             } finally {
-                if (!cancelled) {
+                if (!controller.signal.aborted) {
                     setLoading(false);
                 }
             }
@@ -31,7 +32,7 @@ export function useRegionSummary() {
         loadSummary();
 
         return () => {
-            cancelled = true;
+            controller.abort();
         };
     }, []);
 

--- a/frontend/src/hooks/useResearchProfile.ts
+++ b/frontend/src/hooks/useResearchProfile.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Season } from '../api/catApi';
 import { fetchResearchProfile } from '../api/researchApi';
 import { ResearchProfile } from '../types/research';
+import { errorMessage, isAbortError } from '../api/http';
 
 export function useResearchProfile(regionCode: string | null, season: Season) {
     const [profile, setProfile] = useState<ResearchProfile | null>(null);
@@ -16,27 +17,27 @@ export function useResearchProfile(regionCode: string | null, season: Season) {
             return;
         }
 
-        let active = true;
+        const controller = new AbortController();
         setLoading(true);
         setProfile(null);
         setError(null);
 
-        fetchResearchProfile(regionCode, season)
+        fetchResearchProfile(regionCode, season, controller.signal)
             .then(data => {
-                if (active) setProfile(data);
+                if (!controller.signal.aborted) setProfile(data);
             })
-            .catch(err => {
-                if (active) {
+            .catch((caught: unknown) => {
+                if (!isAbortError(caught)) {
                     setProfile(null);
-                    setError(err instanceof Error ? err.message : 'Failed to load research profile');
+                    setError(errorMessage(caught, 'Failed to load research profile'));
                 }
             })
             .finally(() => {
-                if (active) setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             });
 
         return () => {
-            active = false;
+            controller.abort();
         };
     }, [regionCode, season]);
 

--- a/frontend/src/hooks/useScenarioPreview.test.tsx
+++ b/frontend/src/hooks/useScenarioPreview.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchScenarioPreview } from '../api/scenarioApi';
+import { BASELINE_THRESHOLDS, type ScenarioPreviewResponse } from '../types/scenario';
+import { useScenarioPreview } from './useScenarioPreview';
+
+vi.mock('../api/scenarioApi', () => ({
+    fetchScenarioPreview: vi.fn(),
+}));
+
+const preview: ScenarioPreviewResponse = {
+    scenario: {
+        season: 'year_round',
+        thresholds: BASELINE_THRESHOLDS,
+        is_baseline_equivalent: true,
+    },
+    summary: {
+        total_regions: 1,
+        status_changed_regions: 0,
+        score_changed_regions: 0,
+        improved_count: 0,
+        worsened_count: 0,
+        unchanged_count: 1,
+        telehealth_ready: 1,
+        community_anchor: 0,
+        limited_telehealth: 0,
+        critical_gap: 0,
+        data_unavailable: 0,
+    },
+    regions: [],
+};
+
+describe('useScenarioPreview', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it('clears stale output immediately when assumptions change or the refresh fails', async () => {
+        vi.useFakeTimers();
+        vi.mocked(fetchScenarioPreview)
+            .mockResolvedValueOnce(preview)
+            .mockRejectedValueOnce(new Error('Preview unavailable'));
+        const setMode = vi.fn();
+
+        const { result, rerender } = renderHook(
+            ({ thresholds }) => useScenarioPreview(
+                'active',
+                thresholds,
+                'year_round',
+                null,
+                setMode,
+            ),
+            { initialProps: { thresholds: BASELINE_THRESHOLDS } },
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(500);
+            await Promise.resolve();
+        });
+        expect(result.current.data).toEqual(preview);
+
+        rerender({ thresholds: { ...BASELINE_THRESHOLDS, min_download_mbps: 75 } });
+        expect(result.current.data).toBeNull();
+        expect(result.current.loading).toBe(true);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(500);
+            await Promise.resolve();
+        });
+        expect(result.current.data).toBeNull();
+        expect(result.current.error).toBe('Preview unavailable');
+    });
+});

--- a/frontend/src/hooks/useScenarioPreview.ts
+++ b/frontend/src/hooks/useScenarioPreview.ts
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchScenarioPreview } from '../api/scenarioApi';
 import type { Season } from '../api/catApi';
+import { errorMessage, isAbortError } from '../api/http';
 import type {
     ScenarioMode,
     ScenarioPreviewResponse,
@@ -33,6 +34,7 @@ export function useScenarioPreview(
     regionCodes: string[] | null = null,
     setMode?: (mode: ScenarioMode) => void,
 ): ScenarioPreviewState {
+    const enabled = mode !== 'off';
     const [data, setData] = useState<ScenarioPreviewResponse | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -96,10 +98,11 @@ export function useScenarioPreview(
             setError(null);
             setMode?.('active');
             abortRef.current = null;
-        } catch (err: any) {
-            if (err?.name === 'AbortError') return;
+        } catch (err: unknown) {
+            if (isAbortError(err)) return;
             if (!controller.signal.aborted && abortRef.current === controller) {
-                setError(err?.message || 'Scenario preview failed');
+                setData(null);
+                setError(errorMessage(err, 'Scenario preview failed'));
                 setLoading(false);
                 setMode?.('active');
                 abortRef.current = null;
@@ -109,7 +112,7 @@ export function useScenarioPreview(
 
     // Debounced fetch
     useEffect(() => {
-        if (mode === 'off') {
+        if (!enabled) {
             setData(null);
             setError(null);
             setLoading(false);
@@ -126,6 +129,13 @@ export function useScenarioPreview(
             window.clearTimeout(timerRef.current);
         }
 
+        abortRef.current?.abort();
+        abortRef.current = null;
+        setData(null);
+        setError(null);
+        setLoading(true);
+        setMode?.('calculating');
+
         timerRef.current = window.setTimeout(() => {
             fetchPreview(thresholds, season, regionCodes);
         }, DEBOUNCE_MS);
@@ -136,7 +146,7 @@ export function useScenarioPreview(
                 timerRef.current = null;
             }
         };
-    }, [mode, thresholds, season, regionCodes, fetchPreview]);
+    }, [enabled, thresholds, season, regionCodes, fetchPreview, setMode]);
 
     // Cleanup on unmount
     useEffect(() => {

--- a/frontend/src/hooks/useScenarioState.test.tsx
+++ b/frontend/src/hooks/useScenarioState.test.tsx
@@ -1,17 +1,21 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BASELINE_THRESHOLDS } from '../types/scenario';
 import { useScenarioState } from './useScenarioState';
 
-describe('useScenarioState URL sync', () => {
-    it('restores scenario params and removes them when scenario mode is deactivated', async () => {
-        window.history.replaceState(
-            null,
-            '',
-            '/?scenario=1&bd=100&up=20&latency=90&aff=4&clinic=30&preset=equity',
-        );
-
-        const { result } = renderHook(() => useScenarioState('year_round'));
+describe('useScenarioState restoration', () => {
+    it('restores scenario state supplied by URL ownership and resets when deactivated', () => {
+        const { result } = renderHook(() => useScenarioState('year_round', {
+            active: true,
+            thresholds: {
+                min_download_mbps: 100,
+                min_upload_mbps: 20,
+                max_latency_ms: 90,
+                affordability_burden_pct: 4,
+                clinic_proximity_km: 30,
+            },
+            preset: 'equity',
+        }));
 
         expect(result.current.mode).toBe('active');
         expect(result.current.thresholds.min_download_mbps).toBe(100);
@@ -21,26 +25,11 @@ describe('useScenarioState URL sync', () => {
         expect(result.current.thresholds.clinic_proximity_km).toBe(30);
 
         act(() => {
-            result.current.setThreshold('min_download_mbps', 75);
-            result.current.setThreshold('max_latency_ms', 120);
-        });
-
-        await waitFor(() => {
-            const params = new URLSearchParams(window.location.search);
-            expect(params.get('bd')).toBe('75');
-            expect(params.get('latency')).toBe('120');
-        });
-
-        act(() => {
             result.current.deactivate();
         });
 
-        await waitFor(() => {
-            const params = new URLSearchParams(window.location.search);
-            expect(params.has('scenario')).toBe(false);
-            expect(params.has('bd')).toBe(false);
-            expect(params.has('latency')).toBe(false);
-        });
+        expect(result.current.mode).toBe('off');
         expect(result.current.thresholds).toEqual(BASELINE_THRESHOLDS);
+        expect(result.current.activePreset).toBeNull();
     });
 });

--- a/frontend/src/hooks/useScenarioState.test.tsx
+++ b/frontend/src/hooks/useScenarioState.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { BASELINE_THRESHOLDS } from '../types/scenario';
 import { useScenarioState } from './useScenarioState';
 
-describe('useScenarioState restoration', () => {
-    it('restores scenario state supplied by URL ownership and resets when deactivated', () => {
+describe('useScenarioState', () => {
+    it('owns thresholds while accepting initial and restored URL state', () => {
         const { result } = renderHook(() => useScenarioState('year_round', {
             active: true,
             thresholds: {
@@ -25,7 +25,20 @@ describe('useScenarioState restoration', () => {
         expect(result.current.thresholds.clinic_proximity_km).toBe(30);
 
         act(() => {
-            result.current.deactivate();
+            result.current.setThreshold('min_download_mbps', 75);
+            result.current.setThreshold('max_latency_ms', 120);
+        });
+
+        expect(result.current.thresholds.min_download_mbps).toBe(75);
+        expect(result.current.thresholds.max_latency_ms).toBe(120);
+        expect(result.current.activePreset).toBeNull();
+
+        act(() => {
+            result.current.restoreFromUrl({
+                active: false,
+                thresholds: {},
+                preset: null,
+            });
         });
 
         expect(result.current.mode).toBe('off');

--- a/frontend/src/hooks/useScenarioState.ts
+++ b/frontend/src/hooks/useScenarioState.ts
@@ -1,17 +1,14 @@
 /**
- * useScenarioState – manages scenario thresholds, presets, and URL state
+ * useScenarioState – manages scenario thresholds and presets.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { Season } from '../api/catApi';
 import {
     BASELINE_THRESHOLDS,
     SCENARIO_PRESETS,
     type ScenarioMode,
-    type ScenarioPreset,
     type ScenarioThresholds,
 } from '../types/scenario';
-
-const URL_SYNC_DEBOUNCE_MS = 300;
 
 function thresholdsEqual(a: ScenarioThresholds, b: ScenarioThresholds): boolean {
     return (
@@ -23,45 +20,10 @@ function thresholdsEqual(a: ScenarioThresholds, b: ScenarioThresholds): boolean 
     );
 }
 
-function parseScenarioUrlParams(): {
+export interface ScenarioUrlState {
     active: boolean;
     thresholds: Partial<ScenarioThresholds>;
     preset: string | null;
-} {
-    if (typeof window === 'undefined') {
-        return { active: false, thresholds: {}, preset: null };
-    }
-
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('scenario') !== '1') {
-        return { active: false, thresholds: {}, preset: null };
-    }
-
-    const partial: Partial<ScenarioThresholds> = {};
-    const bd = params.get('bd');
-    if (bd !== null && !isNaN(Number(bd))) partial.min_download_mbps = Number(bd);
-    const up = params.get('up');
-    if (up !== null && !isNaN(Number(up))) partial.min_upload_mbps = Number(up);
-    const latency = params.get('latency');
-    if (latency !== null) {
-        if (latency === 'baseline') {
-            partial.max_latency_ms = null;
-        } else if (!isNaN(Number(latency))) {
-            partial.max_latency_ms = Number(latency);
-        }
-    }
-    const aff = params.get('aff');
-    if (aff !== null && !isNaN(Number(aff))) partial.affordability_burden_pct = Number(aff);
-    const clinic = params.get('clinic');
-    if (clinic !== null && clinic !== 'baseline') {
-        if (!isNaN(Number(clinic))) partial.clinic_proximity_km = Number(clinic);
-    }
-
-    return {
-        active: true,
-        thresholds: partial,
-        preset: params.get('preset'),
-    };
 }
 
 export interface ScenarioState {
@@ -82,74 +44,31 @@ export interface ScenarioState {
     resetToBaseline: () => void;
     /** Set mode directly (e.g. for 'calculating') */
     setMode: (mode: ScenarioMode) => void;
+    /** Restore scenario state from browser navigation. */
+    restoreFromUrl: (state: ScenarioUrlState) => void;
 }
 
-export function useScenarioState(season: Season): ScenarioState {
-    const initialUrl = useMemo(() => parseScenarioUrlParams(), []);
+const EMPTY_SCENARIO_URL_STATE: ScenarioUrlState = {
+    active: false,
+    thresholds: {},
+    preset: null,
+};
 
+export function useScenarioState(
+    _season: Season,
+    initialUrl: ScenarioUrlState = EMPTY_SCENARIO_URL_STATE,
+): ScenarioState {
     const [mode, setMode] = useState<ScenarioMode>(initialUrl.active ? 'active' : 'off');
     const [thresholds, setThresholds] = useState<ScenarioThresholds>(() => ({
         ...BASELINE_THRESHOLDS,
         ...initialUrl.thresholds,
     }));
     const [activePreset, setActivePreset] = useState<string | null>(initialUrl.preset);
-    const urlSyncTimerRef = useRef<number | null>(null);
 
     const isBaselineEquivalent = useMemo(
         () => thresholdsEqual(thresholds, BASELINE_THRESHOLDS),
         [thresholds],
     );
-
-    // ── URL state sync ─────────────────────────────────────────────────
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-
-        if (urlSyncTimerRef.current) {
-            window.clearTimeout(urlSyncTimerRef.current);
-        }
-
-        urlSyncTimerRef.current = window.setTimeout(() => {
-            const params = new URLSearchParams(window.location.search);
-
-            // Remove all scenario params first
-            params.delete('scenario');
-            params.delete('bd');
-            params.delete('up');
-            params.delete('latency');
-            params.delete('aff');
-            params.delete('clinic');
-            params.delete('preset');
-
-            if (mode !== 'off') {
-                params.set('scenario', '1');
-                params.set('bd', String(thresholds.min_download_mbps));
-                params.set('up', String(thresholds.min_upload_mbps));
-                if (thresholds.max_latency_ms !== null) {
-                    params.set('latency', String(thresholds.max_latency_ms));
-                } else {
-                    params.set('latency', 'baseline');
-                }
-                params.set('aff', String(thresholds.affordability_burden_pct));
-                if (thresholds.clinic_proximity_km !== null) {
-                    params.set('clinic', String(thresholds.clinic_proximity_km));
-                } else {
-                    params.set('clinic', 'baseline');
-                }
-                if (activePreset) params.set('preset', activePreset);
-            }
-
-            const nextUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-            window.history.replaceState(null, '', nextUrl);
-            urlSyncTimerRef.current = null;
-        }, URL_SYNC_DEBOUNCE_MS);
-
-        return () => {
-            if (urlSyncTimerRef.current) {
-                window.clearTimeout(urlSyncTimerRef.current);
-                urlSyncTimerRef.current = null;
-            }
-        };
-    }, [mode, thresholds, activePreset]);
 
     // ── Actions ────────────────────────────────────────────────────────
     const activate = useCallback(() => setMode('active'), []);
@@ -186,6 +105,12 @@ export function useScenarioState(season: Season): ScenarioState {
         setActivePreset('baseline');
     }, []);
 
+    const restoreFromUrl = useCallback((state: ScenarioUrlState) => {
+        setMode(state.active ? 'active' : 'off');
+        setThresholds({ ...BASELINE_THRESHOLDS, ...state.thresholds });
+        setActivePreset(state.preset);
+    }, []);
+
     return {
         mode,
         thresholds,
@@ -197,5 +122,6 @@ export function useScenarioState(season: Season): ScenarioState {
         applyPreset,
         resetToBaseline,
         setMode,
+        restoreFromUrl,
     };
 }

--- a/frontend/src/hooks/useScenarioState.ts
+++ b/frontend/src/hooks/useScenarioState.ts
@@ -95,7 +95,7 @@ export function useScenarioState(
         }
         const preset = SCENARIO_PRESETS.find(p => p.id === presetId);
         if (preset) {
-            setThresholds(prev => ({ ...BASELINE_THRESHOLDS, ...preset.thresholds }));
+            setThresholds({ ...BASELINE_THRESHOLDS, ...preset.thresholds });
             setActivePreset(presetId);
         }
     }, []);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,206 @@
+/* TENeT shared design tokens
+ *
+ * The semantic tokens are the preferred API for new UI. The aliases near the
+ * end of :root keep existing screens working while they are migrated.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Neutral surfaces */
+  --color-canvas: #f4f7fa;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f8fafc;
+  --color-surface-muted: #eef2f6;
+  --color-surface-overlay: rgba(255, 255, 255, 0.94);
+
+  /* Text */
+  --color-text: #172033;
+  --color-text-secondary: #536176;
+  --color-text-muted: #64748b;
+  --color-text-inverse: #ffffff;
+  --color-text-link: #1d4ed8;
+
+  /* Borders */
+  --color-border: #d8e0e8;
+  --color-border-strong: #b8c4d0;
+  --color-border-subtle: #e8edf2;
+
+  /* Brand and interaction */
+  --color-primary: #1d4ed8;
+  --color-primary-hover: #1e40af;
+  --color-primary-active: #1e3a8a;
+  --color-primary-subtle: #eff6ff;
+  --color-danger: #b42318;
+  --color-danger-hover: #912018;
+  --color-danger-subtle: #fef3f2;
+
+  /* Operational status colors */
+  --color-status-ready: #15803d;
+  --color-status-ready-subtle: #f0fdf4;
+  --color-status-anchor: #b45309;
+  --color-status-anchor-subtle: #fffbeb;
+  --color-status-gap: #b42318;
+  --color-status-gap-subtle: #fef3f2;
+  --color-status-limited: #6d28d9;
+  --color-status-limited-subtle: #f5f3ff;
+  --color-status-info: #0369a1;
+  --color-status-info-subtle: #f0f9ff;
+  --color-status-unknown: #64748b;
+  --color-status-unknown-subtle: #f1f5f9;
+
+  /* Typography */
+  --font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-xs: 0.75rem;
+  --font-sm: 0.875rem;
+  --font-base: 1rem;
+  --font-lg: 1.125rem;
+  --font-xl: 1.25rem;
+  --font-2xl: 1.5rem;
+
+  /* Spacing (4px base) */
+  --spacing-0: 0;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
+
+  /* Shape */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Elevation */
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.05);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 6px 18px rgba(15, 23, 42, 0.1);
+  --shadow-lg: 0 16px 36px rgba(15, 23, 42, 0.14);
+
+  /* Controls and motion */
+  --control-height-sm: 2rem;
+  --control-height: 2.5rem;
+  --control-height-lg: 2.75rem;
+  --control-icon-size-sm: 2rem;
+  --control-icon-size: 2.5rem;
+  --focus-ring-color: rgba(37, 99, 235, 0.28);
+  --focus-ring: 0 0 0 3px var(--focus-ring-color);
+  --transition-fast: 150ms ease;
+
+  /* Layer order — matches actual overlay stacking across the app */
+  --z-map-controls: 1000;
+  --z-overlay: 1100;
+  --z-toast: 1150;
+  --z-sidebar: 1200;
+  --z-popover: 1500;
+  --z-tooltip: 2500;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  overflow: hidden;
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+p {
+  color: var(--color-text-secondary);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  background: none;
+}
+
+button:not(:disabled) {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+:where(button, input, select, textarea, a):focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: #dbeafe;
+  color: var(--color-text);
+}
+
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-full);
+  background: #c1cad4;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #98a6b6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
-
+import './index.css'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -1,7 +1,8 @@
 /**
  * Scenario Analysis types
  */
-import { Season, TelehealthStatusName } from '../api/catApi';
+import { Season } from '../api/catApi';
+import type { ScenarioTelehealthStatusName } from '../domain/statusPresentation';
 
 /** Scenario lifecycle states */
 export type ScenarioMode = 'off' | 'calculating' | 'active';
@@ -24,8 +25,8 @@ export interface ScenarioRegion {
     name: string;
     lat: number | null;
     lon: number | null;
-    baseline_status: string;
-    scenario_status: string;
+    baseline_status: ScenarioTelehealthStatusName;
+    scenario_status: ScenarioTelehealthStatusName;
     status_delta: StatusDelta;
     baseline_need_score: number;
     scenario_need_score: number;
@@ -75,7 +76,7 @@ export interface ScenarioPreset {
 export const SCENARIO_PRESETS: ScenarioPreset[] = [
     {
         id: 'fcc',
-        label: 'FCC Standard',
+        label: 'Baseline (25/3 Mbps)',
         thresholds: {
             min_download_mbps: 25,
             min_upload_mbps: 3,
@@ -108,22 +109,21 @@ export const BASELINE_THRESHOLDS: ScenarioThresholds = {
     affordability_burden_pct: 2,
 };
 
-/** Status color helper */
-export function getScenarioStatusColor(status: string): string {
-    switch (status) {
-        case 'TELEHEALTH_READY': return '#22c55e';
-        case 'LIMITED_TELEHEALTH': return '#eab308';
-        case 'COMMUNITY_ANCHOR': return '#f97316';
-        case 'CRITICAL_GAP': return '#ef4444';
-        case 'DATA_UNAVAILABLE': return '#6b7280';
-        default: return '#6b7280';
-    }
-}
-
 export function getScenarioDeltaColor(delta: StatusDelta): string {
     switch (delta) {
         case 'improved': return '#22c55e';
         case 'worsened': return '#ef4444';
         case 'unchanged': return '#94a3b8';
+    }
+}
+
+export function getScenarioStatusColor(status: ScenarioTelehealthStatusName | string): string {
+    switch (status) {
+        case 'TELEHEALTH_READY': return '#22c55e';
+        case 'COMMUNITY_ANCHOR': return '#f97316';
+        case 'LIMITED_TELEHEALTH': return '#eab308';
+        case 'CRITICAL_GAP': return '#ef4444';
+        case 'DATA_UNAVAILABLE': return '#6b7280';
+        default: return '#94a3b8';
     }
 }

--- a/frontend/src/utils/escapeHtml.test.ts
+++ b/frontend/src/utils/escapeHtml.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from './escapeHtml';
+
+describe('escapeHtml', () => {
+    it('escapes backend text before it is inserted into Leaflet HTML', () => {
+        expect(escapeHtml('<img src=x onerror="alert(1)"> & test')).toBe(
+            '&lt;img src=x onerror=&quot;alert(1)&quot;&gt; &amp; test',
+        );
+    });
+});

--- a/frontend/src/utils/escapeHtml.ts
+++ b/frontend/src/utils/escapeHtml.ts
@@ -1,0 +1,11 @@
+const HTML_ENTITIES: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;',
+};
+
+export function escapeHtml(value: string | number): string {
+    return String(value).replace(/[&<>"']/g, character => HTML_ENTITIES[character]);
+}

--- a/frontend/src/utils/markerUtils.ts
+++ b/frontend/src/utils/markerUtils.ts
@@ -1,6 +1,41 @@
 import L from 'leaflet';
+import type { ScenarioTelehealthStatusName } from '../domain/statusPresentation';
+import { escapeHtml } from './escapeHtml';
 
 const markerIconCache = new Map<string, L.DivIcon>();
+
+export interface MarkerMetadata {
+    needScore?: number;
+    scenarioStatus?: ScenarioTelehealthStatusName;
+}
+
+export interface MarkerClusterLike {
+    getChildCount: () => number;
+    getAllChildMarkers: () => L.Marker[];
+}
+
+type MarkerWithMetadata = L.Marker & {
+    options: L.MarkerOptions & MarkerMetadata;
+};
+
+export function setMarkerMetadata(marker: L.Marker, metadata: MarkerMetadata): void {
+    Object.assign((marker as MarkerWithMetadata).options, metadata);
+}
+
+export function getMarkerMetadata(marker: L.Marker): Readonly<MarkerMetadata> {
+    return (marker as MarkerWithMetadata).options;
+}
+
+export function getClusterMarkerSize(pointCount: number): number {
+    if (pointCount >= 200) return 36;
+    if (pointCount >= 50) return 32.4;
+    if (pointCount >= 10) return 28.8;
+    return 24;
+}
+
+function safeMarkerColor(color: string): string {
+    return /^#[0-9a-f]{3,8}$/i.test(color) ? color : '#94a3b8';
+}
 
 /**
  * Shared Leaflet marker icon factory.
@@ -10,7 +45,8 @@ const markerIconCache = new Map<string, L.DivIcon>();
  * Clusters will just be slightly larger dots with the number centered inside.
  */
 export function createMarkerIcon(color: string, selected = false, size = 24, text?: string): L.DivIcon {
-    const cacheKey = `${color}:${selected}:${size}:${text || ''}`;
+    const markerColor = safeMarkerColor(color);
+    const cacheKey = `${markerColor}:${selected}:${size}:${text || ''}`;
     const cached = markerIconCache.get(cacheKey);
     if (cached) return cached;
 
@@ -20,37 +56,11 @@ export function createMarkerIcon(color: string, selected = false, size = 24, tex
     const innerSize = selected ? actualSize * 0.4 : actualSize * 0.35;
 
     const html = `
-    <div style="width: ${diagonal}px; height: ${diagonal}px; display: flex; align-items: center; justify-content: center; position: relative;">
-      <div style="
-        width: ${actualSize}px;
-        height: ${actualSize}px;
-        background: white;
-        border: ${selected ? '2px solid #475569' : '1.5px solid #cbd5e1'};
-        border-radius: 50% 50% 0 50%;
-        transform: rotate(45deg);
-        box-shadow: ${selected ? '2px 2px 4px rgba(0,0,0,0.3)' : '1px 1px 2px rgba(0,0,0,0.15)'};
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        box-sizing: border-box;
-      " class="healthsites-cluster-wrapper">
-        <div style="
-          transform: rotate(-45deg);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          width: 100%;
-          height: 100%;
-          position: relative;
-        ">
-          <div style="
-            width: ${innerSize}px;
-            height: ${innerSize}px;
-            border-radius: 50%;
-            background-color: ${color};
-            ${selected ? 'box-shadow: 0 0 0 2px white;' : ''}
-          "></div>
-          ${text ? `<div style="position: absolute; font-size: ${Math.round(actualSize * 0.45)}px; font-weight: 800; color: #1e293b; top: -14px;">${text}</div>` : ''}
+    <div class="tenet-marker-shell" style="--marker-shell-size:${diagonal}px;--marker-size:${actualSize}px;--marker-dot-size:${innerSize}px;--marker-color:${markerColor};--marker-count-size:${Math.round(actualSize * 0.45)}px">
+      <div class="tenet-marker-pin${selected ? ' is-selected' : ''}">
+        <div class="tenet-marker-content">
+          <div class="tenet-marker-dot"></div>
+          ${text ? `<div class="tenet-marker-count">${escapeHtml(text)}</div>` : ''}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

Final scoped QA polish for the frontend cleanup chain.

## Scope

- Tighten sidebar responsive CSS and selected-region panel behavior.
- Clean up metric tooltip and research comparison presentation details.
- Preserve existing frontend behavior and backend API contracts.
- Leave unrelated backend data/script changes untouched.

## Validation

Validated on this final stacked branch:

- `npm run typecheck` passed
- `npm run test` passed: 14 files, 45 tests
- `npm run build` passed with the existing Vite large chunk warning

## Notes

This is intentionally small and should be reviewed after PRs #88 through #92.
