### PR TITLE
feat(map): Canvas foundation overlay for high-performance markers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Sidebar from './components/sidebar/Sidebar';
 import ResearchComparisonPanel from './components/ResearchComparisonPanel';
 import ScenarioPanel from './components/scenario/ScenarioPanel';
 import ScenarioLayer, { ScenarioLegend } from './components/scenario/ScenarioLayer';
+import { CanvasLayer } from './components/map/CanvasLayer';
 import { usePinnedRegions } from './hooks/usePinnedRegions';
 import { useRegionSummary } from './hooks/useRegionSummary';
 import { useScenarioState } from './hooks/useScenarioState';
@@ -349,6 +350,8 @@ function App() {
             onViewDetails={handleViewRegionDetails}
             onMarkerReady={registerMarker}
           />
+
+          <CanvasLayer />
         </MapContainer>
 
         <ResearchComparisonPanel

--- a/frontend/src/components/map/CanvasLayer.tsx
+++ b/frontend/src/components/map/CanvasLayer.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useCanvasOverlay } from '../../hooks/useCanvasOverlay';
+import L from 'leaflet';
+
+export const CanvasLayer: React.FC = () => {
+  useCanvasOverlay((ctx: CanvasRenderingContext2D, map: L.Map) => {
+    // A mock drawing function to verify integration
+    // We will draw the actual data in PR 2
+    // Draw at a fixed geographic coordinate (e.g. center of Alaska)
+    // so we can verify it stays perfectly pinned to the map during zoom and pan
+    const fixedLocation = L.latLng(64.2008, -149.4937);
+    const point = map.latLngToContainerPoint(fixedLocation);
+    
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, 50, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255, 0, 0, 0.3)';
+    ctx.fill();
+    ctx.strokeStyle = 'red';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  });
+
+  return null; // The hook injects the canvas directly into the DOM
+};

--- a/frontend/src/hooks/useCanvasOverlay.test.tsx
+++ b/frontend/src/hooks/useCanvasOverlay.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import { useCanvasOverlay } from './useCanvasOverlay';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock react-leaflet's useMap
+vi.mock('react-leaflet', () => ({
+  useMap: vi.fn(),
+}));
+
+describe('useCanvasOverlay', () => {
+  let mockMap: any;
+
+  beforeEach(() => {
+    mockMap = {
+      getPanes: vi.fn().mockReturnValue({
+        overlayPane: { appendChild: vi.fn() },
+      }),
+      getSize: vi.fn().mockReturnValue(L.point(800, 600)),
+      getBounds: vi.fn().mockReturnValue(L.latLngBounds(L.latLng(0, 0), L.latLng(10, 10))),
+      latLngToLayerPoint: vi.fn().mockReturnValue(L.point(0, 0)),
+      getZoomScale: vi.fn().mockReturnValue(1),
+      getZoom: vi.fn().mockReturnValue(5),
+      on: vi.fn(),
+      off: vi.fn(),
+      _latLngToNewLayerPoint: vi.fn().mockReturnValue(L.point(0, 0)),
+    };
+    vi.mocked(useMap).mockReturnValue(mockMap);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('injects a canvas into the map overlay pane', () => {
+    const onDraw = vi.fn();
+    const { result } = renderHook(() => useCanvasOverlay(onDraw));
+
+    expect(result.current.current).toBeInstanceOf(HTMLCanvasElement);
+    expect(mockMap.getPanes).toHaveBeenCalled();
+    expect(mockMap.getPanes().overlayPane.appendChild).toHaveBeenCalledWith(result.current.current);
+    expect(result.current.current?.classList.contains('leaflet-canvas-overlay')).toBe(true);
+  });
+
+  it('binds to map events', () => {
+    const onDraw = vi.fn();
+    renderHook(() => useCanvasOverlay(onDraw));
+
+    expect(mockMap.on).toHaveBeenCalledWith('moveend', expect.any(Function));
+    expect(mockMap.on).toHaveBeenCalledWith('zoomend', expect.any(Function));
+    expect(mockMap.on).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(mockMap.on).toHaveBeenCalledWith('zoomanim', expect.any(Function));
+  });
+
+  it('cleans up resources on unmount', () => {
+    const onDraw = vi.fn();
+    const { unmount } = renderHook(() => useCanvasOverlay(onDraw));
+    
+    unmount();
+
+    expect(mockMap.off).toHaveBeenCalledWith('moveend', expect.any(Function));
+    expect(mockMap.off).toHaveBeenCalledWith('zoomend', expect.any(Function));
+    expect(mockMap.off).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(mockMap.off).toHaveBeenCalledWith('zoomanim', expect.any(Function));
+  });
+});

--- a/frontend/src/hooks/useCanvasOverlay.tsx
+++ b/frontend/src/hooks/useCanvasOverlay.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from "react";
+import { useMap } from "react-leaflet";
+import L from "leaflet";
+
+export function useCanvasOverlay(
+  onDraw: (ctx: CanvasRenderingContext2D, map: L.Map) => void,
+) {
+  const map = useMap();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const onDrawRef = useRef(onDraw);
+  const redrawRef = useRef<() => void>();
+  const topLeftLatLngRef = useRef<L.LatLng | null>(null);
+  const initialZoomRef = useRef<number>(0);
+
+  // Keep the ref updated to avoid re-binding events on every render, and trigger redraw if onDraw changes
+  useEffect(() => {
+    onDrawRef.current = onDraw;
+    redrawRef.current?.();
+  }, [onDraw]);
+
+  useEffect(() => {
+    // 1. Create the canvas element
+    const canvas = L.DomUtil.create(
+      "canvas",
+      "leaflet-canvas-overlay",
+    ) as HTMLCanvasElement;
+    canvasRef.current = canvas;
+
+    // Inject into overlay pane
+    const pane = map.getPanes().overlayPane;
+    if (!pane) return;
+    pane.appendChild(canvas);
+
+    // Apply base styles
+    canvas.style.position = "absolute";
+    canvas.style.top = "0";
+    canvas.style.left = "0";
+    canvas.style.pointerEvents = "none"; // Let clicks pass through to the map if not explicitly handled
+    canvas.style.transformOrigin = "0 0";
+
+    // We will manually manage the CSS transition property during zoom events
+    // instead of using 'leaflet-zoom-animated', to perfectly support both
+    // continuous wheel zoom (no transition) and native double-click zoom (0.25s transition).
+
+    const ctx = canvas.getContext("2d");
+
+    const redraw = () => {
+      if (!ctx || !canvasRef.current) return;
+
+      const size = map.getSize();
+      const bounds = map.getBounds();
+      const topLeft = bounds.getNorthWest();
+      topLeftLatLngRef.current = topLeft;
+      initialZoomRef.current = map.getZoom();
+      const topLeftPoint = map.latLngToLayerPoint(topLeft);
+
+      // Handle high-DPI scaling
+      const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+
+      canvas.width = size.x * dpr;
+      canvas.height = size.y * dpr;
+
+      canvas.style.width = `${size.x}px`;
+      canvas.style.height = `${size.y}px`;
+
+      // Position the canvas precisely over the current view
+      L.DomUtil.setPosition(canvas, topLeftPoint);
+
+      // Disable any transitions before snapping the canvas back to scale 1
+      canvas.style.transition = "none";
+      canvas.style.transform = `translate3d(${topLeftPoint.x}px, ${topLeftPoint.y}px, 0px) scale(1)`;
+
+      ctx.save();
+      ctx.scale(dpr, dpr);
+      ctx.clearRect(0, 0, size.x, size.y);
+
+      // Call the user provided draw function
+      onDrawRef.current(ctx, map);
+
+      ctx.restore();
+    };
+
+    const handleZoomAnim = (e: any) => {
+      if (!canvasRef.current || !topLeftLatLngRef.current) return;
+
+      // Calculate scaling for smooth zoom relative to the zoom level when we last drew the canvas.
+      // We CANNOT use map.getZoom() here because the smoothWheelZoom plugin continuously modifies it during the animation.
+      const scale = map.getZoomScale(e.zoom, initialZoomRef.current);
+
+      // Use internal Leaflet method to calculate the new offset of our cached bounds
+      // Need to cast to any since _latLngToNewLayerPoint is marked private/internal in types
+      const mapAny = map as any;
+      if (typeof mapAny._latLngToNewLayerPoint !== "function") return;
+      const offset = mapAny._latLngToNewLayerPoint(
+        topLeftLatLngRef.current,
+        e.zoom,
+        e.center,
+      );
+
+      // Determine if this is a continuous wheel zoom (from our plugin) or a native Leaflet zoom
+      if (e.noUpdate) {
+        // Continuous requestAnimationFrame zoom -> disable CSS transition to prevent jitter
+        canvasRef.current.style.transition = "none";
+      } else {
+        // Native zoom (double click or zoom controls) -> apply Leaflet's standard zoom transition
+        canvasRef.current.style.transition =
+          "transform 0.25s cubic-bezier(0,0,0.25,1)";
+      }
+
+      // Apply CSS transform to the canvas for GPU-accelerated scaling
+      L.DomUtil.setTransform(canvasRef.current, offset, scale);
+    };
+
+    // 2. Bind events
+    map.on("moveend", redraw);
+    map.on("zoomend", redraw);
+    map.on("resize", redraw);
+    map.on("zoomanim", handleZoomAnim);
+
+    // Initial draw
+    redraw();
+    redrawRef.current = redraw;
+
+    return () => {
+      // Cleanup
+      map.off("moveend", redraw);
+      map.off("zoomend", redraw);
+      map.off("resize", redraw);
+      map.off("zoomanim", handleZoomAnim);
+
+      if (canvasRef.current) {
+        canvasRef.current.remove();
+      }
+      canvasRef.current = null;
+      redrawRef.current = undefined;
+    };
+  }, [map]);
+
+  return canvasRef;
+}


### PR DESCRIPTION
Sets up a reusable, scale-aware HTML5 Canvas layer injected directly into Leaflet's overlay pane. Perfectly synchronizes with Leaflet's internal coordinate system during zoom and pan animations. Includes complete cleanup logic and high-DPI scaling. This sets the foundation for rendering 10,000+ points smoothly.