### PR TITLE
fix: resolving some final blockers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ backend-test: ## Run backend pytest suite
 	$(COMPOSE) run --rm -e DB_PATH=/tmp/tenet-test.db backend python -m pytest
 
 frontend-test: ## Run frontend Vitest suite
-	$(COMPOSE) run --rm frontend npm run test
+	$(COMPOSE) run --rm frontend-tooling npm run test
 
 frontend-build: ## Run frontend production build
-	$(COMPOSE) run --rm frontend npm run build
+	$(COMPOSE) run --rm frontend-tooling npm run build
 
 frontend-typecheck: ## Run frontend TypeScript checks
-	$(COMPOSE) run --rm frontend npm run typecheck
+	$(COMPOSE) run --rm frontend-tooling npm run typecheck
 
 backend-lint: ## Run minimal backend lint checks
 	$(COMPOSE) run --rm backend python -m flake8 . --exclude venv,data,__pycache__

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,6 +29,10 @@ make e2e                # Playwright smoke suite against a running app
 
 `make smoke` expects the backend to be running at `http://127.0.0.1:5001` unless `API_URL` is overridden.
 
+Frontend test, typecheck, and build commands run in the dedicated Node-based
+`frontend-tooling` Compose service. The production `frontend` service continues
+to use the nginx-only `prod` image stage.
+
 ## Backend Testing
 
 Backend tests should verify:

--- a/backend/data/scripts/audit_telehealth_consistency.py
+++ b/backend/data/scripts/audit_telehealth_consistency.py
@@ -1,0 +1,92 @@
+"""Audit canonical telehealth status consistency on the configured database.
+
+Run against a freshly seeded temporary database, for example:
+
+    DB_PATH=/tmp/tenet-audit.db python data/scripts/audit_telehealth_consistency.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, BACKEND_ROOT)
+
+from database.config import SessionLocal  # noqa: E402
+from database.models import CATRegion  # noqa: E402
+from routes.cat_routes import _build_region_summary  # noqa: E402
+from services.research_profile_service import ResearchProfileService  # noqa: E402
+from services.scenario_engine import ScenarioEngine  # noqa: E402
+from services.scenario_input_cache import ScenarioInputCache  # noqa: E402
+from services.telehealth_classification import (  # noqa: E402
+    TelehealthClassificationService,
+)
+
+
+def audit_consistency(db):
+    ScenarioInputCache.clear()
+    regions = db.query(CATRegion).order_by(CATRegion.region_code).all()
+    codes = [region.region_code for region in regions]
+
+    summary_lookup = {
+        item["region_code"]: item["telehealth_status"]
+        for item in _build_region_summary(db, regions)
+    }
+    profiles, missing_codes = ResearchProfileService.get_profiles(db, codes)
+    profile_lookup = {
+        profile["region"]["region_code"]: profile["telehealth"]["status"]
+        for profile in profiles
+    }
+    map_lookup = {
+        code: context.classification.status
+        for code, context in TelehealthClassificationService.classify_regions(
+            db, regions
+        ).items()
+    }
+    scenario = ScenarioEngine.preview(db, thresholds={}, region_codes=codes)
+    baseline_lookup = {
+        item["region_code"]: item["baseline_status"]
+        for item in scenario["regions"]
+    }
+    scenario_lookup = {
+        item["region_code"]: item["scenario_status"]
+        for item in scenario["regions"]
+    }
+
+    mismatches = []
+    for code in codes:
+        statuses = {
+            "summary": summary_lookup.get(code),
+            "profile": profile_lookup.get(code),
+            "telehealth_map": map_lookup.get(code),
+            "scenario_baseline": baseline_lookup.get(code),
+            "scenario_default": scenario_lookup.get(code),
+        }
+        if len(set(statuses.values())) != 1:
+            mismatches.append({"region_code": code, "statuses": statuses})
+
+    return {
+        "total_communities": len(codes),
+        "missing_profiles": missing_codes,
+        "mismatch_count": len(mismatches),
+        "mismatches": mismatches,
+    }
+
+
+def main():
+    db = SessionLocal()
+    try:
+        result = audit_consistency(db)
+    finally:
+        db.close()
+        ScenarioInputCache.clear()
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    raise SystemExit(1 if result["mismatch_count"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -13,6 +13,7 @@ from services.data_importer import CATDataImporter
 from services.healthcare_desert_calculator import HealthcareDesertCalculator, haversine_km as _haversine_km
 from services.isp_config import ISP_CONFIG as _ISP_CONFIG, get_internet_cost as _get_regional_internet_cost
 from services.research_profile_service import ResearchProfileService
+from services.telehealth_classification import TelehealthClassificationService
 from services.season_constants import (
     SEASON_SUMMER, SEASON_WINTER, SEASON_YEAR_ROUND, VALID_SEASONS, 
     ROAD_QUALITY_LOCAL, VALID_ROAD_QUALITIES,
@@ -82,123 +83,15 @@ def _data_confidence(record):
     return (record.confidence or 'unknown').lower()
 
 
-def _nearest_income_record(region, census_records):
-    if region.centroid_lat is None or region.centroid_lon is None:
-        return None
-
-    region_lat = float(region.centroid_lat)
-    region_lon = float(region.centroid_lon)
-    max_distance_km = 55
-    lat_window = max_distance_km / 111.0
-    lon_window = max_distance_km / (111.0 * max(math.cos(math.radians(region_lat)), 0.1))
-
-    nearest = None
-    min_dist = float('inf')
-    for record in census_records:
-        if record.centroid_lat is None or record.centroid_lon is None:
-            continue
-
-        record_lat = float(record.centroid_lat)
-        record_lon = float(record.centroid_lon)
-        if abs(record_lat - region_lat) > lat_window or abs(record_lon - region_lon) > lon_window:
-            continue
-
-        distance = _haversine_km(
-            region_lat,
-            region_lon,
-            record_lat,
-            record_lon,
-        )
-        if distance < min_dist and distance < max_distance_km:
-            min_dist = distance
-            nearest = record
-
-    return nearest
-
-
 def _build_telehealth_context(db, regions):
-    """
-    Reuse the existing telehealth status ingredients in a compact lookup for
-    list endpoints. This mirrors the status formula used by /telehealth-status/all.
-    """
-    census_records = db.query(CensusIncome).filter(
-        CensusIncome.median_income.isnot(None),
-        CensusIncome.median_income > 0
-    ).all()
-    facilities = db.query(HealthcareSite).filter(
-        HealthcareSite.is_active == True,
-        HealthcareSite.latitude.isnot(None),
-        HealthcareSite.longitude.isnot(None)
-    ).all()
-    clinics = [
-        f for f in facilities
-        if f.site_type in ['clinic', 'hospital', 'health_center']
-    ]
-
-    context = {}
-    for region in regions:
-        status = 'DATA_UNAVAILABLE'
-        affordability_status = 'unknown'
-
-        if region.centroid_lat is not None and region.centroid_lon is not None:
-            best_zcta = _nearest_income_record(region, census_records)
-            has_income_data = best_zcta is not None
-            is_affordable = False
-            burden_pct = None
-            internet_cost = None
-
-            if best_zcta is not None:
-                internet_cost, _ = _get_regional_internet_cost(str(getattr(best_zcta, 'zcta', '')))
-                median_income = float(getattr(best_zcta, 'median_income', 0) or 0)
-                monthly_income = median_income / 12.0
-                burden_pct = float((internet_cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
-
-                t_conf = _ISP_CONFIG.get('thresholds', {})
-                t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
-                threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
-
-                is_affordable = bool(burden_pct < threshold) and bool(internet_cost < 400.0)
-                affordability_status = 'affordable' if is_affordable else 'unaffordable'
-            else:
-                internet_cost = 450
-                affordability_status = 'unknown'
-
-            access_modes = (region.properties or {}).get('primary_access_modes', '')
-            distance_threshold_km = 10 if 'road' in access_modes.lower() else 50
-
-            nearest_distance = float('inf')
-            for clinic in clinics:
-                distance = _haversine_km(
-                    region.centroid_lat,
-                    region.centroid_lon,
-                    clinic.latitude,
-                    clinic.longitude,
-                )
-                nearest_distance = min(nearest_distance, distance)
-
-            has_nearby_clinic = nearest_distance <= distance_threshold_km
-            is_extreme_cost = internet_cost and internet_cost >= 400
-
-            if not has_income_data:
-                if is_extreme_cost:
-                    status = 'COMMUNITY_ANCHOR' if has_nearby_clinic else 'CRITICAL_GAP'
-                elif has_nearby_clinic:
-                    status = 'COMMUNITY_ANCHOR'
-                else:
-                    status = 'DATA_UNAVAILABLE'
-            elif is_affordable:
-                status = 'TELEHEALTH_READY'
-            elif has_nearby_clinic:
-                status = 'COMMUNITY_ANCHOR'
-            else:
-                status = 'CRITICAL_GAP'
-
-        context[region.region_code] = {
-            'telehealth_status': status,
-            'affordability_status': affordability_status,
+    contexts = TelehealthClassificationService.classify_regions(db, regions)
+    return {
+        code: {
+            'telehealth_status': context.classification.status,
+            'affordability_status': context.classification.affordability_status,
         }
-
-    return context
+        for code, context in contexts.items()
+    }
 
 
 def _build_desert_score_lookup(db, regions):
@@ -1889,151 +1782,41 @@ def get_region_telehealth_status(region_code):
     """
     Get composite telehealth access status for a region.
     
-    Combines affordability and clinic proximity into a single classification:
-    - TELEHEALTH_READY (Green): Affordable home internet
-    - COMMUNITY_ANCHOR (Yellow/Amber): Unaffordable home, but clinic nearby
-    - CRITICAL_GAP (Red): Unaffordable home AND no nearby clinic
-    - DATA_UNAVAILABLE (Gray): Cannot determine (missing income data)
+    Uses the canonical Ookla/FCC, affordability, and clinic-access classifier.
     """
     db = SessionLocal()
     try:
         region = CATDataHandler.get_region_by_code(db, region_code)
-        if not region or not region.centroid_lat:
+        if not region:
             return jsonify({'error': 'Region not found'}), 404
-        
-        # === STEP 1: Check Affordability ===
-        lat_range, lon_range = 0.5, 1.0
-        candidates = db.query(CensusIncome).filter(
-            CensusIncome.median_income.isnot(None),
-            CensusIncome.median_income > 0,
-            CensusIncome.centroid_lat.between(region.centroid_lat - lat_range, region.centroid_lat + lat_range),
-            CensusIncome.centroid_lon.between(region.centroid_lon - lon_range, region.centroid_lon + lon_range)
-        ).all()
-        
-        best_zcta = None
-        min_dist = float('inf')
-        for c in candidates:
-            if c.centroid_lat and c.centroid_lon:
-                dist = _haversine_km(region.centroid_lat, region.centroid_lon, c.centroid_lat, c.centroid_lon)
-                if dist < min_dist:
-                    min_dist = dist
-                    best_zcta = c
-        
-        has_income_data = best_zcta is not None
-        is_affordable = False
-        burden_pct = None
-        internet_cost = None
-        
-        if has_income_data and best_zcta is not None:
-            assert best_zcta is not None
-            zcta_str = str(best_zcta.zcta) if hasattr(best_zcta, 'zcta') and best_zcta.zcta else ""
-            internet_cost, isp_name = _get_regional_internet_cost(zcta_str)
-            med_inc = float(getattr(best_zcta, 'median_income', 0) or 0)
-            monthly_income = med_inc / 12.0
-            burden_pct = float((internet_cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
-            
-            t_conf = _ISP_CONFIG.get('thresholds', {})
-            t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
-            threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
-            
-            # Absolute cost threshold: $400+/mo is inherently unaffordable regardless of income
-            absolute_cost_threshold = 400.0
-            is_affordable = bool(burden_pct < threshold) and bool(internet_cost < absolute_cost_threshold)
-        else:
-            # No income data - check if cost is extreme rural ($450+)
-            # Get cost based on region location
-            region_zcta = region.properties.get('zcta') if region.properties else None
-            if region_zcta:
-                internet_cost, isp_name = _get_regional_internet_cost(region_zcta)
-            else:
-                # Default to fastwyre for unknown areas
-                internet_cost = 450
-                isp_name = 'FastWyre'
-        
-        # === STEP 2: Check Clinic Proximity ===
-        properties = region.properties or {}
-        access_modes = properties.get('primary_access_modes', '')
-        distance_threshold_km = 10 if 'road' in access_modes.lower() else 50
-        
-        facilities = db.query(HealthcareSite).filter(
-            HealthcareSite.is_active == True,
-            HealthcareSite.latitude.isnot(None)
-        ).all()
-        
-        nearest_clinic = None
-        nearest_distance = float('inf')
-        for f in facilities:
-            if f.site_type in ['clinic', 'hospital', 'health_center']:
-                dist = _haversine_km(region.centroid_lat, region.centroid_lon, f.latitude, f.longitude)
-                if dist < nearest_distance:
-                    nearest_distance = dist
-                    nearest_clinic = f
-        
-        has_nearby_clinic = nearest_distance <= distance_threshold_km
-        
-        # === STEP 3: Composite Classification ===
-        # Check for extreme cost first (>$400/mo is automatically unaffordable)
-        is_extreme_cost = internet_cost and internet_cost >= 400
-        
-        if not has_income_data:
-            # Cannot determine affordability by percentage
-            if is_extreme_cost:
-                # Extreme rural pricing - definitely unaffordable
-                if has_nearby_clinic:
-                    status = 'COMMUNITY_ANCHOR'
-                    color = '#f59e0b'  # Amber
-                    label = 'Community Anchor'
-                    description = f'Extreme cost (${internet_cost}/mo); clinic provides safety net'
-                else:
-                    status = 'CRITICAL_GAP'
-                    color = '#ef4444'  # Red
-                    label = 'Critical Gap'
-                    description = f'Extreme cost (${internet_cost}/mo) AND no nearby clinic'
-            elif has_nearby_clinic:
-                status = 'COMMUNITY_ANCHOR'
-                color = '#f59e0b'  # Amber
-                label = 'Community Anchor'
-                description = 'Income data unavailable; clinic provides safety net'
-            else:
-                status = 'DATA_UNAVAILABLE'
-                color = '#6b7280'  # Gray
-                label = 'Data Gap'
-                description = 'Cannot assess - no income data and no nearby clinic'
-        elif is_affordable:
-            status = 'TELEHEALTH_READY'
-            color = '#22c55e'  # Green
-            label = 'Telehealth Ready'
-            description = f'Home internet affordable ({burden_pct:.1f}% of income)'
-        elif has_nearby_clinic:
-            status = 'COMMUNITY_ANCHOR'
-            color = '#f59e0b'  # Amber/Yellow
-            label = 'Community Anchor'
-            description = f'Home internet unaffordable ({burden_pct:.1f}%), but clinic {nearest_distance:.1f}km away'
-        else:
-            status = 'CRITICAL_GAP'
-            color = '#ef4444'  # Red
-            label = 'Critical Gap'
-            description = f'Home internet unaffordable ({burden_pct:.1f}%) AND no clinic within {distance_threshold_km}km'
-        
+        context = TelehealthClassificationService.classify_region(db, region)
+        inputs = context.inputs
+        classification = context.classification
         return jsonify({
             'region_code': region_code,
             'region_name': region.region_name,
-            'status': status,
-            'color': color,
-            'label': label,
-            'description': description,
+            'status': classification.status,
+            'color': classification.color,
+            'label': classification.label,
+            'description': classification.explanation,
             'affordability': {
-                'has_data': has_income_data,
-                'is_affordable': is_affordable,
-                'burden_pct': float(f"{burden_pct:.2f}") if burden_pct else None,
-                'internet_cost': internet_cost
+                'has_data': classification.affordability_status != 'unknown',
+                'is_affordable': (
+                    classification.affordability_status == 'affordable'
+                    if classification.affordability_status != 'unknown' else None
+                ),
+                'burden_pct': round(inputs.burden_pct, 2) if inputs.burden_pct is not None else None,
+                'internet_cost': inputs.monthly_internet_cost,
             },
             'clinic_proximity': {
-                'has_nearby': has_nearby_clinic,
-                'nearest_name': nearest_clinic.name if nearest_clinic else None,
-                'nearest_distance_km': float(f"{nearest_distance:.1f}") if nearest_clinic else None,
-                'threshold_km': distance_threshold_km
-            }
+                'has_nearby': classification.clinic_supported,
+                'nearest_name': context.nearest_clinic.name if context.nearest_clinic else None,
+                'nearest_distance_km': (
+                    round(inputs.nearest_clinic_distance_km, 1)
+                    if inputs.nearest_clinic_distance_km is not None else None
+                ),
+                'threshold_km': classification.clinic_threshold_km,
+            },
         }), 200
         
     except Exception as e:
@@ -2051,124 +1834,42 @@ def get_all_telehealth_status():
     db = SessionLocal()
     try:
         regions = db.query(CATRegion).all()
-        
-        # Pre-fetch all census and healthcare data for efficiency
-        all_census = db.query(CensusIncome).filter(
-            CensusIncome.median_income.isnot(None),
-            CensusIncome.median_income > 0
-        ).all()
-        
-        all_facilities = db.query(HealthcareSite).filter(
-            HealthcareSite.is_active == True,
-            HealthcareSite.latitude.isnot(None)
-        ).all()
-        
-        # Filter to clinics/hospitals only
-        clinics = [f for f in all_facilities if f.site_type in ['clinic', 'hospital', 'health_center']]
-        
+        contexts = TelehealthClassificationService.classify_regions(db, regions)
         results = []
-        summary = {'telehealth_ready': 0, 'community_anchor': 0, 'critical_gap': 0, 'data_unavailable': 0}
-        
+        summary = {
+            'telehealth_ready': 0,
+            'community_anchor': 0,
+            'limited_telehealth': 0,
+            'critical_gap': 0,
+            'data_unavailable': 0,
+        }
+
         for region in regions:
-            if not region.centroid_lat or not region.centroid_lon:
-                continue
-            
-            # Find nearest ZCTA with income
-            best_zcta = None
-            min_dist = float('inf')
-            for c in all_census:
-                if c.centroid_lat and c.centroid_lon:
-                    dist = _haversine_km(region.centroid_lat, region.centroid_lon, c.centroid_lat, c.centroid_lon)
-                    if dist < min_dist and dist < 55:  # 55km threshold
-                        min_dist = dist
-                        best_zcta = c
-            
-            has_income_data = best_zcta is not None
-            is_affordable = False
-            burden_pct = None
-            internet_cost = None
-            median_income = None
-            isp_name = 'Unknown'
-            
-            if has_income_data and best_zcta is not None:
-                assert best_zcta is not None
-                internet_cost, isp_name = _get_regional_internet_cost(str(getattr(best_zcta, 'zcta', '')))
-                median_income = float(getattr(best_zcta, 'median_income', 0) or 0)
-                monthly_income = median_income / 12.0
-                burden_pct = float((internet_cost / monthly_income) * 100.0) if monthly_income > 0 else 100.0
-                
-                t_conf = _ISP_CONFIG.get('thresholds', {})
-                t_val = t_conf.get('affordability_burden_pct', 2.0) if isinstance(t_conf, dict) else 2.0
-                threshold = float(t_val) if isinstance(t_val, (int, float)) else 2.0
-                
-                is_affordable = bool(burden_pct < threshold) and bool(internet_cost < 400.0)
-            else:
-                internet_cost = 450  # Default fastwyre
-                isp_name = 'FastWyre (est.)'
-            
-            # Find nearest clinic
-            properties = region.properties or {}
-            access_modes = properties.get('primary_access_modes', '')
-            distance_threshold_km = 10 if 'road' in access_modes.lower() else 50
-            
-            nearest_distance = float('inf')
-            nearest_clinic_name = None
-            for f in clinics:
-                dist = _haversine_km(region.centroid_lat, region.centroid_lon, f.latitude, f.longitude)
-                if dist < nearest_distance:
-                    nearest_distance = dist
-                    nearest_clinic_name = f.name
-            
-            has_nearby_clinic = nearest_distance <= distance_threshold_km
-            is_extreme_cost = internet_cost and internet_cost >= 400
-            
-            # Classification + Recommendation
-            if not has_income_data:
-                if is_extreme_cost:
-                    # $450+/mo is inherently unaffordable - mark as such even without income data
-                    if has_nearby_clinic:
-                        status, color = 'COMMUNITY_ANCHOR', '#f59e0b'
-                        recommendation = f'Extreme cost (${internet_cost}/mo) - use community clinic for telehealth'
-                    else:
-                        status, color = 'CRITICAL_GAP', '#ef4444'
-                        recommendation = f'UNAFFORDABLE (${internet_cost}/mo) + No clinic access - urgent intervention needed'
-                elif has_nearby_clinic:
-                    status, color = 'COMMUNITY_ANCHOR', '#f59e0b'
-                    recommendation = 'Use community clinic for telehealth access'
-                else:
-                    status, color = 'DATA_UNAVAILABLE', '#6b7280'
-                    recommendation = 'Collect income data to assess affordability'
-            elif is_affordable:
-                status, color = 'TELEHEALTH_READY', '#22c55e'
-                recommendation = 'Home-based telehealth is viable'
-            elif has_nearby_clinic:
-                status, color = 'COMMUNITY_ANCHOR', '#f59e0b'
-                recommendation = 'Use community clinic for telehealth access'
-            else:
-                status, color = 'CRITICAL_GAP', '#ef4444'
-                recommendation = f'UNAFFORDABLE ({burden_pct:.1f}% burden) + No clinic - urgent intervention needed'
-            
-            # Update summary
-            summary[status.lower()] = summary.get(status.lower(), 0) + 1
-            
+            context = contexts[region.region_code]
+            inputs = context.inputs
+            classification = context.classification
+            summary[classification.status.lower()] += 1
             results.append({
                 'region_code': region.region_code,
                 'region_name': region.region_name,
                 'lat': region.centroid_lat,
                 'lon': region.centroid_lon,
-                'status': status,
-                'color': color,
-                'internet_cost': internet_cost,
-                'isp_name': isp_name,
-                'burden_pct': float(f"{burden_pct:.1f}") if burden_pct else None,
-                'median_income': median_income,
-                'has_nearby_clinic': has_nearby_clinic,
-                'nearest_clinic_name': nearest_clinic_name,
-                'nearest_clinic_km': float(f"{nearest_distance:.1f}") if nearest_distance != float('inf') else None,
-                'access_mode': access_modes or 'unknown',
-                'recommendation': recommendation
+                'status': classification.status,
+                'color': classification.color,
+                'internet_cost': inputs.monthly_internet_cost,
+                'isp_name': context.isp_name or 'Unknown',
+                'burden_pct': round(inputs.burden_pct, 1) if inputs.burden_pct is not None else None,
+                'median_income': inputs.median_income,
+                'has_nearby_clinic': classification.clinic_supported,
+                'nearest_clinic_name': context.nearest_clinic.name if context.nearest_clinic else None,
+                'nearest_clinic_km': (
+                    round(inputs.nearest_clinic_distance_km, 1)
+                    if inputs.nearest_clinic_distance_km is not None else None
+                ),
+                'access_mode': inputs.access_modes or 'unknown',
+                'recommendation': classification.explanation,
             })
-        
+
         return jsonify({
             'regions': results,
             'count': len(results),

--- a/backend/services/research_profile_service.py
+++ b/backend/services/research_profile_service.py
@@ -7,9 +7,7 @@ comparison, and future research exports.
 
 from __future__ import annotations
 
-import json
 import math
-import os
 from datetime import datetime, timezone
 
 from sqlalchemy import and_, func
@@ -26,9 +24,13 @@ from services.data_quality_service import DataQualityService
 from services.healthcare_desert_calculator import HealthcareDesertCalculator, haversine_km as _haversine_km
 from services.isp_config import get_internet_cost, get_affordability_threshold
 from services.season_constants import SEASON_YEAR_ROUND, VALID_SEASONS, get_season_display_name
+from services.telehealth_classification import (
+    ABSOLUTE_COST_LIMIT,
+    TelehealthClassification,
+    TelehealthClassificationService,
+)
 
 
-AFFORDABILITY_DEFAULT_THRESHOLD = 2.0
 MAX_INCOME_MATCH_KM = 55.0
 MAX_OOKLA_MATCH_KM = 75.0
 
@@ -58,9 +60,10 @@ class ResearchProfileService:
         if region is None:
             return None
 
-        broadband = ResearchProfileService._broadband_for_region(db, region.region_code)
-        ookla = ResearchProfileService._nearest_ookla_tile(db, region)
-        income = ResearchProfileService._nearest_income_record(db, region)
+        telehealth_context = TelehealthClassificationService.classify_region(db, region)
+        broadband = telehealth_context.broadband
+        ookla = telehealth_context.ookla
+        income = telehealth_context.income
         nearest_facility = ResearchProfileService._nearest_facility(db, region)
         facility_count = db.query(HealthcareSite).filter(
             HealthcareSite.region_code == region.region_code,
@@ -87,13 +90,9 @@ class ResearchProfileService:
             desert_score,
         )
         connectivity = ResearchProfileService._connectivity_payload(broadband, ookla)
-        access_modes = (region.properties or {}).get("primary_access_modes", "")
         telehealth = ResearchProfileService._telehealth_payload(
-            connectivity,
-            affordability,
-            healthcare,
+            telehealth_context.classification,
             season,
-            access_modes,
         )
 
         sources = ["CAT region boundaries"]
@@ -281,7 +280,11 @@ class ResearchProfileService:
             status = "unknown"
         else:
             burden_pct = (float(cost) / (float(median_income) / 12.0)) * 100.0
-            status = "affordable" if burden_pct < threshold else "unaffordable"
+            status = (
+                "affordable"
+                if burden_pct < threshold and float(cost) < ABSOLUTE_COST_LIMIT
+                else "unaffordable"
+            )
 
         return {
             "monthly_cost": _round(cost, 2),
@@ -307,51 +310,13 @@ class ResearchProfileService:
         }
 
     @staticmethod
-    def _telehealth_payload(connectivity: dict, affordability: dict, healthcare: dict, season: str, access_modes: str = "") -> dict:
-        download = connectivity["ookla_download_mbps"]
-        latency = connectivity["latency_ms"]
-        coverage = connectivity["fcc_coverage_25mbps_pct"]
-
-        video_feasible = None
-        if download is not None or coverage is not None:
-            video_feasible = bool(
-                (download is not None and download >= 25 and (latency is None or latency <= 150))
-                or (download is None and coverage is not None and coverage >= 70)
-            )
-
-        audio_feasible = None
-        if download is not None or coverage is not None:
-            audio_feasible = bool(
-                (download is not None and download >= 5)
-                or (download is None and coverage is not None and coverage >= 25)
-            )
-
-        clinic_supported = None
-        if healthcare["nearest_facility_distance_km"] is not None:
-            threshold = 10 if "road" in (access_modes or "").lower() else 50
-            clinic_supported = healthcare["nearest_facility_distance_km"] <= threshold
-        if video_feasible and affordability["status"] == "affordable":
-            status = "TELEHEALTH_READY"
-            label = "Telehealth ready"
-        elif clinic_supported:
-            status = "COMMUNITY_ANCHOR"
-            label = "Clinic-supported"
-        elif audio_feasible:
-            status = "LIMITED_TELEHEALTH"
-            label = "Limited telehealth"
-        elif video_feasible is None and audio_feasible is None:
-            status = "DATA_UNAVAILABLE"
-            label = "Data unavailable"
-        else:
-            status = "CRITICAL_GAP"
-            label = "Critical access gap"
-
+    def _telehealth_payload(classification: TelehealthClassification, season: str) -> dict:
         return {
-            "status": status,
-            "label": label,
-            "video_feasible": video_feasible,
-            "audio_feasible": audio_feasible,
-            "clinic_supported": clinic_supported,
+            "status": classification.status,
+            "label": classification.label,
+            "video_feasible": classification.video_feasible,
+            "audio_feasible": classification.audio_feasible,
+            "clinic_supported": classification.clinic_supported,
             "season": season,
             "season_note": f"{get_season_display_name(season)} scenario applied.",
         }

--- a/backend/services/scenario_engine.py
+++ b/backend/services/scenario_engine.py
@@ -5,11 +5,7 @@ Re-evaluates telehealth readiness status for all (or selected) communities
 under user-specified thresholds.  The engine never mutates baseline data; it
 returns a modeled preview of how status and need-scores would change.
 
-Reuses:
-    - ResearchProfileService (income, broadband, ookla lookups)
-    - DataQualityService (confidence evaluation)
-    - HealthcareDesertCalculator (distance + density scoring)
-    - ISP pricing configuration
+Reuses the canonical telehealth classifier and cached factual inputs.
 
 Status ranking (worst → best):
     DATA_UNAVAILABLE < CRITICAL_GAP < LIMITED_TELEHEALTH < COMMUNITY_ANCHOR < TELEHEALTH_READY
@@ -17,15 +13,18 @@ Status ranking (worst → best):
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
-from services.data_quality_service import normalize_confidence, split_gap_flags
-from services.healthcare_desert_calculator import HealthcareDesertCalculator
-from services.isp_config import get_internet_cost, get_affordability_threshold
 from services.scenario_input_cache import ScenarioInputCache
 from services.season_constants import SEASON_YEAR_ROUND, VALID_SEASONS
+from services.telehealth_classification import (
+    TelehealthInputs,
+    TelehealthThresholds,
+    baseline_thresholds,
+    classify_telehealth,
+)
 
 
 # ── Status ranking ──────────────────────────────────────────────────────────
@@ -38,23 +37,15 @@ STATUS_RANK: Dict[str, int] = {
     "TELEHEALTH_READY": 4,
 }
 
-STATUS_DISPLAY = {
-    "TELEHEALTH_READY": "Telehealth Ready",
-    "COMMUNITY_ANCHOR": "Community Anchor",
-    "LIMITED_TELEHEALTH": "Limited Telehealth",
-    "CRITICAL_GAP": "Critical Gap",
-    "DATA_UNAVAILABLE": "Data Unavailable",
-}
-
-
 # ── Default baseline thresholds ─────────────────────────────────────────────
 
+_CANONICAL_BASELINE = baseline_thresholds()
 BASELINE_THRESHOLDS = {
-    "min_download_mbps": 25,
-    "min_upload_mbps": 3,
-    "max_latency_ms": 150,
+    "min_download_mbps": _CANONICAL_BASELINE.min_download_mbps,
+    "min_upload_mbps": _CANONICAL_BASELINE.min_upload_mbps,
+    "max_latency_ms": _CANONICAL_BASELINE.max_latency_ms,
     "clinic_proximity_km": None,  # use existing access-mode logic
-    "affordability_burden_pct": get_affordability_threshold(),
+    "affordability_burden_pct": _CANONICAL_BASELINE.affordability_burden_pct,
 }
 
 _NULLABLE_THRESHOLD_KEYS = {"max_latency_ms", "clinic_proximity_km"}
@@ -158,7 +149,6 @@ class ScenarioEngine:
             entry = ScenarioEngine._evaluate_cached_input(
                 scenario_input=scenario_input,
                 merged_thresholds=merged,
-                is_baseline_equivalent=is_baseline_equivalent,
             )
             results.append(entry)
 
@@ -200,22 +190,13 @@ class ScenarioEngine:
         *,
         scenario_input: dict,
         merged_thresholds: dict,
-        is_baseline_equivalent: bool,
     ) -> dict:
         baseline_status = scenario_input["baseline_status"]
         baseline_need_score = scenario_input["baseline_need_score"]
-
-        if is_baseline_equivalent:
-            scenario = {
-                "status": baseline_status,
-                "reason_codes": ["BASELINE_EQUIVALENT"],
-                "explanation": "Baseline thresholds applied; modeled status matches the current classification.",
-            }
-        else:
-            scenario = ScenarioEngine._scenario_status_from_input(
-                scenario_input=scenario_input,
-                merged_thresholds=merged_thresholds,
-            )
+        scenario = ScenarioEngine._scenario_status_from_input(
+            scenario_input=scenario_input,
+            merged_thresholds=merged_thresholds,
+        )
 
         scenario_status = scenario["status"]
         scenario_need_score = baseline_need_score
@@ -247,131 +228,40 @@ class ScenarioEngine:
         scenario_input: dict,
         merged_thresholds: dict,
     ) -> dict:
-        reason_codes: List[str] = []
-        explanation_parts: List[str] = []
-
-        if scenario_input["lat"] is None or scenario_input["lon"] is None:
-            return {
-                "status": "DATA_UNAVAILABLE",
-                "reason_codes": ["MISSING_COORDINATES"],
-                "explanation": "Region has no geolocation data.",
-            }
-
-        min_download = merged_thresholds.get("min_download_mbps", 25)
-        min_upload = merged_thresholds.get("min_upload_mbps", 3)
-        max_latency = merged_thresholds.get("max_latency_ms", 150)
-        download_mbps = scenario_input.get("ookla_download_mbps")
-        upload_mbps = scenario_input.get("ookla_upload_mbps")
-        latency_ms = scenario_input.get("ookla_latency_ms")
-        fcc_coverage = scenario_input.get("fcc_coverage_pct")
-
-        meets_broadband = False
-        if download_mbps is not None:
-            if download_mbps >= min_download:
-                if upload_mbps is None or upload_mbps >= min_upload:
-                    if max_latency is None or latency_ms is None or latency_ms <= max_latency:
-                        meets_broadband = True
-                        reason_codes.append("MEETS_BROADBAND")
-                        explanation_parts.append(
-                            f"Broadband meets {min_download:g}/{min_upload:g} Mbps threshold"
-                        )
-                    else:
-                        reason_codes.append("HIGH_LATENCY")
-                        explanation_parts.append(
-                            f"Latency {latency_ms:.0f}ms exceeds {max_latency:g}ms"
-                        )
-                else:
-                    reason_codes.append("LOW_UPLOAD")
-                    explanation_parts.append(
-                        f"Upload {upload_mbps:.1f} Mbps below {min_upload:g} Mbps"
-                    )
-            else:
-                reason_codes.append("LOW_DOWNLOAD")
-                explanation_parts.append(
-                    f"Download {download_mbps:.1f} Mbps below {min_download:g} Mbps"
-                )
-        elif fcc_coverage is not None and fcc_coverage >= 70:
-            if min_download <= 25 and min_upload <= 3:
-                meets_broadband = True
-                reason_codes.append("MEETS_BROADBAND_FCC")
-                explanation_parts.append("FCC coverage supports broadband threshold")
-            else:
-                reason_codes.append("FCC_BELOW_SCENARIO_THRESHOLD")
-                explanation_parts.append("FCC data doesn't cover higher scenario thresholds")
-        else:
-            reason_codes.append("NO_BROADBAND_DATA")
-            explanation_parts.append("No measured broadband data available")
-
-        aff_threshold = merged_thresholds.get("affordability_burden_pct", 2.0)
-        burden_pct = scenario_input.get("burden_pct")
-        internet_cost = scenario_input.get("monthly_internet_cost")
-        has_income_data = burden_pct is not None
-        is_affordable = False
-
-        if has_income_data:
-            is_affordable = bool(
-                burden_pct < aff_threshold
-                and internet_cost is not None
-                and internet_cost < 400.0
-            )
-            if is_affordable:
-                reason_codes.append("AFFORDABLE")
-                explanation_parts.append(
-                    f"Internet burden {burden_pct:.1f}% below {aff_threshold:g}%"
-                )
-            else:
-                reason_codes.append("UNAFFORDABLE")
-                explanation_parts.append(
-                    f"Internet burden {burden_pct:.1f}% exceeds {aff_threshold:g}%"
-                )
-        else:
-            internet_cost = 450.0
-            reason_codes.append("NO_INCOME_DATA")
-            explanation_parts.append("No income data to assess affordability")
-
-        clinic_threshold_km = merged_thresholds.get("clinic_proximity_km")
-        distance_threshold_km = (
-            scenario_input["distance_threshold_km"]
-            if clinic_threshold_km is None
-            else float(clinic_threshold_km)
+        thresholds = TelehealthThresholds(
+            min_download_mbps=float(merged_thresholds["min_download_mbps"]),
+            min_upload_mbps=float(merged_thresholds["min_upload_mbps"]),
+            max_latency_ms=(
+                float(merged_thresholds["max_latency_ms"])
+                if merged_thresholds["max_latency_ms"] is not None else None
+            ),
+            clinic_proximity_km=(
+                float(merged_thresholds["clinic_proximity_km"])
+                if merged_thresholds["clinic_proximity_km"] is not None else None
+            ),
+            affordability_burden_pct=float(
+                merged_thresholds["affordability_burden_pct"]
+            ),
         )
-        nearest_distance = scenario_input.get("nearest_clinic_distance_km")
-        has_nearby_clinic = (
-            nearest_distance is not None
-            and nearest_distance <= distance_threshold_km
+        classification = classify_telehealth(
+            TelehealthInputs(
+                latitude=scenario_input.get("lat"),
+                longitude=scenario_input.get("lon"),
+                access_modes=scenario_input.get("access_modes", ""),
+                ookla_download_mbps=scenario_input.get("ookla_download_mbps"),
+                ookla_upload_mbps=scenario_input.get("ookla_upload_mbps"),
+                ookla_latency_ms=scenario_input.get("ookla_latency_ms"),
+                fcc_coverage_pct=scenario_input.get("fcc_coverage_pct"),
+                median_income=scenario_input.get("median_income"),
+                monthly_internet_cost=scenario_input.get("monthly_internet_cost"),
+                burden_pct=scenario_input.get("burden_pct"),
+                nearest_clinic_distance_km=scenario_input.get("nearest_clinic_distance_km"),
+                clinic_data_available=scenario_input.get("clinic_data_available", False),
+            ),
+            thresholds,
         )
-        if has_nearby_clinic:
-            reason_codes.append("ACCESSIBLE_CARE")
-            explanation_parts.append(f"Clinic within {distance_threshold_km:.0f}km")
-        else:
-            reason_codes.append("NO_NEARBY_CLINIC")
-            explanation_parts.append(f"No clinic within {distance_threshold_km:.0f}km")
-
-        is_extreme_cost = internet_cost is not None and internet_cost >= 400
-
-        if not has_income_data:
-            if is_extreme_cost:
-                status = "COMMUNITY_ANCHOR" if has_nearby_clinic else "CRITICAL_GAP"
-            elif has_nearby_clinic:
-                status = "COMMUNITY_ANCHOR"
-            else:
-                status = "DATA_UNAVAILABLE"
-        elif meets_broadband and is_affordable:
-            status = "TELEHEALTH_READY"
-        elif is_affordable:
-            if "NO_BROADBAND_DATA" in reason_codes:
-                status = "DATA_UNAVAILABLE"
-            elif has_nearby_clinic:
-                status = "LIMITED_TELEHEALTH"
-            else:
-                status = "CRITICAL_GAP"
-        elif has_nearby_clinic:
-            status = "COMMUNITY_ANCHOR"
-        else:
-            status = "CRITICAL_GAP"
-
         return {
-            "status": status,
-            "reason_codes": reason_codes,
-            "explanation": "; ".join(explanation_parts) if explanation_parts else "No assessment available.",
+            "status": classification.status,
+            "reason_codes": list(classification.reason_codes),
+            "explanation": classification.explanation,
         }

--- a/backend/services/scenario_input_cache.py
+++ b/backend/services/scenario_input_cache.py
@@ -8,47 +8,28 @@ database/season and lets ScenarioEngine do cheap threshold comparisons.
 
 from __future__ import annotations
 
-import json
-import math
-import os
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 
 from database.models import (
-    BroadbandCoverage,
     CATDataPoint,
     CATRegion,
-    CensusIncome,
     HealthcareSite,
-    OoklaPerformance,
 )
 from services.data_quality_service import normalize_confidence, split_gap_flags
 from services.healthcare_desert_calculator import HealthcareDesertCalculator, haversine_km as _haversine_km
-from services.isp_config import get_internet_cost, get_affordability_threshold
 from services.season_constants import (
     ROAD_QUALITY_LOCAL,
     SEASON_YEAR_ROUND,
     VALID_ROAD_QUALITIES,
     VALID_SEASONS,
 )
-
-
-def _bucket_key(lat: float, lon: float) -> Tuple[int, int]:
-    return math.floor(lat), math.floor(lon)
-
-
-def _candidate_buckets(lat: float, lon: float, max_km: float) -> Iterable[Tuple[int, int]]:
-    lat_window = max_km / 111.0
-    lon_window = max_km / (111.0 * max(math.cos(math.radians(lat)), 0.1))
-    min_lat = math.floor(lat - lat_window)
-    max_lat = math.floor(lat + lat_window)
-    min_lon = math.floor(lon - lon_window)
-    max_lon = math.floor(lon + lon_window)
-    for lat_key in range(min_lat, max_lat + 1):
-        for lon_key in range(min_lon, max_lon + 1):
-            yield lat_key, lon_key
+from services.telehealth_classification import (
+    TelehealthClassificationService,
+    TelehealthRegionContext,
+)
 
 
 class ScenarioInputCache:
@@ -96,90 +77,23 @@ class ScenarioInputCache:
             HealthcareSite.latitude.isnot(None),
             HealthcareSite.longitude.isnot(None),
         ).all()
-        status_clinics = [
-            site for site in facilities
-            if (site.site_type or "").lower() in {"clinic", "hospital", "health_center"}
-        ]
-
-        broadband_lookup = cls._broadband_lookup(db, region_codes)
-        census_buckets: Dict[Tuple[int, int], List[CensusIncome]] = defaultdict(list)
-        for record in cls._census_records(db):
-            census_buckets[
-                _bucket_key(float(record.centroid_lat), float(record.centroid_lon))
-            ].append(record)
-
-        ookla_buckets = cls._latest_ookla_buckets(db)
+        telehealth_contexts = TelehealthClassificationService.classify_regions(db, regions)
         data_points_by_region, first_data_point_by_region = cls._data_points(db, region_codes)
         site_counts, specialist_regions = cls._healthcare_site_stats(facilities)
-
-        baseline_threshold = get_affordability_threshold()
 
         return [
             cls._region_input(
                 region=region,
                 season=season,
                 facilities=facilities,
-                status_clinics=status_clinics,
-                broadband=broadband_lookup.get(region.region_code),
-                census_buckets=census_buckets,
-                ookla_buckets=ookla_buckets,
+                telehealth_context=telehealth_contexts[region.region_code],
                 data_points=data_points_by_region.get(region.region_code, []),
                 first_data_point=first_data_point_by_region.get(region.region_code),
                 site_count=site_counts.get(region.region_code, 0),
                 has_specialists=region.region_code in specialist_regions,
-                baseline_threshold=baseline_threshold,
             )
             for region in regions
         ]
-
-    @staticmethod
-    def _broadband_lookup(db: Session, region_codes: List[str]) -> Dict[str, BroadbandCoverage]:
-        records = db.query(BroadbandCoverage).filter(
-            BroadbandCoverage.region_code.in_(region_codes)
-        ).all()
-        lookup: Dict[str, BroadbandCoverage] = {}
-        for record in records:
-            if record.region_code and record.region_code not in lookup:
-                lookup[record.region_code] = record
-        return lookup
-
-    @staticmethod
-    def _census_records(db: Session) -> List[CensusIncome]:
-        return db.query(CensusIncome).filter(
-            CensusIncome.median_income.isnot(None),
-            CensusIncome.median_income > 0,
-            CensusIncome.centroid_lat.isnot(None),
-            CensusIncome.centroid_lon.isnot(None),
-        ).all()
-
-    @staticmethod
-    def _latest_ookla_buckets(db: Session) -> Dict[Tuple[int, int], List[Any]]:
-        latest = db.query(
-            OoklaPerformance.year, OoklaPerformance.quarter
-        ).distinct().order_by(
-            OoklaPerformance.year.desc(),
-            OoklaPerformance.quarter.desc(),
-        ).first()
-        if latest is None:
-            return {}
-
-        rows = db.query(
-            OoklaPerformance.centroid_lat,
-            OoklaPerformance.centroid_lon,
-            OoklaPerformance.avg_d_kbps,
-            OoklaPerformance.avg_u_kbps,
-            OoklaPerformance.avg_lat_ms,
-        ).filter(
-            OoklaPerformance.year == latest.year,
-            OoklaPerformance.quarter == latest.quarter,
-            OoklaPerformance.centroid_lat.isnot(None),
-            OoklaPerformance.centroid_lon.isnot(None),
-        ).all()
-
-        buckets: Dict[Tuple[int, int], List[Any]] = defaultdict(list)
-        for row in rows:
-            buckets[_bucket_key(float(row.centroid_lat), float(row.centroid_lon))].append(row)
-        return buckets
 
     @staticmethod
     def _data_points(
@@ -218,15 +132,11 @@ class ScenarioInputCache:
         region: CATRegion,
         season: str,
         facilities: List[HealthcareSite],
-        status_clinics: List[HealthcareSite],
-        broadband: Optional[BroadbandCoverage],
-        census_buckets: Dict[Tuple[int, int], List[CensusIncome]],
-        ookla_buckets: Dict[Tuple[int, int], List[Any]],
+        telehealth_context: TelehealthRegionContext,
         data_points: List[CATDataPoint],
         first_data_point: Optional[CATDataPoint],
         site_count: int,
         has_specialists: bool,
-        baseline_threshold: float,
     ) -> Dict[str, Any]:
         display_lat = region.centroid_lat
         display_lon = region.centroid_lon
@@ -236,51 +146,9 @@ class ScenarioInputCache:
             score_lat = sum(point.latitude for point in data_points) / len(data_points)
             score_lon = sum(point.longitude for point in data_points) / len(data_points)
 
-        access_modes = (region.properties or {}).get("primary_access_modes", "")
-        distance_threshold_km = 10 if "road" in access_modes.lower() else 50
-
-        income = (
-            cls._nearest_income(census_buckets, display_lat, display_lon)
-            if display_lat is not None and display_lon is not None
-            else None
-        )
-        monthly_internet_cost: Optional[float] = None
-        burden_pct: Optional[float] = None
-        median_income: Optional[float] = None
-        has_income_data = income is not None
-
-        if income is not None:
-            median_income = float(income.median_income)
-            monthly_internet_cost, _ = get_internet_cost(str(income.zcta))
-            monthly_income = median_income / 12.0
-            burden_pct = (
-                float((monthly_internet_cost / monthly_income) * 100.0)
-                if monthly_income > 0
-                else 100.0
-            )
-        else:
-            monthly_internet_cost = 450.0
-
-        nearest_status_clinic = (
-            cls._nearest_distance(status_clinics, display_lat, display_lon)
-            if display_lat is not None and display_lon is not None
-            else None
-        )
+        inputs = telehealth_context.inputs
+        broadband = telehealth_context.broadband
         facility_distances = cls._facility_distances(facilities, score_lat, score_lon)
-        ookla = (
-            cls._nearest_ookla(ookla_buckets, display_lat, display_lon)
-            if display_lat is not None and display_lon is not None
-            else None
-        )
-
-        baseline_status = cls._baseline_status(
-            has_income_data=has_income_data,
-            burden_pct=burden_pct,
-            monthly_internet_cost=monthly_internet_cost,
-            affordability_threshold=baseline_threshold,
-            nearest_clinic_distance_km=nearest_status_clinic,
-            distance_threshold_km=distance_threshold_km,
-        )
         baseline_need_score = cls._need_score(
             facility_distances=facility_distances,
             site_count=site_count,
@@ -290,9 +158,9 @@ class ScenarioInputCache:
         )
 
         missing_fields: List[str] = []
-        if broadband is None:
+        if inputs.ookla_download_mbps is None and inputs.fcc_coverage_pct is None:
             missing_fields.append("connectivity.fcc_coverage")
-        if display_lat is None or display_lon is None or income is None:
+        if display_lat is None or display_lon is None or inputs.median_income is None:
             missing_fields.append("affordability.median_income")
 
         return {
@@ -300,34 +168,19 @@ class ScenarioInputCache:
             "name": region.region_name,
             "lat": float(display_lat) if display_lat is not None else None,
             "lon": float(display_lon) if display_lon is not None else None,
-            "access_modes": access_modes,
-            "baseline_status": baseline_status,
+            "access_modes": inputs.access_modes,
+            "baseline_status": telehealth_context.classification.status,
             "baseline_need_score": baseline_need_score,
-            "nearest_clinic_distance_km": nearest_status_clinic,
-            "distance_threshold_km": distance_threshold_km,
-            "median_income": median_income,
-            "monthly_internet_cost": monthly_internet_cost,
-            "burden_pct": burden_pct,
-            "ookla_download_mbps": (
-                float(ookla.avg_d_kbps) / 1000.0
-                if ookla is not None and ookla.avg_d_kbps is not None
-                else None
-            ),
-            "ookla_upload_mbps": (
-                float(ookla.avg_u_kbps) / 1000.0
-                if ookla is not None and ookla.avg_u_kbps is not None
-                else None
-            ),
-            "ookla_latency_ms": (
-                float(ookla.avg_lat_ms)
-                if ookla is not None and ookla.avg_lat_ms is not None
-                else None
-            ),
-            "fcc_coverage_pct": (
-                float(broadband.any_tech_25mbps_pct)
-                if broadband is not None and broadband.any_tech_25mbps_pct is not None
-                else None
-            ),
+            "nearest_clinic_distance_km": inputs.nearest_clinic_distance_km,
+            "distance_threshold_km": telehealth_context.classification.clinic_threshold_km,
+            "clinic_data_available": inputs.clinic_data_available,
+            "median_income": inputs.median_income,
+            "monthly_internet_cost": inputs.monthly_internet_cost,
+            "burden_pct": inputs.burden_pct,
+            "ookla_download_mbps": inputs.ookla_download_mbps,
+            "ookla_upload_mbps": inputs.ookla_upload_mbps,
+            "ookla_latency_ms": inputs.ookla_latency_ms,
+            "fcc_coverage_pct": inputs.fcc_coverage_pct,
             "has_data_gap": bool(missing_fields) or bool(
                 split_gap_flags(getattr(broadband, "data_gaps", None) if broadband else None)
             ),
@@ -336,20 +189,6 @@ class ScenarioInputCache:
                 getattr(broadband, "confidence", None) if broadband else None
             ),
         }
-
-    @staticmethod
-    def _nearest_distance(
-        sites: List[HealthcareSite],
-        lat: Optional[float],
-        lon: Optional[float],
-    ) -> Optional[float]:
-        if lat is None or lon is None or not sites:
-            return None
-        nearest = min(
-            _haversine_km(float(lat), float(lon), site.latitude, site.longitude)
-            for site in sites
-        )
-        return round(float(nearest), 2)
 
     @staticmethod
     def _facility_distances(
@@ -377,80 +216,6 @@ class ScenarioInputCache:
             key: (999.0 if value == float("inf") else round(float(value), 2))
             for key, value in distances.items()
         }
-
-    @staticmethod
-    def _nearest_income(
-        census_buckets: Dict[Tuple[int, int], List[CensusIncome]],
-        lat: float,
-        lon: float,
-        max_km: float = 55.0,
-    ) -> Optional[CensusIncome]:
-        best = None
-        min_dist = float("inf")
-        for key in _candidate_buckets(float(lat), float(lon), max_km):
-            for record in census_buckets.get(key, []):
-                dist = _haversine_km(
-                    float(lat),
-                    float(lon),
-                    record.centroid_lat,
-                    record.centroid_lon,
-                )
-                if dist < min_dist and dist <= max_km:
-                    min_dist = dist
-                    best = record
-        return best
-
-    @staticmethod
-    def _nearest_ookla(
-        buckets: Dict[Tuple[int, int], List[Any]],
-        lat: float,
-        lon: float,
-        max_km: float = 75.0,
-    ) -> Optional[Any]:
-        best = None
-        min_dist = float("inf")
-        for key in _candidate_buckets(float(lat), float(lon), max_km):
-            for tile in buckets.get(key, []):
-                dist = _haversine_km(float(lat), float(lon), tile.centroid_lat, tile.centroid_lon)
-                if dist < min_dist and dist <= max_km:
-                    min_dist = dist
-                    best = tile
-        return best
-
-    @staticmethod
-    def _baseline_status(
-        *,
-        has_income_data: bool,
-        burden_pct: Optional[float],
-        monthly_internet_cost: Optional[float],
-        affordability_threshold: float,
-        nearest_clinic_distance_km: Optional[float],
-        distance_threshold_km: float,
-    ) -> str:
-        is_affordable = (
-            has_income_data
-            and burden_pct is not None
-            and monthly_internet_cost is not None
-            and burden_pct < affordability_threshold
-            and monthly_internet_cost < 400.0
-        )
-        has_nearby_clinic = (
-            nearest_clinic_distance_km is not None
-            and nearest_clinic_distance_km <= distance_threshold_km
-        )
-        is_extreme_cost = monthly_internet_cost is not None and monthly_internet_cost >= 400.0
-
-        if not has_income_data:
-            if is_extreme_cost:
-                return "COMMUNITY_ANCHOR" if has_nearby_clinic else "CRITICAL_GAP"
-            if has_nearby_clinic:
-                return "COMMUNITY_ANCHOR"
-            return "DATA_UNAVAILABLE"
-        if is_affordable:
-            return "TELEHEALTH_READY"
-        if has_nearby_clinic:
-            return "COMMUNITY_ANCHOR"
-        return "CRITICAL_GAP"
 
     @staticmethod
     def _need_score(

--- a/backend/services/telehealth_classification.py
+++ b/backend/services/telehealth_classification.py
@@ -1,0 +1,483 @@
+"""Canonical telehealth classification and source-data resolution.
+
+Every backend surface that publishes a telehealth status must use this
+module.  Ookla measurements are preferred when a download measurement is
+available; FCC 25/3 coverage is the fallback.  Income and clinic availability
+remain explicit so missing data cannot be interpreted as a successful result.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from database.models import (
+    BroadbandCoverage,
+    CATRegion,
+    CensusIncome,
+    HealthcareSite,
+    OoklaPerformance,
+)
+from services.healthcare_desert_calculator import haversine_km
+from services.isp_config import get_affordability_threshold, get_internet_cost
+
+
+MAX_INCOME_MATCH_KM = 55.0
+MAX_OOKLA_MATCH_KM = 75.0
+FCC_VIDEO_COVERAGE_PCT = 70.0
+FCC_AUDIO_COVERAGE_PCT = 25.0
+AUDIO_DOWNLOAD_MBPS = 5.0
+ABSOLUTE_COST_LIMIT = 400.0
+ROAD_CLINIC_THRESHOLD_KM = 10.0
+NON_ROAD_CLINIC_THRESHOLD_KM = 50.0
+
+STATUS_PRESENTATION = {
+    "TELEHEALTH_READY": ("Telehealth Ready", "#22c55e"),
+    "COMMUNITY_ANCHOR": ("Community Anchor", "#f59e0b"),
+    "LIMITED_TELEHEALTH": ("Limited Telehealth", "#f97316"),
+    "CRITICAL_GAP": ("Critical Gap", "#ef4444"),
+    "DATA_UNAVAILABLE": ("Data Unavailable", "#6b7280"),
+}
+
+
+@dataclass(frozen=True)
+class TelehealthThresholds:
+    min_download_mbps: float = 25.0
+    min_upload_mbps: float = 3.0
+    max_latency_ms: Optional[float] = 150.0
+    clinic_proximity_km: Optional[float] = None
+    affordability_burden_pct: float = 2.0
+
+
+def baseline_thresholds() -> TelehealthThresholds:
+    return TelehealthThresholds(
+        affordability_burden_pct=get_affordability_threshold(),
+    )
+
+
+@dataclass(frozen=True)
+class TelehealthInputs:
+    latitude: Optional[float]
+    longitude: Optional[float]
+    access_modes: str = ""
+    ookla_download_mbps: Optional[float] = None
+    ookla_upload_mbps: Optional[float] = None
+    ookla_latency_ms: Optional[float] = None
+    fcc_coverage_pct: Optional[float] = None
+    median_income: Optional[float] = None
+    monthly_internet_cost: Optional[float] = None
+    burden_pct: Optional[float] = None
+    nearest_clinic_distance_km: Optional[float] = None
+    clinic_data_available: bool = False
+
+
+@dataclass(frozen=True)
+class TelehealthClassification:
+    status: str
+    label: str
+    color: str
+    video_feasible: Optional[bool]
+    audio_feasible: Optional[bool]
+    clinic_supported: Optional[bool]
+    affordability_status: str
+    broadband_source: Optional[str]
+    clinic_threshold_km: float
+    reason_codes: Tuple[str, ...]
+    explanation: str
+
+
+@dataclass(frozen=True)
+class TelehealthRegionContext:
+    region: CATRegion
+    broadband: Optional[BroadbandCoverage]
+    income: Optional[CensusIncome]
+    ookla: Optional[object]
+    nearest_clinic: Optional[HealthcareSite]
+    inputs: TelehealthInputs
+    classification: TelehealthClassification
+    isp_name: Optional[str]
+
+
+def clinic_threshold_km(access_modes: str, override: Optional[float] = None) -> float:
+    if override is not None:
+        return float(override)
+    modes = {
+        token for token in re.split(r"[,;/|\s]+", (access_modes or "").lower())
+        if token
+    }
+    return ROAD_CLINIC_THRESHOLD_KM if "road" in modes else NON_ROAD_CLINIC_THRESHOLD_KM
+
+
+def classify_telehealth(
+    inputs: TelehealthInputs,
+    thresholds: Optional[TelehealthThresholds] = None,
+) -> TelehealthClassification:
+    """Classify one community from factual inputs without mutating them."""
+    thresholds = thresholds or baseline_thresholds()
+    reasons = []
+    details = []
+    clinic_threshold = clinic_threshold_km(
+        inputs.access_modes,
+        thresholds.clinic_proximity_km,
+    )
+
+    if inputs.latitude is None or inputs.longitude is None:
+        return _classification(
+            status="DATA_UNAVAILABLE",
+            video_feasible=None,
+            audio_feasible=None,
+            clinic_supported=None,
+            affordability_status="unknown",
+            broadband_source=None,
+            clinic_threshold=clinic_threshold,
+            reasons=("MISSING_COORDINATES",),
+            details=("Community coordinates are unavailable",),
+        )
+
+    video_feasible: Optional[bool]
+    audio_feasible: Optional[bool]
+    broadband_source: Optional[str]
+    download = inputs.ookla_download_mbps
+    if download is not None:
+        broadband_source = "OOKLA"
+        audio_feasible = download >= AUDIO_DOWNLOAD_MBPS
+        if download < thresholds.min_download_mbps:
+            video_feasible = False
+            reasons.append("LOW_DOWNLOAD")
+            details.append(
+                f"Measured download {download:.1f} Mbps is below {thresholds.min_download_mbps:g} Mbps"
+            )
+        elif inputs.ookla_upload_mbps is None:
+            video_feasible = None
+            reasons.append("MISSING_UPLOAD")
+            details.append("Measured upload speed is unavailable")
+        elif inputs.ookla_upload_mbps < thresholds.min_upload_mbps:
+            video_feasible = False
+            reasons.append("LOW_UPLOAD")
+            details.append(
+                f"Measured upload {inputs.ookla_upload_mbps:.1f} Mbps is below {thresholds.min_upload_mbps:g} Mbps"
+            )
+        elif (
+            thresholds.max_latency_ms is not None
+            and inputs.ookla_latency_ms is not None
+            and inputs.ookla_latency_ms > thresholds.max_latency_ms
+        ):
+            video_feasible = False
+            reasons.append("HIGH_LATENCY")
+            details.append(
+                f"Measured latency {inputs.ookla_latency_ms:.0f} ms exceeds {thresholds.max_latency_ms:g} ms"
+            )
+        else:
+            video_feasible = True
+            reasons.append("MEETS_BROADBAND_OOKLA")
+            details.append("Measured Ookla performance meets the video threshold")
+            if thresholds.max_latency_ms is not None and inputs.ookla_latency_ms is None:
+                reasons.append("MISSING_LATENCY")
+        if audio_feasible:
+            reasons.append("MEETS_AUDIO_OOKLA")
+    elif inputs.fcc_coverage_pct is not None:
+        broadband_source = "FCC"
+        supports_requested_speed = (
+            thresholds.min_download_mbps <= 25.0
+            and thresholds.min_upload_mbps <= 3.0
+        )
+        video_feasible = bool(
+            supports_requested_speed
+            and inputs.fcc_coverage_pct >= FCC_VIDEO_COVERAGE_PCT
+        )
+        audio_feasible = inputs.fcc_coverage_pct >= FCC_AUDIO_COVERAGE_PCT
+        if video_feasible:
+            reasons.append("MEETS_BROADBAND_FCC")
+            details.append("FCC 25/3 coverage meets the video fallback threshold")
+        elif not supports_requested_speed:
+            reasons.append("FCC_BELOW_SCENARIO_THRESHOLD")
+            details.append("FCC 25/3 data cannot establish the requested higher speed")
+        else:
+            reasons.append("LOW_FCC_COVERAGE")
+            details.append("FCC coverage is below the video fallback threshold")
+        if audio_feasible:
+            reasons.append("MEETS_AUDIO_FCC")
+    else:
+        broadband_source = None
+        video_feasible = None
+        audio_feasible = None
+        reasons.append("NO_BROADBAND_DATA")
+        details.append("Neither measured Ookla nor FCC coverage data is available")
+
+    has_income = (
+        inputs.median_income is not None
+        and inputs.median_income > 0
+        and inputs.monthly_internet_cost is not None
+        and inputs.burden_pct is not None
+    )
+    if has_income:
+        affordable = bool(
+            inputs.burden_pct < thresholds.affordability_burden_pct
+            and inputs.monthly_internet_cost < ABSOLUTE_COST_LIMIT
+        )
+        affordability_status = "affordable" if affordable else "unaffordable"
+        reasons.append("AFFORDABLE" if affordable else "UNAFFORDABLE")
+        details.append(
+            f"Internet burden is {inputs.burden_pct:.1f}% "
+            f"against a {thresholds.affordability_burden_pct:g}% threshold"
+        )
+    else:
+        affordable = None
+        affordability_status = "unknown"
+        reasons.append("NO_INCOME_DATA")
+        details.append("Income or price data is unavailable")
+
+    if not inputs.clinic_data_available:
+        clinic_supported = None
+        reasons.append("NO_CLINIC_DATA")
+        details.append("Clinic proximity data is unavailable")
+    else:
+        clinic_supported = bool(
+            inputs.nearest_clinic_distance_km is not None
+            and inputs.nearest_clinic_distance_km <= clinic_threshold
+        )
+        reasons.append("ACCESSIBLE_CARE" if clinic_supported else "NO_NEARBY_CLINIC")
+        if clinic_supported:
+            details.append(f"A clinic is within the {clinic_threshold:g} km access threshold")
+        else:
+            details.append(f"No clinic is within the {clinic_threshold:g} km access threshold")
+
+    # Missing broadband or income prevents a positive status. Missing clinic
+    # data prevents an anchor/gap decision when home access is not viable.
+    if video_feasible is None and audio_feasible is None:
+        status = "DATA_UNAVAILABLE"
+    elif affordable is None:
+        status = "DATA_UNAVAILABLE"
+    elif video_feasible and affordable:
+        status = "TELEHEALTH_READY"
+    elif clinic_supported is True:
+        status = "COMMUNITY_ANCHOR"
+    elif audio_feasible and affordable:
+        status = "LIMITED_TELEHEALTH"
+    elif clinic_supported is None:
+        status = "DATA_UNAVAILABLE"
+    else:
+        status = "CRITICAL_GAP"
+
+    return _classification(
+        status=status,
+        video_feasible=video_feasible,
+        audio_feasible=audio_feasible,
+        clinic_supported=clinic_supported,
+        affordability_status=affordability_status,
+        broadband_source=broadband_source,
+        clinic_threshold=clinic_threshold,
+        reasons=tuple(reasons),
+        details=tuple(details),
+    )
+
+
+def _classification(
+    *,
+    status: str,
+    video_feasible: Optional[bool],
+    audio_feasible: Optional[bool],
+    clinic_supported: Optional[bool],
+    affordability_status: str,
+    broadband_source: Optional[str],
+    clinic_threshold: float,
+    reasons: Tuple[str, ...],
+    details: Tuple[str, ...],
+) -> TelehealthClassification:
+    label, color = STATUS_PRESENTATION[status]
+    return TelehealthClassification(
+        status=status,
+        label=label,
+        color=color,
+        video_feasible=video_feasible,
+        audio_feasible=audio_feasible,
+        clinic_supported=clinic_supported,
+        affordability_status=affordability_status,
+        broadband_source=broadband_source,
+        clinic_threshold_km=clinic_threshold,
+        reason_codes=reasons,
+        explanation="; ".join(details) + ".",
+    )
+
+
+def _bucket_key(lat: float, lon: float) -> Tuple[int, int]:
+    return math.floor(lat), math.floor(lon)
+
+
+def _candidate_buckets(lat: float, lon: float, max_km: float) -> Iterable[Tuple[int, int]]:
+    lat_window = max_km / 111.0
+    lon_window = max_km / (111.0 * max(math.cos(math.radians(lat)), 0.1))
+    for lat_key in range(math.floor(lat - lat_window), math.floor(lat + lat_window) + 1):
+        for lon_key in range(math.floor(lon - lon_window), math.floor(lon + lon_window) + 1):
+            yield lat_key, lon_key
+
+
+def _nearest_record(buckets, lat: float, lon: float, max_km: float):
+    nearest = None
+    nearest_distance = float("inf")
+    for key in _candidate_buckets(lat, lon, max_km):
+        for record in buckets.get(key, []):
+            distance = haversine_km(lat, lon, record.centroid_lat, record.centroid_lon)
+            if distance < nearest_distance and distance <= max_km:
+                nearest = record
+                nearest_distance = distance
+    return nearest
+
+
+class TelehealthClassificationService:
+    """Resolve canonical source inputs and classify one or more regions."""
+
+    @classmethod
+    def classify_region(cls, db: Session, region: CATRegion) -> TelehealthRegionContext:
+        return cls.classify_regions(db, [region])[region.region_code]
+
+    @classmethod
+    def classify_regions(
+        cls,
+        db: Session,
+        regions: Iterable[CATRegion],
+    ) -> Dict[str, TelehealthRegionContext]:
+        regions = list(regions)
+        region_codes = [region.region_code for region in regions]
+        broadband = cls._broadband_lookup(db, region_codes)
+        income_buckets = cls._income_buckets(db)
+        ookla_buckets = cls._latest_ookla_buckets(db)
+        clinics = db.query(HealthcareSite).filter(
+            HealthcareSite.is_active == True,
+            HealthcareSite.latitude.isnot(None),
+            HealthcareSite.longitude.isnot(None),
+        ).all()
+        clinics = [
+            site for site in clinics
+            if (site.site_type or "").lower() in {"clinic", "hospital", "health_center"}
+        ]
+
+        contexts: Dict[str, TelehealthRegionContext] = {}
+        for region in regions:
+            lat = float(region.centroid_lat) if region.centroid_lat is not None else None
+            lon = float(region.centroid_lon) if region.centroid_lon is not None else None
+            income = (
+                _nearest_record(income_buckets, lat, lon, MAX_INCOME_MATCH_KM)
+                if lat is not None and lon is not None else None
+            )
+            ookla = (
+                _nearest_record(ookla_buckets, lat, lon, MAX_OOKLA_MATCH_KM)
+                if lat is not None and lon is not None else None
+            )
+
+            nearest_clinic = None
+            nearest_clinic_distance = None
+            if lat is not None and lon is not None and clinics:
+                nearest_distance = float("inf")
+                for clinic in clinics:
+                    distance = haversine_km(lat, lon, clinic.latitude, clinic.longitude)
+                    if distance < nearest_distance:
+                        nearest_clinic = clinic
+                        nearest_distance = distance
+                nearest_clinic_distance = round(nearest_distance, 2)
+
+            monthly_cost = None
+            isp_name = None
+            median_income = None
+            burden_pct = None
+            if income is not None:
+                median_income = float(income.median_income)
+                monthly_cost, isp_name = get_internet_cost(str(income.zcta))
+                if median_income > 0:
+                    burden_pct = (monthly_cost / (median_income / 12.0)) * 100.0
+
+            coverage = broadband.get(region.region_code)
+            inputs = TelehealthInputs(
+                latitude=lat,
+                longitude=lon,
+                access_modes=(region.properties or {}).get("primary_access_modes", ""),
+                ookla_download_mbps=(
+                    float(ookla.avg_d_kbps) / 1000.0
+                    if ookla is not None and ookla.avg_d_kbps is not None else None
+                ),
+                ookla_upload_mbps=(
+                    float(ookla.avg_u_kbps) / 1000.0
+                    if ookla is not None and ookla.avg_u_kbps is not None else None
+                ),
+                ookla_latency_ms=(
+                    float(ookla.avg_lat_ms)
+                    if ookla is not None and ookla.avg_lat_ms is not None else None
+                ),
+                fcc_coverage_pct=(
+                    float(coverage.any_tech_25mbps_pct)
+                    if coverage is not None and coverage.any_tech_25mbps_pct is not None else None
+                ),
+                median_income=median_income,
+                monthly_internet_cost=monthly_cost,
+                burden_pct=burden_pct,
+                nearest_clinic_distance_km=nearest_clinic_distance,
+                clinic_data_available=bool(clinics),
+            )
+            classification = classify_telehealth(inputs)
+            contexts[region.region_code] = TelehealthRegionContext(
+                region=region,
+                broadband=coverage,
+                income=income,
+                ookla=ookla,
+                nearest_clinic=nearest_clinic,
+                inputs=inputs,
+                classification=classification,
+                isp_name=isp_name,
+            )
+        return contexts
+
+    @staticmethod
+    def _broadband_lookup(db: Session, region_codes) -> Dict[str, BroadbandCoverage]:
+        confidence_rank = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
+        lookup = {}
+        for record in db.query(BroadbandCoverage).filter(
+            BroadbandCoverage.region_code.in_(region_codes)
+        ).all():
+            current = lookup.get(record.region_code)
+            record_rank = confidence_rank.get((record.confidence or "").upper(), 0)
+            current_rank = confidence_rank.get(
+                (current.confidence or "").upper(), 0
+            ) if current is not None else -1
+            if current is None or record_rank > current_rank:
+                lookup[record.region_code] = record
+        return lookup
+
+    @staticmethod
+    def _income_buckets(db: Session):
+        buckets = defaultdict(list)
+        records = db.query(CensusIncome).filter(
+            CensusIncome.median_income.isnot(None),
+            CensusIncome.median_income > 0,
+            CensusIncome.centroid_lat.isnot(None),
+            CensusIncome.centroid_lon.isnot(None),
+        ).all()
+        for record in records:
+            buckets[_bucket_key(float(record.centroid_lat), float(record.centroid_lon))].append(record)
+        return buckets
+
+    @staticmethod
+    def _latest_ookla_buckets(db: Session):
+        latest = db.query(
+            OoklaPerformance.year,
+            OoklaPerformance.quarter,
+        ).distinct().order_by(
+            OoklaPerformance.year.desc(),
+            OoklaPerformance.quarter.desc(),
+        ).first()
+        buckets = defaultdict(list)
+        if latest is None:
+            return buckets
+        records = db.query(OoklaPerformance).filter(
+            OoklaPerformance.year == latest.year,
+            OoklaPerformance.quarter == latest.quarter,
+            OoklaPerformance.centroid_lat.isnot(None),
+            OoklaPerformance.centroid_lon.isnot(None),
+        ).all()
+        for record in records:
+            buckets[_bucket_key(float(record.centroid_lat), float(record.centroid_lon))].append(record)
+        return buckets

--- a/backend/tests/test_region_discovery_api.py
+++ b/backend/tests/test_region_discovery_api.py
@@ -56,6 +56,13 @@ def client(db_session):
         centroid_lat=61.2181,
         centroid_lon=-149.9003,
     ))
+    db_session.add(CensusIncome(
+        zcta="99723",
+        median_income=20000,
+        acs_year=2022,
+        centroid_lat=52.7123,
+        centroid_lon=174.114,
+    ))
     db_session.add(HealthcareSite(
         name="Anchorage Clinic",
         site_type="clinic",
@@ -79,6 +86,7 @@ def client(db_session):
         place_name="Eareckson",
         confidence="LOW",
         data_gaps="MISSING_WIRED_DATA;LOW_CONFIDENCE",
+        any_tech_25mbps_pct=10,
         telehealth_viable="UNCERTAIN",
         primary_access="SATELLITE",
         region_code="AK-EARECKSON",

--- a/backend/tests/test_telehealth_classification.py
+++ b/backend/tests/test_telehealth_classification.py
@@ -1,0 +1,217 @@
+from dataclasses import replace
+
+import pytest
+
+from services.telehealth_classification import (
+    TelehealthInputs,
+    classify_telehealth,
+)
+
+
+@pytest.fixture()
+def complete_inputs():
+    return TelehealthInputs(
+        latitude=61.2,
+        longitude=-149.9,
+        access_modes="road",
+        ookla_download_mbps=50.0,
+        ookla_upload_mbps=10.0,
+        ookla_latency_ms=40.0,
+        fcc_coverage_pct=95.0,
+        median_income=100000.0,
+        monthly_internet_cost=100.0,
+        burden_pct=1.2,
+        nearest_clinic_distance_km=20.0,
+        clinic_data_available=True,
+    )
+
+
+def test_measured_broadband_is_preferred_when_available(complete_inputs):
+    inputs = replace(
+        complete_inputs,
+        ookla_download_mbps=1.0,
+        ookla_upload_mbps=1.0,
+        fcc_coverage_pct=100.0,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.broadband_source == "OOKLA"
+    assert result.video_feasible is False
+    assert result.status == "CRITICAL_GAP"
+
+
+def test_measured_broadband_can_establish_ready_status(complete_inputs):
+    result = classify_telehealth(complete_inputs)
+
+    assert result.broadband_source == "OOKLA"
+    assert result.video_feasible is True
+    assert result.status == "TELEHEALTH_READY"
+
+
+def test_fcc_is_used_only_as_broadband_fallback(complete_inputs):
+    inputs = replace(
+        complete_inputs,
+        ookla_download_mbps=None,
+        ookla_upload_mbps=None,
+        ookla_latency_ms=None,
+        fcc_coverage_pct=75.0,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.broadband_source == "FCC"
+    assert result.video_feasible is True
+    assert result.status == "TELEHEALTH_READY"
+
+
+def test_missing_broadband_is_explicitly_unavailable(complete_inputs):
+    inputs = replace(
+        complete_inputs,
+        ookla_download_mbps=None,
+        ookla_upload_mbps=None,
+        ookla_latency_ms=None,
+        fcc_coverage_pct=None,
+        nearest_clinic_distance_km=1.0,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.status == "DATA_UNAVAILABLE"
+    assert "NO_BROADBAND_DATA" in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "burden_pct, monthly_cost, expected_status",
+    [
+        (1.999, 399.99, "TELEHEALTH_READY"),
+        (2.0, 399.99, "COMMUNITY_ANCHOR"),
+        (1.0, 400.0, "COMMUNITY_ANCHOR"),
+    ],
+)
+def test_affordability_boundaries_are_exclusive(
+    complete_inputs,
+    burden_pct,
+    monthly_cost,
+    expected_status,
+):
+    inputs = replace(
+        complete_inputs,
+        burden_pct=burden_pct,
+        monthly_internet_cost=monthly_cost,
+        nearest_clinic_distance_km=5.0,
+    )
+
+    assert classify_telehealth(inputs).status == expected_status
+
+
+def test_missing_income_is_not_treated_as_affordable(complete_inputs):
+    inputs = replace(
+        complete_inputs,
+        median_income=None,
+        monthly_internet_cost=None,
+        burden_pct=None,
+        nearest_clinic_distance_km=1.0,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.affordability_status == "unknown"
+    assert result.status == "DATA_UNAVAILABLE"
+    assert "NO_INCOME_DATA" in result.reason_codes
+
+
+def test_unaffordable_home_access_is_not_labeled_limited(complete_inputs):
+    inputs = replace(
+        complete_inputs,
+        burden_pct=3.0,
+        nearest_clinic_distance_km=20.0,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.audio_feasible is True
+    assert result.status == "CRITICAL_GAP"
+
+
+@pytest.mark.parametrize(
+    "distance_km, expected_status",
+    [
+        (9.99, "COMMUNITY_ANCHOR"),
+        (10.01, "CRITICAL_GAP"),
+    ],
+)
+def test_nearby_and_distant_clinics(complete_inputs, distance_km, expected_status):
+    inputs = replace(
+        complete_inputs,
+        ookla_download_mbps=1.0,
+        ookla_upload_mbps=1.0,
+        burden_pct=3.0,
+        nearest_clinic_distance_km=distance_km,
+    )
+
+    assert classify_telehealth(inputs).status == expected_status
+
+
+@pytest.mark.parametrize(
+    "access_modes, expected_threshold, expected_status",
+    [
+        ("air,road", 10.0, "CRITICAL_GAP"),
+        ("air", 50.0, "COMMUNITY_ANCHOR"),
+        ("no_direct_access", 50.0, "COMMUNITY_ANCHOR"),
+    ],
+)
+def test_access_mode_selects_road_or_non_road_clinic_threshold(
+    complete_inputs,
+    access_modes,
+    expected_threshold,
+    expected_status,
+):
+    inputs = replace(
+        complete_inputs,
+        access_modes=access_modes,
+        ookla_download_mbps=1.0,
+        ookla_upload_mbps=1.0,
+        burden_pct=3.0,
+        nearest_clinic_distance_km=20.0,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.clinic_threshold_km == expected_threshold
+    assert result.status == expected_status
+
+
+@pytest.mark.parametrize(
+    "changes, reason_code",
+    [
+        ({"latitude": None}, "MISSING_COORDINATES"),
+        ({"longitude": None}, "MISSING_COORDINATES"),
+        ({"clinic_data_available": False}, "NO_CLINIC_DATA"),
+    ],
+)
+def test_missing_coordinates_and_clinic_data_are_explicit(
+    complete_inputs,
+    changes,
+    reason_code,
+):
+    inputs = replace(
+        complete_inputs,
+        ookla_download_mbps=1.0,
+        ookla_upload_mbps=1.0,
+        burden_pct=3.0,
+        **changes,
+    )
+
+    result = classify_telehealth(inputs)
+
+    assert result.status == "DATA_UNAVAILABLE"
+    assert reason_code in result.reason_codes
+
+
+def test_missing_measured_upload_does_not_create_video_success(complete_inputs):
+    result = classify_telehealth(replace(complete_inputs, ookla_upload_mbps=None))
+
+    assert result.video_feasible is None
+    assert result.status == "LIMITED_TELEHEALTH"
+    assert "MISSING_UPLOAD" in result.reason_codes

--- a/backend/tests/test_telehealth_consistency_api.py
+++ b/backend/tests/test_telehealth_consistency_api.py
@@ -1,0 +1,112 @@
+import pytest
+
+from database.models import (
+    BroadbandCoverage,
+    CATRegion,
+    CensusIncome,
+    HealthcareSite,
+    OoklaPerformance,
+)
+from services.scenario_input_cache import ScenarioInputCache
+
+
+@pytest.fixture()
+def client(db_session):
+    ScenarioInputCache.clear()
+    db_session.add(CATRegion(
+        region_code="AK-CONSISTENT",
+        region_name="Consistent Village",
+        tier_level=2,
+        centroid_lat=61.2,
+        centroid_lon=-149.9,
+        properties={"primary_access_modes": "road"},
+    ))
+    db_session.add(BroadbandCoverage(
+        place_id="consistent",
+        place_name="Consistent Village",
+        confidence="HIGH",
+        any_tech_25mbps_pct=95.0,
+        region_code="AK-CONSISTENT",
+        data_source="FCC",
+    ))
+    db_session.add(CensusIncome(
+        zcta="99501",
+        median_income=200000.0,
+        acs_year=2022,
+        centroid_lat=61.2,
+        centroid_lon=-149.9,
+    ))
+    db_session.add(HealthcareSite(
+        name="Consistent Clinic",
+        site_type="clinic",
+        latitude=61.2,
+        longitude=-149.9,
+        region_code="AK-CONSISTENT",
+        is_active=True,
+    ))
+    db_session.add(OoklaPerformance(
+        quadkey="consistent",
+        avg_d_kbps=52000,
+        avg_u_kbps=12000,
+        avg_lat_ms=45,
+        tests=20,
+        devices=8,
+        year=2025,
+        quarter=4,
+        centroid_lat=61.2,
+        centroid_lon=-149.9,
+    ))
+    db_session.commit()
+
+    from app import app
+
+    yield app.test_client()
+    ScenarioInputCache.clear()
+
+
+def test_all_public_telehealth_paths_agree_for_same_community(client):
+    summary_response = client.get("/api/cat/regions/summary")
+    profile_response = client.get(
+        "/api/cat/regions/AK-CONSISTENT/research-profile"
+    )
+    batch_profile_response = client.get(
+        "/api/cat/regions/research-profiles?codes=AK-CONSISTENT"
+    )
+    status_response = client.get(
+        "/api/cat/regions/AK-CONSISTENT/telehealth-status"
+    )
+    status_map_response = client.get("/api/cat/telehealth-status/all")
+    scenario_response = client.post(
+        "/api/cat/scenarios/preview",
+        json={"thresholds": {}, "region_codes": ["AK-CONSISTENT"]},
+    )
+
+    for response in (
+        summary_response,
+        profile_response,
+        batch_profile_response,
+        status_response,
+        status_map_response,
+        scenario_response,
+    ):
+        assert response.status_code == 200
+
+    summary_status = summary_response.get_json()["regions"][0]["telehealth_status"]
+    profile_status = profile_response.get_json()["telehealth"]["status"]
+    batch_profile_status = (
+        batch_profile_response.get_json()["profiles"][0]["telehealth"]["status"]
+    )
+    single_status = status_response.get_json()["status"]
+    map_status = status_map_response.get_json()["regions"][0]["status"]
+    scenario_region = scenario_response.get_json()["regions"][0]
+
+    assert {
+        summary_status,
+        profile_status,
+        batch_profile_status,
+        single_status,
+        map_status,
+        scenario_region["baseline_status"],
+        scenario_region["scenario_status"],
+    } == {"TELEHEALTH_READY"}
+    assert scenario_region["reason_codes"] != ["BASELINE_EQUIVALENT"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,12 @@ services:
     depends_on:
       - backend
     restart: unless-stopped
+
+  frontend-tooling:
+    build:
+      context: ./frontend
+      target: dev
+      args:
+        VITE_API_BASE_URL: "${VITE_API_BASE_URL:-/api/cat}"
+    profiles:
+      - tooling


### PR DESCRIPTION
## Summary

This PR is intended to fix the following two things mainly:

1. Divergent backend telehealth classifications.
2. Broken frontend Docker tooling used by the Make test/build/typecheck targets.

## Canonical telehealth classification

Added `backend/services/telehealth_classification.py` as the single source of truth for:

- resolving relevant broadband, income, and clinic data;
- selecting measured Ookla performance when available;
- using FCC 25/3 coverage as the fallback;
- calculating affordability with exclusive burden and absolute-cost boundaries;
- applying 10 km road and 50 km non-road clinic thresholds;
- handling missing coordinates, broadband, income, and clinic data explicitly;
- assigning the existing public status vocabulary:
  - `TELEHEALTH_READY`
  - `COMMUNITY_ANCHOR`
  - `LIMITED_TELEHEALTH`
  - `CRITICAL_GAP`
  - `DATA_UNAVAILABLE`

Missing income is no longer assigned a fabricated monthly internet cost. Missing broadband or income cannot silently produce a successful readiness classification.

The canonical implementation is now used by:

- `/regions/summary` and summary-derived search/dashboard data;
- single research profiles;
- batch research profiles;
- `/regions/<region_code>/telehealth-status`;
- `/telehealth-status/all`;
- scenario baseline input caching;
- scenario preview calculations.

The scenario engine’s baseline-equivalent shortcut was removed. Default scenarios now calculate their status through the canonical classifier and compare that result with the independently classified cached baseline.

No stored source data is mutated.

## Consistency result

The previous final-evaluation audit reported:

- **94 mismatches across 421 freshly seeded communities**

After this change, an isolated fresh seed reports:

- **0 summary/profile/map mismatches across 421 communities**
- **0 default-scenario baseline discrepancies**
- **0 missing research profiles**

A reusable audit command was added at:

`backend/data/scripts/audit_telehealth_consistency.py`

## Frontend Docker tooling

The production `frontend` service remains on the Dockerfile’s nginx-only `prod` target.

A separate `frontend-tooling` Compose service now uses the Node-based `dev` stage, which contains npm and installed dependencies. The tooling service is behind the `tooling` Compose profile and does not alter normal application startup or nginx proxy behavior.

Updated Make targets:

- `make frontend-test`
- `make frontend-typecheck`
- `make frontend-build`
- `make test`

These now route frontend commands through `frontend-tooling`.

`TESTING.md` documents the separation between the production nginx image and the Node tooling image.

## Tests added

- Focused canonical-classifier unit tests covering:
  - measured Ookla data;
  - FCC-only fallback;
  - missing broadband;
  - affordability and absolute-cost boundaries;
  - missing income;
  - nearby and distant clinics;
  - road and non-road thresholds;
  - missing coordinates and clinic data;
  - incomplete measured upload data.
- API integration coverage proving agreement across:
  - region summary;
  - single and batch research profiles;
  - single and batch telehealth-status APIs;
  - cached scenario baseline;
  - calculated default scenario.
- Fresh-seed cross-service consistency audit.

An existing discovery fixture was updated with explicit low FCC coverage and unaffordable income so its critical-gap assertion continues to test documented behavior rather than relying on missing-data defaults.

## Verification

Passed:

- `cd backend && python3 -m pytest -q`
  - **77 passed**
- `cd frontend && npm run typecheck`
  - passed
- `cd frontend && npm run test`
  - **16 test files passed, 49 tests passed**
- `cd frontend && npm run build`
  - passed
  - Vite emitted the existing non-failing large-chunk advisory
- `docker compose config -q`
  - passed
- `docker compose --profile tooling config --services`
  - passed; includes `backend`, `frontend`, and `frontend-tooling`
- `make -n test frontend-typecheck frontend-build`
  - passed; all frontend commands resolve to `frontend-tooling`
- `docker compose config | rg -n "target: prod"`
  - passed; production frontend still targets `prod`
- Python compilation check using a temporary bytecode cache
  - passed
- duplicate status-formula scan
  - passed; status assignment exists only in the canonical classifier
- `git diff --check`
  - passed
- `git diff --cached --check`
  - passed

Fresh database verification:

- Seeded `/tmp/tenet-final-evaluation.zVEygT/tenet-fresh-seed.db`
- Created:
  - 421 regions
  - 421 CAT data points
  - 325 healthcare facilities
  - 354 broadband records
  - 13 Census income records
- Ran `python3 data/scripts/audit_telehealth_consistency.py`
- Result:
  - `total_communities`: 421
  - `mismatch_count`: **0**
  - `missing_profiles`: `[]`

The developer database was not modified.

Equivalent direct host tests all passed, and Make command routing was validated with dry runs.