### PR TITLE
Season aware community data

### DIFF
--- a/backend/routes/cat_routes.py
+++ b/backend/routes/cat_routes.py
@@ -201,7 +201,7 @@ def _build_telehealth_context(db, regions):
     return context
 
 
-def _build_desert_score_lookup(db, regions):
+def _build_desert_score_lookup(db, regions, season=SEASON_YEAR_ROUND):
     region_codes = [region.region_code for region in regions if region.region_code]
     if not region_codes:
         return {}
@@ -274,9 +274,14 @@ def _build_desert_score_lookup(db, regions):
         specialist_score = HealthcareDesertCalculator.score_specialist_component(
             region.region_code in specialist_regions
         )
+        transport_mode = HealthcareDesertCalculator.resolve_transport_mode(
+            region,
+            region_points[0] if region_points else None,
+        )
         transport_score = HealthcareDesertCalculator.score_transport_component(
             travel_time,
-            transport_mode='road',
+            season=season,
+            transport_mode=transport_mode,
         )
 
         score_lookup[region.region_code] = round(float(
@@ -289,25 +294,31 @@ def _build_desert_score_lookup(db, regions):
     return score_lookup
 
 
-def _build_region_summary(db, regions):
+def _build_region_summary(db, regions, season=SEASON_YEAR_ROUND):
     broadband_lookup = _broadband_for_regions(
         db,
         [region.region_code for region in regions if region.region_code]
     )
     telehealth_lookup = _build_telehealth_context(db, regions)
-    desert_score_lookup = _build_desert_score_lookup(db, regions)
+    desert_score_lookup = _build_desert_score_lookup(db, regions, season)
 
     summaries = []
     for region in regions:
         broadband = broadband_lookup.get(region.region_code)
         telehealth = telehealth_lookup.get(region.region_code, {})
+        adjusted_tier, _, _ = _calculate_seasonal_tier(
+            region.tier_level,
+            region.access_score if region.access_score is not None else 50,
+            region.properties,
+            season,
+        )
         summaries.append({
             'id': region.id,
             'region_code': region.region_code,
             'name': region.region_name,
             'lat': _to_float_or_none(region.centroid_lat),
             'lon': _to_float_or_none(region.centroid_lon),
-            'cat_tier': region.tier_level if region.tier_level is not None else None,
+            'cat_tier': adjusted_tier if region.tier_level is not None else None,
             'telehealth_status': telehealth.get('telehealth_status', 'DATA_UNAVAILABLE'),
             'desert_score': desert_score_lookup.get(region.region_code),
             'affordability_status': telehealth.get('affordability_status', 'unknown'),
@@ -558,12 +569,16 @@ def get_regions_summary():
     """
     db = SessionLocal()
     try:
+        season = request.args.get('season', SEASON_YEAR_ROUND)
+        if season not in VALID_SEASONS:
+            season = SEASON_YEAR_ROUND
         regions = db.query(CATRegion).order_by(CATRegion.region_name).all()
-        summaries = _build_region_summary(db, regions)
+        summaries = _build_region_summary(db, regions, season)
 
         return jsonify({
             'regions': summaries,
-            'count': len(summaries)
+            'count': len(summaries),
+            'season': season,
         }), 200
 
     except Exception as e:
@@ -652,15 +667,19 @@ def search_regions():
     """
     db = SessionLocal()
     try:
+        season = request.args.get('season', SEASON_YEAR_ROUND)
+        if season not in VALID_SEASONS:
+            season = SEASON_YEAR_ROUND
         filters = _parse_region_search_args(request.args)
         regions = db.query(CATRegion).order_by(CATRegion.region_name).all()
-        summaries = _build_region_summary(db, regions)
+        summaries = _build_region_summary(db, regions, season)
         filtered = _filter_region_summaries(summaries, filters)
 
         return jsonify({
             'regions': filtered,
             'count': len(filtered),
-            'filters': filters
+            'filters': filters,
+            'season': season,
         }), 200
 
     except Exception as e:

--- a/backend/services/healthcare_desert_calculator.py
+++ b/backend/services/healthcare_desert_calculator.py
@@ -88,7 +88,7 @@ class HealthcareDesertCalculator:
                 return 40
             return 50
 
-        mode = transport_mode if transport_mode in {"road", "water", "air"} else "road"
+        mode = transport_mode if transport_mode in {"road", "water", "air"} else "unknown"
         friction = get_road_friction(road_quality, season) if mode == "road" else 1.0
         adjusted_travel_time = travel_time_minutes * friction
 
@@ -99,6 +99,21 @@ class HealthcareDesertCalculator:
         availability_penalty = (1.0 - modifier) * 30
         base_transport_score = min(100, (adjusted_travel_time / 240) * 100)
         return min(100, base_transport_score + availability_penalty)
+
+    @staticmethod
+    def resolve_transport_mode(region: Optional[CATRegion], data_point: Optional[CATDataPoint]) -> str:
+        """Return the first declared usable access mode for a community."""
+        raw_modes = ""
+        if region and region.properties:
+            raw_modes = str(region.properties.get("primary_access_modes", ""))
+        if not raw_modes and data_point:
+            raw_modes = str(data_point.access_type or "")
+
+        for mode in raw_modes.lower().replace(";", ",").split(","):
+            normalized = mode.strip()
+            if normalized in {"road", "water", "air"}:
+                return normalized
+        return "unknown"
 
     @staticmethod
     def _region_center(db: Session, region_code: str) -> Optional[Tuple[float, float]]:
@@ -244,12 +259,19 @@ class HealthcareDesertCalculator:
         data_point = db.query(CATDataPoint).filter(
             CATDataPoint.region_code == region_code
         ).first()
+        region = db.query(CATRegion).filter(
+            CATRegion.region_code == region_code
+        ).first()
+        transport_mode = HealthcareDesertCalculator.resolve_transport_mode(
+            region,
+            data_point,
+        )
         
         transport_score = HealthcareDesertCalculator.score_transport_component(
             data_point.travel_time_minutes if data_point else None,
             season,
             road_quality,
-            "road",
+            transport_mode,
         )
         
         # Calculate weighted score
@@ -272,6 +294,7 @@ class HealthcareDesertCalculator:
                 'active_season': season,
                 'season_display': get_season_display_name(season),
                 'road_quality': road_quality,
+                'transport_mode': transport_mode,
                 'assumption': 'User-selected seasonal scenario for planning purposes. '
                              'Actual conditions may vary.'
             },

--- a/backend/tests/test_healthcare_desert_calculator.py
+++ b/backend/tests/test_healthcare_desert_calculator.py
@@ -164,6 +164,21 @@ def test_winter_transport_adjustment_increases_score_against_summer(db_session):
     assert winter["necessity_score"] > summer["necessity_score"]
 
 
+def test_declared_air_access_is_used_instead_of_assuming_a_road(db_session):
+    region = add_region(db_session, travel_time=120)
+    region.properties = {"primary_access_modes": "air"}
+    db_session.commit()
+
+    winter = HealthcareDesertCalculator.calculate_healthcare_necessity_score(
+        db_session,
+        "AK-TEST",
+        season=SEASON_WINTER,
+    )
+
+    assert winter["season_scenario"]["transport_mode"] == "air"
+    assert winter["breakdown"]["transport_component"] == 59
+
+
 def test_specialist_availability_lowers_need_score(db_session):
     add_region(db_session, travel_time=60)
     add_site(db_session, site_type="clinic")

--- a/backend/tests/test_region_discovery_api.py
+++ b/backend/tests/test_region_discovery_api.py
@@ -197,3 +197,24 @@ def test_regions_summary_preserves_missing_data_labels(client):
     assert missing["affordability_status"] == "unknown"
     assert missing["data_confidence"] == "missing"
     assert missing["has_data_gap"] is True
+
+
+def test_regions_summary_matches_map_metrics_for_selected_season(client):
+    summary_response = client.get("/api/cat/regions/summary?season=winter")
+    map_response = client.get("/api/cat/regions?season=winter")
+
+    assert summary_response.status_code == 200
+    assert summary_response.get_json()["season"] == "winter"
+
+    summaries = {
+        item["region_code"]: item
+        for item in summary_response.get_json()["regions"]
+    }
+    map_regions = {
+        item["region_code"]: item
+        for item in map_response.get_json()["regions"]
+    }
+
+    for code in ("AK-ANCHORAGE", "AK-EARECKSON"):
+        assert summaries[code]["cat_tier"] == map_regions[code]["tier_level"]
+        assert summaries[code]["desert_score"] == map_regions[code]["necessity_score"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,7 +103,7 @@ function App() {
     regions: regionSummaries,
     loading: summaryLoading,
     error: summaryError,
-  } = useRegionSummary();
+  } = useRegionSummary(season);
   const restoreScenarioFromUrl = scenarioState.restoreFromUrl;
 
   const handleVisibleRegionsChange = useCallback((regionCodes: string[]) => {

--- a/frontend/src/api/catApi.test.ts
+++ b/frontend/src/api/catApi.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchRegionSummary } from './catApi';
+
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+
+describe('community summary API', () => {
+    it('requests metrics for the selected season', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ regions: [], count: 0, season: 'winter' }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchRegionSummary('winter')).resolves.toEqual([]);
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/api/cat/regions/summary?season=winter',
+            { signal: undefined },
+        );
+    });
+});

--- a/frontend/src/api/catApi.ts
+++ b/frontend/src/api/catApi.ts
@@ -66,9 +66,11 @@ export interface RegionSummary {
 export interface RegionSummaryResponse {
     regions: RegionSummary[];
     count: number;
+    season: Season;
 }
 
 export interface RegionSearchParams {
+    season?: Season;
     q?: string;
     name?: string;
     tier?: CatTier | `${CatTier}` | null;
@@ -99,6 +101,7 @@ export interface SeasonScenario {
     active_season: Season;
     season_display: string;
     road_quality: string;
+    transport_mode: 'air' | 'road' | 'water' | 'unknown';
     assumption: string;
 }
 
@@ -157,9 +160,12 @@ export function fetchBoundaries(signal?: AbortSignal): Promise<BoundaryCollectio
 /**
  * Fetch lightweight community summaries for sidebar navigation.
  */
-export async function fetchRegionSummary(signal?: AbortSignal): Promise<RegionSummary[]> {
+export async function fetchRegionSummary(
+    season: Season = 'year_round',
+    signal?: AbortSignal,
+): Promise<RegionSummary[]> {
     const data = await fetchJson<RegionSummaryResponse>(
-        `${API_BASE}/regions/summary`,
+        withQuery(`${API_BASE}/regions/summary`, { season }),
         { signal },
         'Failed to fetch region summary',
     );

--- a/frontend/src/components/sidebar/SearchBar.tsx
+++ b/frontend/src/components/sidebar/SearchBar.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEvent, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { RegionSummary } from '../../api/catApi';
+import { RegionSummary, type Season } from '../../api/catApi';
 import { useRegionSearch } from '../../hooks/useRegionSearch';
 import { getTelehealthStatusLabel, getTelehealthStatusTone } from '../../domain/statusPresentation';
 import StatusBadge from '../ui/StatusBadge';
@@ -8,13 +8,17 @@ interface SearchBarProps {
     value: string;
     onChange: (value: string) => void;
     onSelectRegion: (regionCode: string) => void;
+    season?: Season;
 }
 
-export default function SearchBar({ value, onChange, onSelectRegion }: SearchBarProps) {
+export default function SearchBar({ value, onChange, onSelectRegion, season = 'year_round' }: SearchBarProps) {
     const [isOpen, setIsOpen] = useState(false);
     const rootRef = useRef<HTMLDivElement>(null);
     const listboxId = useId();
-    const searchParams = useMemo(() => ({ q: value }), [value]);
+    const searchParams = useMemo(
+        () => ({ q: value, season: value.trim() ? season : undefined }),
+        [season, value],
+    );
     const { results } = useRegionSearch(searchParams);
     const dropdownResults = value.trim() ? results.slice(0, 8) : [];
     const listboxOpen = isOpen && dropdownResults.length > 0;

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -192,6 +192,7 @@ export default function Sidebar({
                 value={query}
                 onChange={setQuery}
                 onSelectRegion={onSelectRegion}
+                season={season}
             />
 
             {showCatTools && (

--- a/frontend/src/hooks/useRegionSummary.ts
+++ b/frontend/src/hooks/useRegionSummary.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { fetchRegionSummary, RegionSummary } from '../api/catApi';
+import type { Season } from '../api/catApi';
 import { errorMessage, isAbortError } from '../api/http';
 
-export function useRegionSummary() {
+export function useRegionSummary(season: Season = 'year_round') {
     const [regions, setRegions] = useState<RegionSummary[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -13,7 +14,7 @@ export function useRegionSummary() {
         async function loadSummary() {
             try {
                 setLoading(true);
-                const data = await fetchRegionSummary(controller.signal);
+                const data = await fetchRegionSummary(season, controller.signal);
                 if (!controller.signal.aborted) {
                     setRegions(data);
                     setError(null);
@@ -34,7 +35,7 @@ export function useRegionSummary() {
         return () => {
             controller.abort();
         };
-    }, []);
+    }, [season]);
 
     return { regions, loading, error };
 }


### PR DESCRIPTION
## Summary

- Derive healthcare transport mode from community access data instead of assuming road access.
- Apply the selected season consistently to map, sidebar summary, and community search results.
- Keep CAT tiers and healthcare desert scores synchronized across frontend views.
- Pass the current season through frontend summary and autocomplete requests.

## Why

Seasonal changes could previously update the map while leaving sidebar and search results on year-round values.

## Validation

- 40 backend tests passed.
- Frontend hook tests and TypeScript type-check passed.
- Anchorage changed from a year-round desert score of 11.7 to 15.7 in winter.
- Winter summary and full-region APIs both returned tier 1 and score 15.67 for Anchorage.

## Manual checks

- Select a community and switch seasons.
- Confirm the map, selected-community card, and result list change together.
- Search for the same community after changing the season.