### PR TITLE
harden the backend for production deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,19 @@ FRONTEND_PORT=5173
 # Flask
 FLASK_HOST=0.0.0.0
 FLASK_PORT=5001
-FLASK_DEBUG=1
+FLASK_DEBUG=0
 
 # Database (sqlite is default, no extra config needed)
 DB_TYPE=sqlite
 DB_PATH=/app/data/tenet.db
+
+# Production process sizing (Gunicorn)
+WEB_CONCURRENCY=2
+GUNICORN_THREADS=4
+
+# Optional comma-separated cross-origin frontend URLs. Leave blank when the
+# frontend reaches the API through the same-origin nginx proxy.
+CORS_ALLOWED_ORIGINS=
 
 # Frontend API base URL baked into the React build.
 # /api/cat is proxied to the backend by nginx in Docker.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -34,6 +34,9 @@ Backend:
 | `DB_TYPE` | `sqlite` | Current database backend |
 | `DB_PATH` | `/app/data/tenet.db` | SQLite path inside backend container |
 | `CORS_ALLOWED_ORIGINS` | `https://tenet.example.org` | Comma-separated frontend origins |
+| `PORT` | platform-provided or `5001` | Gunicorn bind port outside Docker |
+| `WEB_CONCURRENCY` | `2` | Gunicorn worker processes |
+| `GUNICORN_THREADS` | `4` | Request threads per worker |
 
 Frontend:
 
@@ -51,16 +54,17 @@ Frontend:
    python -c "from database.init_db import main; main()"
    ```
 
-4. Start the API:
+4. Start the API with the production server:
 
    ```bash
-   python app.py
+   gunicorn --config gunicorn.conf.py app:app
    ```
 
 5. Verify:
 
    ```bash
    curl -fsS https://<backend-host>/api/health
+   curl -fsS https://<backend-host>/api/ready
    ```
 
 Expected response:
@@ -71,6 +75,13 @@ Expected response:
   "service": "tenet-api"
 }
 ```
+
+`/api/health` is the process liveness check. `/api/ready` also verifies the
+configured database connection and returns HTTP 503 while it is unavailable.
+The Docker image and Compose stack use `/api/ready` for health checks. When the
+frontend and backend are served through the checked-in nginx proxy, leave
+`CORS_ALLOWED_ORIGINS` empty; set an explicit allowlist only for a separate
+frontend origin.
 
 ## Frontend Deployment Steps
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ Common local variables:
 | `FRONTEND_PORT` | `5173` | Host port for Vite |
 | `FLASK_HOST` | `0.0.0.0` | Backend bind address inside Docker |
 | `FLASK_PORT` | `5001` | Backend container port |
-| `FLASK_DEBUG` | `1` | Flask debug mode for local Docker |
+| `FLASK_DEBUG` | `0` | Flask debug mode (opt in locally; keep disabled in production) |
 | `DB_PATH` | `/app/data/tenet.db` | SQLite path inside the backend container |
 | `VITE_API_BASE_URL` | `/api/cat` | Frontend API base URL proxied by nginx in Docker |
-| `CORS_ALLOWED_ORIGINS` | `*` | Comma-separated frontend origins allowed by the API |
+| `CORS_ALLOWED_ORIGINS` | empty | Explicit comma-separated cross-origin frontend URLs; same-origin needs none |
+| `WEB_CONCURRENCY` | `2` | Gunicorn worker processes in the backend container |
+| `GUNICORN_THREADS` | `4` | Request threads per Gunicorn worker |
 
 ### Troubleshooting
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,5 +16,7 @@ RUN mkdir -p data/uploads
 
 EXPOSE 5001
 
-CMD ["python", "app.py"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5001/api/ready', timeout=3)"
 
+CMD ["gunicorn", "--config", "gunicorn.conf.py", "app:app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,13 +2,22 @@ import os
 
 from flask import Flask, jsonify, g
 from flask_cors import CORS
-from database.config import init_db
+from sqlalchemy import text
+from database.config import SessionLocal, init_db
 from routes.cat_routes import cat_bp
 from routes.performance_routes import performance_bp
 
 app = Flask(__name__)
-cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "*")
-CORS(app, origins=cors_origins.split(",") if cors_origins != "*" else "*")
+
+
+def parse_cors_origins(value):
+    """Normalize an explicit comma-separated CORS allowlist."""
+    return [origin.strip() for origin in str(value or "").split(",") if origin.strip()]
+
+
+cors_origins = parse_cors_origins(os.getenv("CORS_ALLOWED_ORIGINS"))
+if cors_origins:
+    CORS(app, origins=cors_origins)
 
 # Initialize database on startup
 with app.app_context():
@@ -31,6 +40,28 @@ app.register_blueprint(performance_bp)
 def health():
     return jsonify({"status": "ok", "service": "tenet-api"})
 
+
+@app.route('/api/ready', methods=['GET'])
+def ready():
+    """Report whether the API can reach its configured database."""
+    db = SessionLocal()
+    try:
+        db.execute(text("SELECT 1"))
+        return jsonify({
+            "status": "ready",
+            "service": "tenet-api",
+            "database": "available",
+        })
+    except Exception:
+        app.logger.exception("Database readiness check failed")
+        return jsonify({
+            "status": "unavailable",
+            "service": "tenet-api",
+            "database": "unavailable",
+        }), 503
+    finally:
+        db.close()
+
 if __name__ == '__main__':
     os.makedirs(os.path.join('data', 'uploads'), exist_ok=True)
     host = os.getenv('FLASK_HOST', '0.0.0.0')
@@ -38,7 +69,7 @@ if __name__ == '__main__':
         port = int(os.getenv('FLASK_PORT', '5001'))
     except ValueError:
         port = 5001
-    debug = os.getenv('FLASK_DEBUG', '1') == '1'
+    debug = os.getenv('FLASK_DEBUG', '0') == '1'
     display_host = 'localhost' if host == '0.0.0.0' else host
     print(f"Starting TENeT Backend on http://{display_host}:{port}")
     app.run(host=host, port=port, debug=debug)

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,0 +1,21 @@
+"""Production defaults for the TENeT Gunicorn server."""
+import os
+
+
+def _positive_int(name, default):
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+port = _positive_int("PORT", _positive_int("FLASK_PORT", 5001))
+bind = f"0.0.0.0:{port}"
+workers = _positive_int("WEB_CONCURRENCY", 2)
+threads = _positive_int("GUNICORN_THREADS", 4)
+timeout = _positive_int("GUNICORN_TIMEOUT", 60)
+graceful_timeout = 30
+accesslog = "-"
+errorlog = "-"
+capture_output = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 Flask==3.1.3
 flask-cors==6.0.0
+gunicorn==23.0.0
 python-dotenv==1.2.2
 pandas==2.1.4
 pyarrow==21.0.0

--- a/backend/tests/test_gunicorn_config.py
+++ b/backend/tests/test_gunicorn_config.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+
+CONFIG_PATH = Path(__file__).parents[1] / "gunicorn.conf.py"
+
+
+def load_config():
+    spec = importlib.util.spec_from_file_location("tenet_gunicorn_config", CONFIG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_gunicorn_defaults_are_production_safe(monkeypatch):
+    for name in ("PORT", "FLASK_PORT", "WEB_CONCURRENCY", "GUNICORN_THREADS"):
+        monkeypatch.delenv(name, raising=False)
+
+    config = load_config()
+
+    assert config.bind == "0.0.0.0:5001"
+    assert config.workers == 2
+    assert config.threads == 4
+    assert config.timeout == 60
+
+
+def test_invalid_process_counts_fall_back_safely(monkeypatch):
+    monkeypatch.setenv("PORT", "not-a-port")
+    monkeypatch.delenv("FLASK_PORT", raising=False)
+    monkeypatch.setenv("WEB_CONCURRENCY", "not-a-number")
+    monkeypatch.setenv("GUNICORN_THREADS", "0")
+
+    config = load_config()
+
+    assert config.workers == 2
+    assert config.threads == 4
+    assert config.bind == "0.0.0.0:5001"

--- a/backend/tests/test_health_api.py
+++ b/backend/tests/test_health_api.py
@@ -8,3 +8,59 @@ def test_health_endpoint_contract():
         "status": "ok",
         "service": "tenet-api",
     }
+
+
+def test_readiness_endpoint_checks_database():
+    from app import app
+
+    response = app.test_client().get("/api/ready")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "ready",
+        "service": "tenet-api",
+        "database": "available",
+    }
+
+
+def test_cors_origins_require_an_explicit_allowlist():
+    from app import parse_cors_origins
+
+    assert parse_cors_origins(None) == []
+    assert parse_cors_origins("") == []
+    assert parse_cors_origins("https://one.example, https://two.example ") == [
+        "https://one.example",
+        "https://two.example",
+    ]
+
+
+def test_default_health_response_does_not_enable_cross_origin_access():
+    from app import app
+
+    response = app.test_client().get(
+        "/api/health",
+        headers={"Origin": "https://unexpected.example"},
+    )
+
+    assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def test_readiness_returns_503_without_exposing_database_errors(monkeypatch):
+    import app as app_module
+
+    class UnavailableDatabase:
+        def execute(self, _query):
+            raise RuntimeError("private database detail")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(app_module, "SessionLocal", UnavailableDatabase)
+    response = app_module.app.test_client().get("/api/ready")
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "status": "unavailable",
+        "service": "tenet-api",
+        "database": "unavailable",
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,20 @@ services:
     volumes:
       - ./backend:/app
     environment:
-      FLASK_DEBUG: "${FLASK_DEBUG:-1}"
+      FLASK_DEBUG: "${FLASK_DEBUG:-0}"
       FLASK_HOST: "${FLASK_HOST:-0.0.0.0}"
       FLASK_PORT: "${FLASK_PORT:-5001}"
       DB_TYPE: "${DB_TYPE:-sqlite}"
       DB_PATH: "${DB_PATH:-/app/data/tenet.db}"
+      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-}"
+      WEB_CONCURRENCY: "${WEB_CONCURRENCY:-2}"
+      GUNICORN_THREADS: "${GUNICORN_THREADS:-4}"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5001/api/ready', timeout=3)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
 
   frontend:
@@ -22,5 +31,12 @@ services:
     ports:
       - "${FRONTEND_PORT:-5173}:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Run the backend with Gunicorn in production containers.
- Add validated worker, thread, port, and timeout configuration.
- Add a database-backed `/api/ready` endpoint.
- Add backend and frontend container health checks.
- Make the frontend wait for backend readiness.
- Disable debug mode and permissive CORS by default.
- Document production environment variables and deployment steps.

## Why

The production setup previously relied on Flask's development server and lacked readiness checks and safe deployment defaults.

## Validation

- 7 production configuration tests passed.
- Docker Compose configuration validation passed.
- Python configuration compilation passed.
- Gunicorn 23.0.0 started successfully with the SQLite database.
- Gunicorn `/api/ready` returned HTTP 200 with the database marked available.

## Deployment notes

Set `CORS_ALLOWED_ORIGINS` to an explicit comma-separated allowlist when cross-origin access is required.

The Docker image was not built locally because the Docker daemon was unavailable. Run `docker compose up --build` after starting Docker Desktop.